### PR TITLE
feat(ui): Chip 컴포넌트 추가

### DIFF
--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps } from 'react';
+
+interface ChipProps extends ComponentProps<'button'> {
+  selected?: boolean;
+}
+
+const BASE = [
+  'inline-flex h-8 items-center justify-center gap-2.5',
+  'rounded-full border px-3.5',
+  'text-sm leading-5',
+  'transition-colors',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default',
+  'disabled:cursor-not-allowed disabled:border-border-subtle',
+  'disabled:bg-background-muted disabled:font-normal disabled:text-text-disabled',
+].join(' ');
+
+const SELECTED =
+  'border-primary-default bg-primary-subtle font-medium text-primary-darker hover:border-primary-darker';
+
+const UNSELECTED =
+  'border-border-default bg-background-default font-normal text-text-secondary hover:bg-background-muted';
+
+const Chip = ({ selected = false, type = 'button', className = '', ...props }: ChipProps) => {
+  return (
+    <button
+      type={type}
+      aria-pressed={selected}
+      className={`${BASE} ${selected ? SELECTED : UNSELECTED} ${className}`}
+      {...props}
+    />
+  );
+};
+
+export { Chip };

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -95,11 +95,75 @@ import { Button } from '@/components/ui/Button';
 <Button variant="danger">삭제</Button>
 <Button disabled>요약 생성</Button>
 ```
+
+---
+
+## Chip
+
+`components/ui/Chip.tsx`
+
+선택할 수 있는 필터입니다. 표시 전용 꼬리표는 Chip이 아니라 Badge를 쓰세요.
+
+### Figma → 코드
+
+| Figma variant | 코드 |
+| --- | --- |
+| `state=default` | 기본값 |
+| `state=selected` | **`selected` prop** — variant 아님 |
+
+값이 둘뿐이고 켜고 끄는 성격이라 `variant="selected"`보다 `selected` 불리언이 자연스럽습니다.
+`<Chip selected={filter === 'A'}>`처럼 상태와 바로 연결됩니다.
+
+`aria-pressed`가 자동으로 붙습니다. 선택 여부를 배경색으로만 표시하면 스크린리더에 전달되지 않기 때문입니다.
+
+### 공통 스펙
+
+| 항목 | 값 |
+| --- | --- |
+| 높이 | `h-8` (32) |
+| radius | `rounded-full` |
+| 좌우 padding | `px-3.5` (14) |
+| 아이콘 gap | `gap-2.5` (10) |
+| 폰트 | 14 / lh 20 |
+| 테두리 | 1 |
+| 너비 | Hug — 늘리려면 `className="w-full"` |
+
+### 상태
+
+| 상태 | 배경 | 테두리 | 텍스트 | 굵기 | 대비 |
+| --- | --- | --- | --- | --- | --- |
+| 미선택 | `bg-background-default` | `border-border-default` | `text-text-secondary` | Regular | 6.49:1 |
+| 미선택 hover | `bg-background-muted` | `border-border-default` | `text-text-secondary` | Regular | 5.64:1 |
+| 선택 | `bg-primary-subtle` | `border-primary-default` | `text-primary-darker` | Medium | 5.05:1 |
+| 선택 hover | `bg-primary-subtle` | `border-primary-darker` | `text-primary-darker` | Medium | 5.05:1 |
+| disabled | `bg-background-muted` | `border-border-subtle` | `text-text-disabled` | Regular | — |
+
+focus는 Button과 같습니다. `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default`
+
+선택 상태의 hover는 배경이 아니라 테두리를 진하게 합니다.
+배경을 `Primary/lighter`로 채우면 텍스트 대비가 3.79:1로 떨어져 AA에 미달하기 때문입니다.
+
+### 주의
+
+- 선택 시 글자 굵기가 Regular → Medium으로 바뀌어 칩 너비가 1~2px 늘어납니다. 시안이 그렇게 정의돼 있어 그대로 구현했습니다. 여러 칩이 줄바꿈되는 곳에서 흔들림이 거슬리면 양쪽 다 Medium으로 통일하세요.
+- disabled는 선택 여부와 무관하게 같은 회색입니다. 상태 표시보다 조작 불가 표시가 우선입니다.
+
+### 사용 예
+
+```tsx
+import { Chip } from '@/components/ui/Chip';
+
+<Chip selected={sessionId === 'A'} onClick={() => handleSelect('A')}>
+  세션 A
+</Chip>
+<Chip disabled>세션 C</Chip>
+```
+
 ---
 
 ## 미작성
 
-Badge · Chip · Input · Card · Toast · Dialog
+Badge · Input · Card · Toast · Dialog
 
 ---
 
@@ -109,3 +173,5 @@ Badge · Chip · Input · Card · Toast · Dialog
 - 2026.08.06 (#14) — focus 규격은 시안에 정의가 없어 코드에서 정함 (`Primary/default` 2px, offset 2)
 - 2026.08.06 (#14) — primary·secondary hover 색 확정. 이때 추가한 신규 토큰은 `Primary/pressed`(#036176) 하나
 - 2026.08.06 (#16) — danger 배경을 `Negative/default`(3.87:1, AA 미달)에서 `Negative/darker`(10.21:1)로 교체. hover용 `Negative/pressed`(#4F1D0D) 신설. `Negative/default` 값은 그대로 둬서 부정 감정 차트·배지는 영향 없음
+- 2026.08.06 (#15) — Chip의 `state` variant를 `selected` 불리언으로 매핑. 필터는 `<button>`으로 렌더하고 `aria-pressed`를 붙임. 표시 전용 꼬리표는 Chip이 아니라 Badge가 담당하기로 함
+- 2026.08.06 (#15) — Chip 선택 상태 hover는 배경 대신 테두리를 진하게 함. `Primary/lighter` 배경은 텍스트 대비 3.79:1로 AA 미달. 신규 토큰 없음


### PR DESCRIPTION
## 변경 사항

디자인 시스템의 두 번째 공용 컴포넌트입니다.

- `components/ui/Chip.tsx` 추가
- `components/ui/README.md`에 Chip 절과 결정 기록 추가

### Figma variant와 다른 부분

Figma의 `state` variant를 코드에서는 `selected` 불리언으로 받습니다.

| Figma | 코드 |
| --- | --- |
| `state=default` | 기본값 |
| `state=selected` | `selected` prop |

값이 둘뿐이고 켜고 끄는 성격이라 `variant="selected"`보다 불리언이 상태와 직접 연결됩니다.

```tsx
<Chip selected={sessionId === 'A'} onClick={() => handleSelect('A')}>세션 A</Chip>
```

`aria-pressed`를 자동으로 붙였습니다. 선택 여부를 배경색으로만 표시하면 스크린리더에 전달되지 않습니다.

### 대비

| 상태 | 대비 |
| --- | --- |
| 미선택 | 6.49:1 |
| 미선택 hover | 5.64:1 |
| 선택 | 5.05:1 |
| 선택 hover | 5.05:1 |

네 조합 모두 WCAG AA(4.5:1)를 충족합니다.

선택 상태의 hover는 배경이 아니라 테두리를 진하게 합니다.
배경을 `Primary/lighter`로 채우면 텍스트 대비가 3.79:1로 떨어져 AA에 미달하기 때문입니다.

## 관련 이슈

Closes #15

## 검증 방법

`npm run lint`

```
✖ 1 problem (0 errors, 1 warning)
public/mockServiceWorker.js
  1:1  warning  Unused eslint-disable directive (no problems were reported)
