### PR TITLE
fix(ui): Toast에 font-normal 추가

### DIFF
--- a/components/ui/Toast.tsx
+++ b/components/ui/Toast.tsx
@@ -8,7 +8,7 @@ const BASE = [
   'inline-flex items-center gap-1.5',
   'rounded-lg px-4 py-3',
   'bg-background-inverse text-text-inverse',
-  'text-sm leading-5',
+  'text-sm font-normal leading-5',
   'shadow-toast',
 ].join(' ');
 


### PR DESCRIPTION
## 변경 사항

`components/ui/Toast.tsx`의 `BASE`에 `font-normal`을 추가했습니다.

```diff
-  'text-sm leading-5',
+  'text-sm font-normal leading-5',
```

## 왜 문제였나

굵기를 안 적으면 CSS가 부모를 상속합니다. `font-medium`인 컨테이너 안에 Toast가 들어가면 시안(Regular)보다 두껍게 렌더됩니다.

Badge에는 같은 이유로 `font-normal`을 명시해뒀는데 Toast에만 빠져 있었습니다. README에는 Regular라고 적혀 있어 문서와 코드가 어긋난 상태였습니다.

Toast는 어두운 배경 위 흰 글씨라 같은 굵기라도 두껍게 보입니다. Banner(Medium)보다 한 단계 낮춰야 균형이 맞는다고 정했었는데(#21), 코드가 그걸 보장하지 못하고 있었습니다.

## 관련 이슈

Closes #53

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.5s
✓ Finished TypeScript in 3.9s
✓ Collecting page data using 11 workers in 1081ms
✓ Generating static pages using 11 workers (9/9) in 302ms
✓ Finalizing page optimization in 25ms
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- README 수정 없음 — 문서는 이미 Regular로 적혀 있었고 코드가 따라온 것입니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 토스트 알림의 텍스트가 일반 굵기로 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->