### PR TITLE
feat(mocks): 세션 수정 MSW 핸들러·스키마 추가

### DIFF
--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -11,6 +11,8 @@ import type {
   PublicReport,
   PulseEvent,
   Report,
+  Session,
+  SessionUpdateRequest,
   SessionView,
   SignupRequest,
   SignupResponse,
@@ -26,6 +28,7 @@ import {
   publicReportSchema,
   pulseEventSchema,
   reportSchema,
+  sessionSchema,
   sessionViewSchema,
   signupResponseSchema,
 } from '@/lib/schemas/api';
@@ -113,6 +116,18 @@ export const fetchSessionsByEventCode = async (eventCode: string): Promise<Sessi
     data,
     'GET /events/{eventCode}/sessions',
   ).items;
+};
+
+export const updateSession = async (
+  eventCode: string,
+  sessionId: number,
+  body: SessionUpdateRequest,
+): Promise<Session> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/sessions/${sessionId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(sessionSchema, data, 'PATCH /events/{eventCode}/sessions/{sessionId}');
 };
 
 // ─────────────────────────────────────────────────────────────

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -213,6 +213,12 @@ export const sessionCreateRequestSchema = z.object({
   order: z.int(),
 });
 
+/** 전 필드 optional(부분 수정). */
+export const sessionUpdateRequestSchema = z.object({
+  title: z.string().min(1).optional(),
+  order: z.int().optional(),
+});
+
 export const eventListResponseSchema = listResponseSchema(pulseEventSchema);
 
 export type PulseEvent = z.infer<typeof pulseEventSchema>;
@@ -222,6 +228,7 @@ export type EventUpdateRequest = z.infer<typeof eventUpdateRequestSchema>;
 export type Session = z.infer<typeof sessionSchema>;
 export type SessionView = z.infer<typeof sessionViewSchema>;
 export type SessionCreateRequest = z.infer<typeof sessionCreateRequestSchema>;
+export type SessionUpdateRequest = z.infer<typeof sessionUpdateRequestSchema>;
 
 // ─────────────────────────────────────────────────────────────
 // feedback

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -6,10 +6,11 @@ import {
   listResponseSchema,
   publicReportSchema,
   reportSchema,
+  sessionSchema,
   sessionViewSchema,
   signupResponseSchema,
 } from '@/lib/schemas/api';
-import { resetDb } from '@/mocks/data/store';
+import { db, resetDb } from '@/mocks/data/store';
 import { API_BASE_URL } from '@/mocks/handlers/shared';
 import { server } from '@/mocks/server';
 
@@ -179,6 +180,99 @@ describe('세션 목록', () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toMatchObject({ code: 'EVENT_NOT_FOUND' });
+  });
+});
+
+describe('세션 수정', () => {
+  it('title만 주면 title만 바뀌고 order는 그대로다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/sessions/101`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '1부: 오프닝 키노트' }),
+    });
+
+    expect(response.status).toBe(200);
+    const session = sessionSchema.parse(await response.json());
+    expect(session).toMatchObject({ id: 101, title: '1부: 오프닝 키노트', order: 1 });
+  });
+
+  it('order만 주면 order만 바뀌고 title은 그대로다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/sessions/101`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ order: 2 }),
+    });
+
+    expect(response.status).toBe(200);
+    const session = sessionSchema.parse(await response.json());
+    expect(session).toMatchObject({ id: 101, title: '1부: 키노트', order: 2 });
+  });
+
+  it('title·order 둘 다 주면 둘 다 바뀌고, 저장소에도 반영된다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/sessions/101`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '1부: 오프닝 키노트', order: 2 }),
+    });
+
+    expect(response.status).toBe(200);
+    const session = sessionSchema.parse(await response.json());
+    expect(session).toMatchObject({ id: 101, title: '1부: 오프닝 키노트', order: 2 });
+
+    // PATCH 응답만이 아니라 저장소 자체가 바뀌었는지 별도 GET으로 확인합니다.
+    const list = await call(`/events/${LIVE_EVENT_CODE}/sessions`);
+    const { items } = listResponseSchema(sessionViewSchema).parse(await list.json());
+    expect(items.find((item) => item.id === 101)).toMatchObject({
+      title: '1부: 오프닝 키노트',
+      order: 2,
+    });
+  });
+
+  it('소유자가 아니면 NOT_OWNER를 준다', async () => {
+    // 시드에는 HOST_USER 소유 이벤트만 있어서, 소유자 불일치를 재현하려면 다른 ownerId의
+    // 이벤트를 직접 심어야 합니다. 세션 존재 여부와 무관하게 소유자 확인이 먼저 걸립니다.
+    db.events.push({
+      id: 999,
+      code: 'other1',
+      title: '다른 사람 이벤트',
+      description: null,
+      ownerId: 999,
+      status: 'LIVE',
+      createdAt: '2026-08-01T09:00:00.000Z',
+    });
+
+    const response = await call('/events/other1/sessions/1', {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '수정 시도' }),
+    });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ code: 'NOT_OWNER' });
+  });
+
+  it('없는 세션이면 SESSION_NOT_FOUND를 준다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/sessions/9999`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '없는 세션' }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ code: 'SESSION_NOT_FOUND' });
+  });
+
+  it('다른 이벤트 소속 세션이면 SESSION_NOT_FOUND를 준다', async () => {
+    // 세션 201은 존재하지만 이벤트 43(ENDED) 소속입니다. eventId 불일치도 존재 자체와
+    // 똑같이 404로 나와야 합니다 — 다른 이벤트 세션 id를 넣어보면 존재 여부를 추측할 수 있게 됩니다.
+    const response = await call(`/events/${LIVE_EVENT_CODE}/sessions/201`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '남의 세션' }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toMatchObject({ code: 'SESSION_NOT_FOUND' });
   });
 });
 

