### PR TITLE
feat(ui): ConfirmDialog 컴포넌트 추가

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -51,6 +51,8 @@
   --color-text-disabled: #b4b2a9;
   --color-text-inverse: #ffffff;
 
+  --color-overlay: rgb(0 0 0 / 0.5);
+
   --shadow-dialog: 0 0.25rem 1rem rgb(0 0 0 / 0.15);
   --shadow-toast: 0 0.25rem 0.25rem rgb(0 0 0 / 0.15);
 }
@@ -59,4 +61,10 @@ body {
   background: var(--color-background-default);
   color: var(--color-text-primary);
   font-family: var(--font-sans);
+}
+
+/* 모달이 열려 있는 동안 뒤 배경 스크롤을 막습니다.
+   showModal()은 포커스와 클릭만 가두고 스크롤은 그대로 두기 때문입니다. */
+body:has(dialog[open]) {
+  overflow: hidden;
 }

--- a/components/ui/ConfirmDialog.tsx
+++ b/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useId, useRef } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
+
+interface ConfirmDialogProps extends Omit<
+  ComponentProps<'dialog'>,
+  'children' | 'open' | 'role' | 'aria-labelledby' | 'aria-describedby' | 'onCancel' | 'onClose'
+> {
+  open: boolean;
+  title: string;
+  description: string;
+  actions: ReactNode;
+  onClose: () => void;
+}
+
+const BASE = [
+  'm-auto w-90 max-w-[calc(100%_-_2rem)]',
+  'open:flex flex-col items-center gap-4',
+  'rounded-xl bg-background-default p-6',
+  'shadow-dialog',
+  'backdrop:bg-overlay',
+].join(' ');
+
+const ConfirmDialog = ({
+  open,
+  title,
+  description,
+  actions,
+  onClose,
+  className = '',
+  ...props
+}: ConfirmDialogProps) => {
+  const ref = useRef<HTMLDialogElement>(null);
+  const id = useId();
+  const titleId = `${id}-title`;
+  const descriptionId = `${id}-description`;
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  return (
+    <dialog
+      ref={ref}
+      className={`${BASE} ${className}`}
+      {...props}
+      role="alertdialog"
+      aria-labelledby={titleId}
+      aria-describedby={descriptionId}
+      onCancel={(event) => {
+        event.preventDefault();
+        onClose();
+      }}
+    >
+      <h2 id={titleId} className="text-center text-lg font-medium leading-7 text-text-primary">
+        {title}
+      </h2>
+
+      <p
+        id={descriptionId}
+        className="text-center text-sm font-normal leading-5 text-text-secondary"
+      >
+        {description}
+      </p>
+
+      <div className="flex gap-2">{actions}</div>
+    </dialog>
+  );
+};
+
+export { ConfirmDialog };

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -562,6 +562,116 @@ import { Stat } from '@/components/ui/Stat';
 
 ---
 
