### PR TITLE
fix(schemas): 감정 개수에 음수 방지 추가

### DIFF
--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -63,6 +63,15 @@ const id = z.int().positive();
 const isoDateTime = z.iso.datetime();
 
 /**
+ * 집계 개수. 0은 나오지만 음수는 나올 수 없습니다.
+ *
+ * 화면에서 clamp하지 않고 여기서 막습니다. 예를 들어 감정 분포에 음수가 들어오면
+ * 막대 컴포넌트는 그 값을 0으로 접어 "아직 소감 없음"과 똑같이 그리게 되는데,
+ * 그러면 백엔드 집계 버그가 정상 화면으로 위장됩니다.
+ */
+const count = z.int().nonnegative();
+
+/**
  * 목록 응답 봉투. v1에 페이지네이션은 없지만, 나중에 nextCursor/hasMore를
  * 필드 추가만으로 도입할 수 있도록 봉투를 씌워둔 상태입니다(비파괴 seam).
  * FE는 반드시 `.items`로 언랩해야 합니다.
@@ -273,13 +282,13 @@ export const feedbackSchema = feedbackViewSchema.extend({
 
 export const keywordCountSchema = z.object({
   keyword: z.string(),
-  count: z.int(),
+  count,
 });
 
 export const sentimentBreakdownSchema = z.object({
-  POS: z.int(),
-  NEU: z.int(),
-  NEG: z.int(),
+  POS: count,
+  NEU: count,
+  NEG: count,
 });
 
 /**
@@ -290,7 +299,7 @@ export const feedbackSnapshotSchema = z.object({
   /** sentiment != UNKNOWN 집계 */
   sentimentBreakdown: sentimentBreakdownSchema,
   /** sentiment = UNKNOWN(태깅 실패) 건수. 대시보드에 "미분류 N건"으로 별도 표시합니다. */
-  unclassifiedCount: z.int(),
+  unclassifiedCount: count,
   /** 빈도순 상위 10 */
   topKeywords: z.array(keywordCountSchema),
   /** 최신 50 */


### PR DESCRIPTION
## 변경 사항

집계 개수 필드가 음수를 허용하고 있었습니다.

- `lib/schemas/api.ts`에 공통 `count` 스키마 추가
- `sentimentBreakdownSchema`의 `POS`·`NEU`·`NEG`에 적용
- `feedbackSnapshotSchema`의 `unclassifiedCount`에 적용
- `keywordCountSchema`의 `count`에 적용

```diff
-const isoDateTime = z.iso.datetime();
+const isoDateTime = z.iso.datetime();
+const count = z.int().nonnegative();
```

`id`가 `z.int().positive()`로 한 번만 정의돼 있는 것과 같은 방식입니다. 필드마다 `.nonnegative()`를 반복하면 새 집계 필드가 생겼을 때 빠뜨립니다.

## 왜 화면이 아니라 스키마인가

Thermometer(#47) 리뷰에서 "컴포넌트가 런타임에 음수를 걸러야 하지 않냐"는 지적이 나왔고, 스키마 쪽으로 옮겼습니다.

컴포넌트에서 `Math.max(0, value)`로 접으면 **막대가 비어 보입니다.** 그런데 그건 "아직 소감이 없는 이벤트"와 화면상 완전히 같습니다. 집계 버그가 정상 화면으로 위장되는 셈이라, 아무도 눈치채지 못합니다.

경계에서 막으면 잘못된 응답이 들어온 순간 zod가 던집니다. 어디서 깨졌는지 바로 드러납니다.

`z.int()`는 `NaN`과 `Infinity`는 이미 막고 있어서, 음수만 남은 구멍이었습니다.

## 관련 이슈

Closes #49

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.4s
✓ Finished TypeScript in 3.9s
✓ Collecting page data using 11 workers in 969ms
✓ Generating static pages using 11 workers (9/9) in 388ms
✓ Finalizing page optimization in 30ms
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음 — 제약을 좁히기만 해서 기존 정상 응답은 그대로 통과합니다
- 타입(`z.infer`) 변화 없음. `number`로 동일합니다
- MSW 목 데이터는 전부 양수라 영향 없습니다

## 트러블슈팅 및 참고 사항

- 이 파일은 #12에서 만들어진 것이라 작성자 확인을 먼저 거쳤습니다(CLAUDE.md "백엔드 API 스펙 변경을 제안할 때는 반드시 담당자 확인").
- **백엔드도 자기 경계에서 같이 막아야 합니다.** 여기서 막는 건 FE가 잘못된 데이터를 그리지 않게 하는 것이지, 잘못된 집계가 나오는 것 자체를 고치지는 않습니다.
- `sessionSchema.order`도 `z.int()`지만 건드리지 않았습니다. 순서값은 음수가 의미를 가질 수 있고 이 이슈 범위 밖입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 집계 숫자에 음수가 입력되지 않도록 검증을 강화했습니다.
  * 키워드 수, 감정별 집계, 미분류 항목 수가 0 이상의 정수만 허용하도록 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->