```

warning 1건은 MSW가 자동 생성한 파일의 기존 이슈로 이번 변경과 무관합니다.

`npm run build`

```
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 2.5s
✓ Finished TypeScript in 2.7s
✓ Collecting page data using 11 workers in 1089ms
✓ Generating static pages using 11 workers (7/7) in 269ms
✓ Finalizing page optimization in 25ms
```

수동 확인 — `app/page.tsx`에 임시 화면을 만들어 확인 후 되돌렸습니다.

- 높이 32, 클릭 시 선택 이동
- 미선택 hover는 배경, 선택 hover는 테두리가 변함
- Tab 이동 시 focus 링 표시, 마우스 클릭 시 미표시
- `disabled` 칩은 클릭·포커스 차단

명암비는 sRGB 상대 휘도 공식(WCAG 2.1)으로 직접 계산했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- 신규 토큰: 없음 (기존 토큰만 조합)

## 트러블슈팅 및 참고 사항

- **표시 전용 꼬리표는 Chip이 아닙니다.** 리포트의 주요 키워드처럼 누를 수 없는 요소는 `<span>`으로 렌더해야 해서 Badge가 담당합니다. 현재 Figma 리포트 화면이 Chip 인스턴스를 쓰고 있어 Badge 작업 시 교체가 필요합니다.
- 선택 시 글자 굵기가 Regular → Medium으로 바뀌어 칩 너비가 1~2px 늘어납니다. 시안 정의를 그대로 따랐고, 줄바꿈되는 목록에서 흔들림이 문제가 되면 양쪽 다 Medium으로 통일하면 됩니다. README 주의 항목에 기재했습니다.
- Figma 세트에는 hover·focus·disabled variant가 없습니다. 상태 정의는 디자인 시스템 페이지의 States 표에 별도로 정리돼 있고, README 상태 표가 그 값을 그대로 옮긴 것입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.