+## ConfirmDialog
+
+`components/ui/ConfirmDialog.tsx`
+
+되돌릴 수 없는 동작을 실행하기 전에 한 번 묻는 창입니다. 시안의 `Alert`입니다.
+
+### 이름을 바꾼 이유
+
+`Alert`는 Banner가 이미 `role="alert"`로 쓰고 있어서 파일 목록에서 헷갈립니다. `Dialog`는 아무 내용이나 담는 껍데기로 읽히는데, 이건 제목·설명·버튼 세 자리가 정해진 확인 전용입니다.
+
+### 네이티브 `<dialog>`를 씁니다
+
+Radix 없이 `showModal()`만으로 아래가 전부 해결됩니다.
+
+| 필요한 것           | 처리          |
+| ------------------- | ------------- |
+| 포커스 가두기       | 브라우저      |
+| ESC로 닫기          | 브라우저      |
+| 뒤 배경 클릭 차단   | 브라우저      |
+| 딤 배경             | `::backdrop`  |
+| 뒤 배경 스크롤 잠금 | `globals.css` |
+
+스크롤 잠금만 `showModal()`이 안 해줍니다. `globals.css`의 `body:has(dialog[open])`가 대신합니다.
+
+외부 컴포넌트 라이브러리 도입은 아직 보류 상태이므로(CLAUDE.md), 이 방식으로 갑니다.
+
+### 스펙
+
+| 항목      | 값                                        |
+| --------- | ----------------------------------------- |
+| 너비      | `w-90` (360), `max-w-[calc(100%_-_2rem)]` |
+| radius    | `rounded-xl` (12)                         |
+| padding   | `p-6` (24)                                |
+| 요소 간격 | `gap-4` (16)                              |
+| 버튼 간격 | `gap-2` (8)                               |
+| 그림자    | `shadow-dialog`                           |
+| 딤 배경   | `backdrop:bg-overlay`                     |
+| 높이      | 176 (내용에서 나오는 값)                  |
+
+| 요소 | 폰트                | 색                    | 대비    |
+| ---- | ------------------- | --------------------- | ------- |
+| 제목 | 18 / Medium / lh28  | `text-text-primary`   | 13.99:1 |
+| 설명 | 14 / Regular / lh20 | `text-text-secondary` | 6.49:1  |
+
+시안은 360 고정이지만 코드에는 `max-w`를 붙였습니다. 320px 화면에서 넘치기 때문입니다.
+
+### `open`이 진실의 원천입니다
+
+DOM의 `open` 속성을 직접 건드리지 않습니다. `open` prop을 보고 `showModal()`·`close()`를 호출합니다.
+
+```tsx
+const [open, setOpen] = useState(false);
+
+<ConfirmDialog open={open} onClose={() => setOpen(false)} ... />
+```
+
+`<dialog open>`처럼 속성으로 열면 **모달이 아닌** 다이얼로그가 됩니다. 포커스도, 배경 차단도, 딤도 없습니다. 그래서 `open`을 props 타입에서 빼고 불리언으로 다시 받습니다.
+
+ESC를 누르면 `onCancel`에서 `preventDefault()`를 하고 `onClose()`만 호출합니다. 브라우저가 먼저 닫아버리면 React는 아직 열려 있다고 알고 있어서 둘이 어긋납니다. 닫는 것은 항상 `open` prop이 합니다.
+
+### 버튼은 밖에서 넘깁니다
+
+FeedItem과 같은 방식입니다. 확인 버튼이 `danger`인지 `primary`인지는 무슨 동작이냐에 달렸고, 그건 컴포넌트가 알 일이 아닙니다.
+
+```tsx
+actions={
+  <>
+    <Button variant="secondary" onClick={() => setOpen(false)}>취소</Button>
+    <Button variant="danger" onClick={handleDelete}>삭제</Button>
+  </>
+}
+```
+
+**취소를 먼저 두세요.** `showModal()`은 첫 번째 포커스 가능한 요소에 포커스를 줍니다. 파괴적 확인창에서 엔터를 눌렀을 때 취소되는 편이 안전합니다.
+
+### 주의
+
+- **`open:flex`입니다. `flex`로 바꾸지 마세요.** 닫힌 `<dialog>`를 숨기는 건 브라우저 기본 스타일인데, 작성자 스타일인 `.flex`가 그걸 이겨서 **닫혀도 화면에 남습니다.** `open:`을 붙이면 열렸을 때만 적용됩니다.
+- **`m-auto`도 지우지 마세요.** Tailwind Preflight가 `dialog { margin: 0 }`으로 초기화해서, 안 넣으면 화면 가운데가 아니라 왼쪽 위에 붙습니다.
+- **`role`·`aria-labelledby`·`aria-describedby`는 밖에서 못 바꿉니다.** `role="alertdialog"` 고정입니다. 되돌릴 수 없는 확인이라 스크린리더가 제목과 설명을 즉시 읽어야 합니다.
+- **`description`은 필수입니다.** 무엇이 일어나는지 안 쓰면 물어보는 의미가 없습니다. `삭제하면 되돌릴 수 없어요`처럼 결과를 적으세요.
+- **클라이언트 컴포넌트입니다.** `useRef`·`useEffect`를 씁니다.
+- 배경을 눌러 닫는 동작은 없습니다. 파괴적 확인창에서는 실수로 닫히는 편이 더 나쁩니다. ESC와 취소 버튼만 남겼습니다.
+
+### 사용 예
+
+```tsx
+import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+
+<ConfirmDialog
+  open={isConfirmOpen}
+  onClose={handleClose}
+  title="세션을 삭제할까요?"
+  description="삭제하면 되돌릴 수 없어요"
+  actions={
+    <>
+      <Button variant="secondary" onClick={handleClose}>
+        취소
+      </Button>
+      <Button variant="danger" onClick={handleDelete}>
+        삭제
+      </Button>
+    </>
+  }
+/>;
+```
+
+---
+
 ## icons
 
 `components/ui/icons.tsx`
