### PR TITLE
feat(feedback): FeedItem 컴포넌트 추가

### DIFF
--- a/components/feedback/FeedItem.tsx
+++ b/components/feedback/FeedItem.tsx
@@ -1,0 +1,66 @@
+import type { ComponentProps, ReactNode } from 'react';
+
+import { Badge } from '@/components/ui/Badge';
+
+type FeedItemState = 'normal' | 'flagged' | 'hidden';
+type Sentiment = 'positive' | 'neutral' | 'negative' | 'none' | 'toxic';
+
+interface FeedItemProps extends Omit<ComponentProps<'article'>, 'children'> {
+  state: FeedItemState;
+  sentiment: Sentiment;
+  meta: string;
+  content: string;
+  actions?: ReactNode;
+}
+
+const BASE = 'flex flex-col gap-1.5 rounded-lg border px-3.5 py-3';
+
+const STATE: Record<FeedItemState, string> = {
+  normal: 'border-border-subtle bg-background-default',
+  flagged: 'border-toxic-lighter bg-background-default',
+  hidden: 'border-transparent bg-background-muted',
+};
+
+const CONTENT: Record<FeedItemState, string> = {
+  normal: 'text-text-primary',
+  flagged: 'text-text-primary',
+  hidden: 'text-text-tertiary',
+};
+
+const SENTIMENT: Record<Sentiment, { tone: ComponentProps<typeof Badge>['tone']; label: string }> = {
+  positive: { tone: 'positive', label: '긍정' },
+  neutral: { tone: 'neutral', label: '중립' },
+  negative: { tone: 'negative', label: '부정' },
+  none: { tone: 'outline', label: '미분류' },
+  toxic: { tone: 'toxic', label: '⚑ 독성 의심' },
+};
+
+const FeedItem = ({
+  state,
+  sentiment,
+  meta,
+  content,
+  actions,
+  className = '',
+  ...props
+}: FeedItemProps) => {
+  const { tone, label } = SENTIMENT[sentiment];
+
+  return (
+    <article className={`${BASE} ${STATE[state]} ${className}`} {...props}>
+      <div className="flex items-center justify-between gap-1.5">
+        <Badge tone={tone}>{label}</Badge>
+        <span className="text-xs font-normal leading-4 text-text-tertiary">
+          {state === 'hidden' ? `${meta} · 숨김` : meta}
+        </span>
+      </div>
+
+      <p className={`text-base font-normal leading-6 ${CONTENT[state]}`}>{content}</p>
+
+      {actions ? <div className="flex gap-1.5">{actions}</div> : null}
+    </article>
+  );
+};
+
+export { FeedItem };
+export type { FeedItemState, Sentiment };

--- a/components/feedback/README.md
+++ b/components/feedback/README.md
@@ -14,11 +14,11 @@
 
 ### 세 가지 상태
 
-| state | 배경 | 테두리 | 본문 | 쓰는 곳 |
-| --- | --- | --- | --- | --- |
-| `normal` | `bg-background-default` | `border-border-subtle` | `text-text-primary` | 실시간 피드 |
-| `flagged` | `bg-background-default` | `border-toxic-lighter` | `text-text-primary` | 모더레이션 큐 |
-| `hidden` | `bg-background-muted` | `border-transparent` | `text-text-tertiary` | 숨김 처리된 항목 |
+| state     | 배경                    | 테두리                 | 본문                 | 쓰는 곳          |
+| --------- | ----------------------- | ---------------------- | -------------------- | ---------------- |
+| `normal`  | `bg-background-default` | `border-border-subtle` | `text-text-primary`  | 실시간 피드      |
+| `flagged` | `bg-background-default` | `border-toxic-lighter` | `text-text-primary`  | 모더레이션 큐    |
+| `hidden`  | `bg-background-muted`   | `border-transparent`   | `text-text-tertiary` | 숨김 처리된 항목 |
 
 `hidden`의 테두리는 투명입니다. 안 보이지만 자리를 차지해서 다른 상태와 높이가 어긋나지 않습니다.
 