--- a/mocks/handlers/event.ts
+++ b/mocks/handlers/event.ts
@@ -1,6 +1,11 @@
 import { http, HttpResponse } from 'msw';
 import type { PulseEvent, Session } from '@/lib/schemas/api';
-import { eventCreateRequestSchema, eventUpdateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
+import {
+  eventCreateRequestSchema,
+  eventUpdateRequestSchema,
+  sessionCreateRequestSchema,
+  sessionUpdateRequestSchema,
+} from '@/lib/schemas/api';
 import {
   HOST_USER,
   db,
@@ -140,6 +145,23 @@ export const eventHandlers = [
     db.sessions.push(session);
 
     return HttpResponse.json(session, { status: 201 });
+  }),
+
+  http.patch(`${API_BASE_URL}/events/:eventCode/sessions/:sessionId`, async ({ request, params }) => {
+    const event = requireOwnedEvent(request, params.eventCode);
+    if (event instanceof Response) return event;
+
+    const sessionId = toNumericId(params.sessionId);
+    const session = sessionId === null ? undefined : findSessionById(sessionId);
+    if (!session || session.eventId !== event.id) return errorResponse('SESSION_NOT_FOUND');
+
+    const body = await parseBody(request, sessionUpdateRequestSchema);
+    if (!body.ok) return body.response;
+
+    if (body.data.title !== undefined) session.title = body.data.title;
+    if (body.data.order !== undefined) session.order = body.data.order;
+
+    return HttpResponse.json(session);
   }),
 
   http.delete(`${API_BASE_URL}/events/:eventCode/sessions/:sessionId`, ({ request, params }) => {


### PR DESCRIPTION
## 변경 사항

- 이 PR은 세션 수정(PATCH /events/{eventCode}/sessions/{sessionId})용 MSW 핸들러·스키마·클라이언트 함수를 추가합니다.  
  기존에는 이 엔드포인트를 처리하는 핸들러가 없었습니다.
  - `lib/schemas/api.ts`: `sessionUpdateRequestSchema`·`SessionUpdateRequest` 타입
  - `mocks/handlers/event.ts`: `PATCH /events/:eventCode/sessions/:sessionId` 핸들러
  - `lib/api/endpoints.ts`: `updateSession` 클라이언트 함수

## 개발 과정 로그

커밋이 1개라 생략합니다.

## 관련 이슈

- Closes #33

## 검증 방법

- `npx tsc --noEmit`, `npm run lint`, `npm run test`가 모두 통과합니다(46개 테스트, 기존 40개 + 신규 6개).
- 신규 테스트입니다.
  - 성공: title만 수정, order만 수정, 둘 다 수정
  - 에러: 403(NOT_OWNER), 404(세션 없음), 404(다른 이벤트 소속 세션)

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- 이슈 본문에는 403·404 두 케이스만 명시돼 있었습니다.  
  코드 리뷰 과정에서 "세션이 다른 이벤트 소속인 경우"(eventId 불일치)가 "세션이 아예 없는 경우"와 별개 코드 분기라는 점을 발견했습니다.  
  그래서 테스트를 하나 더 추가했습니다.
- MSW 핸들러가 저장소(`mocks/data/store.ts`의 인메모리 DB)를 실제로 바꾸지 않고 PATCH 응답 본문만 조작해도 테스트가 통과하는 문제가 있습니다.  
  그래서 "title·order 둘 다 수정" 케이스에는 별도 GET 조회로 저장소 반영 여부까지 확인하는 절차를 추가했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그를 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수·의존성·Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.