@@ -594,7 +704,7 @@ import { Stat } from '@/components/ui/Stat';
 
 ## 미작성
 
-Card · Dialog
+Card
 
 Toast를 화면에 띄우는 구조(`useToast` · `ToastViewport`)도 아직입니다.
 
@@ -622,4 +732,8 @@ Toast를 화면에 띄우는 구조(`useToast` · `ToastViewport`)도 아직입�
 - 2026.08.06 — Toast는 생김새만 만들고 띄우는 방식은 분리. 위치·스택·타이머는 컴포넌트가 아니라 훅과 뷰포트의 일이라 섞으면 Toast가 비대해짐. 신규 토큰은 `--shadow-toast` 하나
 - 2026.08.06 — Toast 폰트를 Regular로. Banner는 Medium인데, 어두운 배경 위 흰 글씨는 같은 굵기라도 두껍게 보여서 한 단계 낮춰야 균형이 맞음
 - 2026.08.06 (#23) — 컴포넌트가 계산하는 접근성 속성은 밖에서 못 바꾸게 막는다. props 타입에서 `Omit`으로 빼고 JSX에서도 `{...props}` 뒤에 배치한다. 타입만 막으면 느슨한 객체를 펼칠 때 런타임에서 뚫린다. 현재 대상은 Banner의 `role`, Chip의 `aria-pressed`, 아이콘의 `aria-hidden`
+- 2026.08.07 — ConfirmDialog를 네이티브 `<dialog>` + `showModal()`로 구현. 포커스 가두기·ESC·배경 차단·딤을 브라우저가 처리해서 Radix 도입 논의가 필요 없어짐. 스크롤 잠금만 `globals.css`의 `body:has(dialog[open])`로 보완. 신규 토큰은 `--color-overlay`(시안에 딤 배경이 없어 코드에서 정함) 하나
+- 2026.08.07 — 열림 상태를 `open` prop 하나로만 관리. `<dialog open>` 속성으로 열면 모달이 아니게 되어 포커스도 배경 차단도 사라짐. ESC는 `onCancel`에서 `preventDefault()` 후 `onClose()`만 호출해서, 브라우저가 먼저 닫고 React가 뒤늦게 아는 상황을 막음
+- 2026.08.07 — 컴포넌트 이름을 시안의 `Alert`에서 `ConfirmDialog`로 변경. Banner가 이미 `role="alert"`를 쓰고 있어 혼동됨. `Dialog`는 아무 내용이나 담는 껍데기로 읽히는데 이건 제목·설명·버튼이 정해진 확인 전용
+- 2026.08.07 — 버튼을 `actions` prop으로 받고 취소를 먼저 배치. 확인 버튼이 danger인지 primary인지는 도메인 사정이고, `showModal()`이 첫 포커스 가능 요소에 포커스를 주므로 파괴적 확인창에서는 취소가 먼저인 편이 안전함
 - 2026.08.06 (#21) — Banner에 닫기 버튼을 넣지 않음. 현재 두 type이 모두 조건형이라, 닫으면 문제가 남아 있는데 표시만 사라짐. 공지형이 생기면 그때 `onClose` 추가


### PR DESCRIPTION
## 변경 사항

되돌릴 수 없는 동작을 실행하기 전에 한 번 묻는 확인 창입니다. 시안의 `Alert`입니다.

- `components/ui/ConfirmDialog.tsx` 추가
- `app/globals.css`에 `--color-overlay` 토큰과 모달 스크롤 잠금 규칙 추가
- `components/ui/README.md`에 스펙과 결정 기록 추가

## Radix 없이 네이티브 `<dialog>`로 했습니다

`미작성` 항목에 Dialog가 남아 있던 이유는 focus trap 때문에 외부 라이브러리 논의가 필요해 보였기 때문입니다. `showModal()`로 해결됩니다.

| 필요한 것           | 처리          |
| ------------------- | ------------- |
| 포커스 가두기       | 브라우저      |
| ESC로 닫기          | 브라우저      |
| 뒤 배경 클릭 차단   | 브라우저      |
| 딤 배경             | `::backdrop`  |
| 뒤 배경 스크롤 잠금 | `globals.css` |

스크롤 잠금만 `showModal()`이 안 해줘서 `body:has(dialog[open])`로 보완했습니다.

CLAUDE.md의 외부 컴포넌트 라이브러리 보류 원칙을 건드리지 않고 갑니다. **Radix 도입 논의는 접어도 됩니다.**

## `open` prop 하나가 진실의 원천입니다

DOM의 `open` 속성을 직접 쓰지 않습니다. `<dialog open>`으로 열면 **모달이 아닌** 다이얼로그가 되어 포커스도 배경 차단도 딤도 없습니다. 그래서 props 타입에서 `open`을 빼고 불리언으로 다시 받은 뒤, `showModal()`·`close()`를 호출합니다.

ESC는 `onCancel`에서 `preventDefault()`를 하고 `onClose()`만 호출합니다. 브라우저가 먼저 닫으면 React는 아직 열려 있다고 알고 있어서 다음 렌더에 어긋납니다.

## 접근성

`role="alertdialog"`입니다. 되돌릴 수 없는 확인이라 스크린리더가 제목과 설명을 즉시 읽어야 합니다. `aria-labelledby`·`aria-describedby`는 `useId`로 연결하고, 셋 다 밖에서 못 바꾸게 막았습니다(#23 규칙).

`description`을 필수로 뒀습니다. 무엇이 일어나는지 안 쓰면 물어보는 의미가 없습니다.

취소 버튼을 먼저 배치했습니다. `showModal()`이 첫 번째 포커스 가능한 요소에 포커스를 주므로, 파괴적 확인창에서 엔터를 눌렀을 때 취소되는 편이 안전합니다.

## 시안과 다르게 한 것

| 항목      | 시안     | 코드                          | 이유                        |
| --------- | -------- | ----------------------------- | --------------------------- |
| 너비      | 360 고정 | `w-90` + `max-w`              | 320px 화면에서 넘침         |
| 딤 배경   | 없음     | `backdrop:bg-overlay`         | 없으면 뒤가 잠긴 걸 알 수 없음 |
| 컴포넌트명 | `Alert`  | `ConfirmDialog`               | Banner가 `role="alert"` 사용 |

## 명암비

| 요소 | 색                    | 대비    |
| ---- | --------------------- | ------- |
| 제목 | `Text/primary`        | 13.99:1 |
| 설명 | `Text/secondary`      | 6.49:1  |
| 취소 | Button `secondary`    | 13.99:1 |
| 삭제 | Button `danger`       | 10.21:1 |

시안의 danger 버튼이 `Negative/default`(3.87:1)로 되어 있어 감사에서 잡았고, `Negative/darker`로 수정한 뒤 구현했습니다.

## 관련 이슈

Closes #50

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.5s
✓ Finished TypeScript in 3.9s
✓ Collecting page data using 11 workers in 980ms
✓ Generating static pages using 11 workers (9/9) in 405ms
✓ Finalizing page optimization in 28ms
```

명암비는 sRGB 상대 휘도 공식(WCAG 2.1)으로 직접 계산했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: `--color-overlay` (시안에 딤 배경이 없어 코드에서 정함)
- Breaking Change: 없음
- `globals.css`에 전역 규칙 하나가 추가됩니다. `dialog[open]`이 있을 때만 걸려서 다른 화면에는 영향이 없습니다

## 트러블슈팅 및 참고 사항

- **`open:flex`입니다.** 그냥 `flex`로 쓰면 닫혀도 화면에 남습니다. 닫힌 `<dialog>`를 숨기는 건 브라우저 기본 스타일인데, 작성자 스타일인 `.flex`가 그걸 이깁니다.
- **`m-auto`가 필요합니다.** Tailwind Preflight가 `dialog { margin: 0 }`으로 초기화해서, 없으면 화면 가운데가 아니라 왼쪽 위에 붙습니다.
- 배경 클릭으로 닫는 동작은 넣지 않았습니다. 파괴적 확인창에서는 실수로 닫히는 편이 더 나쁩니다.
- 버튼은 `actions` prop으로 받습니다. 확인 버튼이 danger인지 primary인지는 도메인 사정이라 FeedItem과 같은 방식으로 뒀습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 확인 및 취소 작업을 위한 접근성 지원 모달 대화상자를 추가했습니다.
  * 제목, 설명, 사용자 지정 작업 버튼을 표시할 수 있습니다.
  * ESC 키로 대화상자를 닫을 수 있습니다.
  * 모달이 열려 있는 동안 배경 스크롤을 차단합니다.

* **문서**
  * 모달 대화상자 사용 방법과 동작을 문서화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->