@@ -28,21 +28,21 @@
 <FeedItem sentiment="positive" ... />   →  <Badge tone="positive">긍정</Badge>
 ```
 
-| sentiment | Badge tone | 문구 |
-| --- | --- | --- |
-| `positive` | positive | 긍정 |
-| `neutral` | neutral | 중립 |
-| `negative` | negative | 부정 |
-| `none` | outline | 미분류 |
-| `toxic` | toxic | ⚑ 독성 의심 |
+| sentiment  | Badge tone | 문구        |
+| ---------- | ---------- | ----------- |
+| `positive` | positive   | 긍정        |
+| `neutral`  | neutral    | 중립        |
+| `negative` | negative   | 부정        |
+| `none`     | outline    | 미분류      |
+| `toxic`    | toxic      | ⚑ 독성 의심 |
 
 이 표가 여기 있는 이유는 `ui/Badge`가 Pulse를 몰라야 하기 때문입니다. 감정을 문구로 바꾸는 일은 도메인 컴포넌트가 합니다.
 
 ### `· 숨김`은 자동으로 붙습니다
 
-`state="hidden"`이면 메타 문구 끝에 ` · 숨김`이 붙습니다.
+`state="hidden"`이면 메타 문구 끝에 `· 숨김`이 붙습니다.
 
-```
+```text
 방금 · 세션 A        →  방금 · 세션 A · 숨김
 ```
 
@@ -60,14 +60,29 @@
   content="신고된 소감 내용"
   actions={
     <>
-      <Button variant="secondary" size="sm" onClick={handleHide}>숨기기</Button>
-      <Button variant="secondary" size="sm" onClick={handleDelete}>삭제</Button>
+      <Button variant="secondary" size="sm" onClick={handleHide}>
+        숨기기
+      </Button>
+      <Button variant="secondary" size="sm" onClick={handleDelete}>
+        삭제
+      </Button>
     </>
   }
 />
 ```
 
-`actions`를 안 넘기면 버튼 영역 자체가 렌더되지 않습니다. `normal`은 버튼이 없어서 높이가 80, 나머지는 122입니다.
+`actions`를 안 넘기면 버튼 영역 자체가 렌더되지 않습니다.
+
+### 높이는 지정하지 않습니다
+
+시안의 80·122는 내용에서 자동으로 나오는 값입니다.
+
+```text
+normal   12 + 24(배지) + 6 + 24(한 줄) + 12 + 테두리 2 = 80
+flagged  12 + 24 + 6 + 24 + 6 + 36(버튼) + 12 + 2      = 122
+```
+
+`min-h`로 못 박지 않았습니다. 같은 숫자가 두 곳에 생기면 나중에 padding을 바꿨을 때 계산값과 어긋납니다. 소감이 두 줄이면 카드가 길어지는 것도 맞는 동작입니다.
 
 ### 주의
 
@@ -78,6 +93,7 @@
 
 ```tsx
 import { FeedItem } from '@/components/feedback/FeedItem';
+import { Button } from '@/components/ui/Button';
 
 <FeedItem state="normal" sentiment="positive" meta="방금 · 세션 A" content="데모가 진짜 인상적이었어요" />
 <FeedItem state="hidden" sentiment="toxic" meta="2분 전 · 세션 B" content="신고된 소감" actions={<Button variant="secondary" size="sm">숨김 해제</Button>} />
@@ -88,5 +104,6 @@ import { FeedItem } from '@/components/feedback/FeedItem';
 ## 결정 기록
 
 - 2026.08.06 — 감정 → 문구 매핑을 `ui/Badge`가 아니라 여기에 둠. `ui/`는 Pulse 도메인을 몰라야 함
-- 2026.08.06 — `state="hidden"`일 때 메타에 ` · 숨김`을 자동으로 붙임. 배경 명도만으로 구분하면 색을 못 보는 사용자에게 전달되지 않고, 화면마다 손으로 쓰면 빠뜨림
+- 2026.08.06 — 높이를 `min-h`로 고정하지 않음. 시안의 80·122는 padding·gap·글자 높이에서 나오는 결과값이라, 따로 적으면 같은 숫자가 두 곳에 생겨 나중에 어긋남
+- 2026.08.06 — `state="hidden"`일 때 메타에 `· 숨김`을 자동으로 붙임. 배경 명도만으로 구분하면 색을 못 보는 사용자에게 전달되지 않고, 화면마다 손으로 쓰면 빠뜨림
 - 2026.08.06 — 버튼을 `actions` prop으로 받음. 숨기기·삭제가 무슨 일을 하는지 FeedItem이 알 필요가 없음

