### PR TITLE
chore: Prettier 강제화 및 .gitignore IDE 대응 추가

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# staged 파일 lint-staged 검사. 우회: git commit --no-verify
+
+npx lint-staged

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 # misc
 .DS_Store
 *.pem
+.idea/
+.vscode/
 
 # debug
 npm-debug.log*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+.next/
+out/
+build/
+next-env.d.ts
+public/mockServiceWorker.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "arrowParens": "always"
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,7 @@
-import { defineConfig, globalIgnores } from "eslint/config";
-import nextVitals from "eslint-config-next/core-web-vitals";
-import nextTs from "eslint-config-next/typescript";
-import prettierConfig from "eslint-config-prettier";
+import { defineConfig, globalIgnores } from 'eslint/config';
+import nextVitals from 'eslint-config-next/core-web-vitals';
+import nextTs from 'eslint-config-next/typescript';
+import prettierConfig from 'eslint-config-prettier';
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -11,12 +11,12 @@ const eslintConfig = defineConfig([
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:
-    ".next/**",
-    "out/**",
-    "build/**",
-    "next-env.d.ts",
+    '.next/**',
+    'out/**',
+    'build/**',
+    'next-env.d.ts',
     // `npx msw init public/`이 생성하는 서비스 워커. 우리가 고치는 파일이 아닙니다.
-    "public/mockServiceWorker.js",
+    'public/mockServiceWorker.js',
   ]),
 ]);
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,10 +1,13 @@
 import { defineConfig, globalIgnores } from "eslint/config";
 import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
+import prettierConfig from "eslint-config-prettier";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
+  // Prettier와 충돌하는 ESLint 스타일 규칙을 꺼줍니다. 배열 마지막에 와야 합니다.
+  prettierConfig,
   // Override default ignores of eslint-config-next.
   globalIgnores([
     // Default ignores of eslint-config-next:

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.12",
+        "eslint-config-prettier": "^10.1.8",
         "lint-staged": "^16.4.0",
         "msw": "^2.15.0",
         "prettier": "^3.9.6",
@@ -4512,6 +4513,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     ]
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{js,jsx,ts,tsx,mjs,cjs,mts,cts}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "format": "prettier --write .",
+    "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest"
   },
@@ -30,6 +32,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.12",
+    "eslint-config-prettier": "^10.1.8",
     "lint-staged": "^16.4.0",
     "msw": "^2.15.0",
     "prettier": "^3.9.6",
@@ -41,5 +44,12 @@
     "workerDirectory": [
       "public"
     ]
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,css}": "prettier --write"
   }
 }


### PR DESCRIPTION
## 변경 사항

- 이 PR은 Prettier 포맷 강제화 장치와 `.gitignore`의 IDE 폴더 대응을 추가합니다.  
  CLAUDE.md에는 코드 포맷을 ESLint/Prettier가 강제한다고 적혀 있었지만, 실제로는 강제하는 장치가 없었습니다.
  - `.prettierrc`, `.prettierignore`를 신설합니다(안치호님 초안 값을 그대로 적용했습니다).
  - `eslint.config.mjs`에 `eslint-config-prettier`(ESLint 규칙 중 Prettier와 충돌하는 스타일 규칙만 꺼주는 패키지)를 연동합니다.
  - `package.json`에 `lint-staged` 설정과 `format`/`format:check` 스크립트를 추가합니다.
  - `.githooks/pre-commit`을 신설해서 `npx lint-staged`를 실행합니다. Husky는 설치하지 않습니다(이유는 이슈 #36 본문에 있습니다).
  - `.gitignore`에 `.idea/`, `.vscode/`를 추가합니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 8664ccc | build(tooling): Prettier 강제화 및 .gitignore IDE 대응 추가 | 이슈 #36에서 정리한 항목을 실제 설정 파일로 반영했습니다. |
| 8faa081 | fix(tooling): lint-staged 글롭에 mjs/cjs/mts/cts 확장자 추가 | 첫 커밋 직후 pre-commit 로그에서 eslint.config.mjs가 검사되지 않는 걸 발견했습니다. |
| bfb6205 | style(tooling): eslint.config.mjs에 Prettier 적용 | 글롭(파일 이름 패턴) 수정이 실제로 이 파일을 커버하는지 확인하는 과정에서 포맷 차이를 발견해 반영했습니다. |

## 관련 이슈

- Closes #36

## 검증 방법

- `npm run lint`, `npm run build`가 모두 통과합니다.
- 실제 커밋 3개를 통해 `.githooks/pre-commit`이 `npx lint-staged`를 실행하는 것을 확인했습니다.
- `git check-ignore -v .idea`로 `.gitignore` 규칙이 `.idea/`를 실제로 잡아내는 것을 확인했습니다.
- `npm run format:check`로 기존 파일 21개가 새 Prettier 설정과 다르다는 것을 확인했습니다.  
  이슈 #36에 적어둔 대로, 이번에는 설정만 추가하고 일괄 재포맷은 하지 않았습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 있음 — `devDependencies`에 `eslint-config-prettier`를 추가했습니다.
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- `.githooks/pre-commit`은 로컬에 `git config core.hooksPath .githooks`가 설정돼 있어야 실제로 동작하는 문제가 있었습니다.  
  CodeRabbit이 이 PR 리뷰에서 같은 문제를 지적했습니다. 새로 clone한 환경에서는 `core.hooksPath`가 Git 기본값(`.git/hooks`)이라 pre-commit 훅 파일이 실행 권한(`100755`)을 갖고 있어도 아예 실행되지 않는다는 지적이었습니다.  
  그래서 `package.json`에 `prepare` 스크립트를 추가해서, `npm install`을 실행하면 `git config core.hooksPath .githooks`가 자동으로 적용되도록 고쳤습니다.  
  `core.hooksPath`를 지운 뒤 `npm install`로 다시 복구되는 것을 직접 확인했습니다.
- 첫 커밋 직후 pre-commit 로그에서 `*.{js,jsx,ts,tsx}` 글롭(`lint-staged` 설정에서 "어떤 파일에 이 명령을 적용할지"를 지정하는 파일 이름 패턴)이 0 files로 나오는 문제가 있었습니다.  
  `eslint.config.mjs`의 확장자(`.mjs`)가 이 패턴에 빠져 있어서 실제로 검사되지 않았습니다.  
  그래서 패턴에 `mjs`·`cjs`·`mts`·`cts`를 추가하고, 실제로 이 파일이 커버되는지 `npx prettier --write`로 직접 확인했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개발 환경 개선**
  * 커밋 전 코드 품질 검사를 자동으로 실행합니다.
  * JavaScript, TypeScript, JSON, Markdown, CSS 파일의 린트 및 포맷팅을 자동화했습니다.
  * 코드 검사와 포맷팅 규칙을 통합해 일관된 스타일을 유지합니다.
  * 필요에 따라 프로젝트 전체의 포맷을 확인하거나 적용할 수 있습니다.
* **설정 개선**
  * IDE 설정, 빌드 산출물 및 생성 파일이 버전 관리 대상에서 제외됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