--- a/components/feedback/README.md
+++ b/components/feedback/README.md
@@ -1,0 +1,92 @@
+# components/feedback
+
+소감과 감정 분류를 다루는 컴포넌트입니다. Pulse의 도메인 개념을 아는 것들이 여기 있습니다.
+
+`components/ui/`와 갈리는 기준은 이렇습니다. 그 파일만 열었을 때 Pulse가 뭐 하는 서비스인지 몰라도 이해되면 `ui/`, `긍정`·`독성 의심` 같은 말이 나오면 여기입니다.
+
+---
+
+## FeedItem
+
+`components/feedback/FeedItem.tsx`
+
+소감 하나를 보여주는 카드입니다. 실시간 피드와 모더레이션 큐에서 씁니다.
+
+### 세 가지 상태
+
+| state | 배경 | 테두리 | 본문 | 쓰는 곳 |
+| --- | --- | --- | --- | --- |
+| `normal` | `bg-background-default` | `border-border-subtle` | `text-text-primary` | 실시간 피드 |
+| `flagged` | `bg-background-default` | `border-toxic-lighter` | `text-text-primary` | 모더레이션 큐 |
+| `hidden` | `bg-background-muted` | `border-transparent` | `text-text-tertiary` | 숨김 처리된 항목 |
+
+`hidden`의 테두리는 투명입니다. 안 보이지만 자리를 차지해서 다른 상태와 높이가 어긋나지 않습니다.
+
+### 감정은 코드가 문구로 바꿉니다
+
+```tsx
+<FeedItem sentiment="positive" ... />   →  <Badge tone="positive">긍정</Badge>
+```
+
+| sentiment | Badge tone | 문구 |
+| --- | --- | --- |
+| `positive` | positive | 긍정 |
+| `neutral` | neutral | 중립 |
+| `negative` | negative | 부정 |
+| `none` | outline | 미분류 |
+| `toxic` | toxic | ⚑ 독성 의심 |
+
+이 표가 여기 있는 이유는 `ui/Badge`가 Pulse를 몰라야 하기 때문입니다. 감정을 문구로 바꾸는 일은 도메인 컴포넌트가 합니다.
+
+### `· 숨김`은 자동으로 붙습니다
+
+`state="hidden"`이면 메타 문구 끝에 ` · 숨김`이 붙습니다.
+
+```
+방금 · 세션 A        →  방금 · 세션 A · 숨김
+```
+
+화면마다 손으로 쓰면 빠뜨립니다. 배경이 흐려지는 것만으로 구분하면 색을 못 보는 사용자에게 전달되지 않습니다.
+
+### 버튼은 밖에서 넘깁니다
+
+`actions`로 받습니다. FeedItem은 숨기기·삭제가 무슨 일을 하는지 몰라도 됩니다.
+
+```tsx
+<FeedItem
+  state="flagged"
+  sentiment="toxic"
+  meta="2분 전 · 세션 B"
+  content="신고된 소감 내용"
+  actions={
+    <>
+      <Button variant="secondary" size="sm" onClick={handleHide}>숨기기</Button>
+      <Button variant="secondary" size="sm" onClick={handleDelete}>삭제</Button>
+    </>
+  }
+/>
+```
+
+`actions`를 안 넘기면 버튼 영역 자체가 렌더되지 않습니다. `normal`은 버튼이 없어서 높이가 80, 나머지는 122입니다.
+
+### 주의
+
+- **`<article>`로 렌더합니다.** 목록 안에 넣을 때는 `<ul><li>`로 감싸세요.
+- 본문은 `content` prop으로 받습니다. 서식 있는 내용이 들어올 자리가 아니라 문자열입니다.
+
+### 사용 예
+
+```tsx
+import { FeedItem } from '@/components/feedback/FeedItem';
+
+<FeedItem state="normal" sentiment="positive" meta="방금 · 세션 A" content="데모가 진짜 인상적이었어요" />
+<FeedItem state="hidden" sentiment="toxic" meta="2분 전 · 세션 B" content="신고된 소감" actions={<Button variant="secondary" size="sm">숨김 해제</Button>} />
+```
+
+---
+
+## 결정 기록
+
+- 2026.08.06 — 감정 → 문구 매핑을 `ui/Badge`가 아니라 여기에 둠. `ui/`는 Pulse 도메인을 몰라야 함
+- 2026.08.06 — `state="hidden"`일 때 메타에 ` · 숨김`을 자동으로 붙임. 배경 명도만으로 구분하면 색을 못 보는 사용자에게 전달되지 않고, 화면마다 손으로 쓰면 빠뜨림
+- 2026.08.06 — 버튼을 `actions` prop으로 받음. 숨기기·삭제가 무슨 일을 하는지 FeedItem이 알 필요가 없음


### PR DESCRIPTION
## 변경 사항

소감 하나를 보여주는 카드입니다. 실시간 피드와 모더레이션 큐에서 씁니다.

- `components/feedback/FeedItem.tsx` 추가
- `components/feedback/README.md` 추가

## `ui/`가 아니라 `feedback/`인 이유

`components/ui/README.md`의 판단 기준입니다.

> 그 파일만 열었을 때 Pulse가 뭐 하는 서비스인지 몰라도 이해되면 `ui/`입니다.

`긍정`·`독성 의심`은 Pulse를 알아야 이해됩니다. Chip 때 감정 래퍼를 도메인 쪽으로 보내기로 한 규칙을 따랐습니다.

## 감정을 문구로 바꾸는 표가 여기 있는 이유

```tsx
<FeedItem sentiment="positive" ... />   →   <Badge tone="positive">긍정</Badge>
```

| sentiment | Badge tone | 문구 |
| --- | --- | --- |
| `positive` | positive | 긍정 |
| `neutral` | neutral | 중립 |
| `negative` | negative | 부정 |
| `none` | outline | 미분류 |
| `toxic` | toxic | ⚑ 독성 의심 |

`ui/Badge`는 `tone`과 `children`만 압니다. 화면마다 `<Badge tone="positive">긍정</Badge>`를 손으로 쓰면 문구가 갈라집니다.

## `· 숨김`을 자동으로 붙입니다

`state="hidden"`이면 메타 문구 끝에 붙습니다.

```text
방금 · 세션 A        →   방금 · 세션 A · 숨김
```

배경이 흐려지는 것만으로 구분하면 색을 못 보는 사용자에게 전달되지 않습니다. 화면마다 손으로 쓰면 빠뜨리고요.

## 세 가지 상태

| state | 배경 | 테두리 | 본문 | 높이 |
| --- | --- | --- | --- | --- |
| `normal` | `Background/default` | `Border/subtle` | `Text/primary` | 80 |
| `flagged` | `Background/default` | `Toxic/lighter` | `Text/primary` | 122 |
| `hidden` | `Background/muted` | 투명 | `Text/tertiary` | 122 |

`hidden`의 테두리는 투명입니다. 시안에서 배경과 같은 색을 준 것과 같은 결과인데, 안 보이지만 자리를 차지해서 다른 상태와 높이가 어긋나지 않습니다.

## 버튼은 밖에서 넘깁니다

`actions` prop으로 받습니다. FeedItem은 숨기기·삭제가 무슨 일을 하는지 모릅니다. 안 넘기면 버튼 영역 자체가 렌더되지 않아 `normal`이 80이 됩니다.

## 관련 이슈

Closes #41

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.6s
✓ Finished TypeScript in 3.6s
✓ Collecting page data using 11 workers in 899ms
✓ Generating static pages using 11 workers (9/9) in 314ms
✓ Finalizing page optimization in 41ms
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- `components/feedback/` 폴더 신설

## 트러블슈팅 및 참고 사항

- `<article>`로 렌더합니다. 목록 안에 넣을 때는 `<ul><li>`로 감싸세요.
- 본문은 `content` prop으로 받는 문자열입니다. 서식 있는 내용이 들어올 자리가 아닙니다.
- Figma의 `meta`는 세트 전체가 공유하는 텍스트 속성이라 variant마다 다른 기본값을 둘 수 없습니다. 시안의 문구는 자리표시자이고, `· 숨김`은 코드가 붙입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 피드 항목을 표시하는 컴포넌트를 추가했습니다.
  * 일반, 플래그 지정, 숨김 상태를 지원합니다.
  * 긍정·중립·부정·미분류·유해 감정을 배지로 표시합니다.
  * 메타 정보, 본문, 선택적 작업 영역을 제공하며 숨김 항목을 구분해 표시합니다.

* **문서**
  * 피드 항목의 상태, 감정 표시, 사용 방법과 예시를 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->