### PR TITLE
fix(api): INVALID_RESPONSE를 재시도 대상에서 제외

### DIFF
--- a/components/providers/QueryProvider.tsx
+++ b/components/providers/QueryProvider.tsx
@@ -25,9 +25,15 @@ const QueryProvider = ({ children }: QueryProviderProps) => {
         defaultOptions: {
           queries: {
             staleTime: 10_000,
-            // 4xx는 다시 물어봐도 같은 답이라 재시도하지 않습니다.
+            // 다시 물어봐도 같은 답이 오는 실패는 재시도하지 않습니다.
             retry: (failureCount, error) => {
-              if (error instanceof ApiError && isClientError(error.code)) return false;
+              if (error instanceof ApiError) {
+                // 응답이 계약과 다른 경우. 같은 요청에 같은 응답이 옵니다.
+                if (error.code === 'INVALID_RESPONSE') return false;
+                // 4xx.
+                if (isClientError(error.code)) return false;
+              }
+
               return failureCount < 2;
             },
             refetchOnWindowFocus: false,

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -55,9 +55,10 @@ import type { z } from 'zod';
  * 않습니다(#56).
  *
  * 원래는 배포 시차로 BE·FE 버전이 잠깐 어긋난 경우를 넘기려고 재시도를 두었습니다.
- * 재시도 3회는 백오프를 포함해도 3초 안에 끝나는데 배포 시차는 분 단위라, 의도한
- * 효과가 없으면서 이미 어긋난 서버로 나가는 요청만 3배가 됐습니다. 집계 API를
- * 3초마다 부르는 화면이 붙으면서 실제로 문제가 됩니다.
+ * 기본 정책은 `failureCount < 2`라 최대 2회 재시도(총 3회 요청)이고, 지수 백오프를
+ * 포함해도 3초 안에 끝납니다. 배포 시차는 분 단위라 의도한 효과가 없으면서 이미
+ * 어긋난 서버로 나가는 요청만 3배가 됐습니다. 집계 API를 3초마다 부르는 화면이
+ * 붙으면서 실제로 문제가 됩니다.
  */
 const parseResponse = <T extends z.ZodType>(schema: T, data: unknown, path: string): z.infer<T> => {
   const result = schema.safeParse(data);

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -50,9 +50,14 @@ import type { z } from 'zod';
  * 그대로 화면까지 흘러가 `items.map`처럼 필드에 손대는 순간 터졌고, 이 함수가 막으려던
  * "조용한 undefined"가 그대로 재현됐습니다. 실패는 호출자가 알아야 하므로 던집니다.
  *
- * `INVALID_RESPONSE`는 `API_ERROR_STATUS`에 없어서 `isClientError`가 false를 주고,
- * 그래서 `QueryProvider`의 기본 정책상 2회까지 재시도됩니다. 배포 시차로 BE·FE 버전이
- * 잠깐 어긋난 경우를 넘길 수 있어 그대로 둡니다.
+ * `INVALID_RESPONSE`는 FE가 만든 코드라 `API_ERROR_STATUS` 표에 없습니다. 그래서
+ * `isClientError`가 false를 주는데, `QueryProvider`가 이 코드를 따로 걸러 재시도하지
+ * 않습니다(#56).
+ *
+ * 원래는 배포 시차로 BE·FE 버전이 잠깐 어긋난 경우를 넘기려고 재시도를 두었습니다.
+ * 재시도 3회는 백오프를 포함해도 3초 안에 끝나는데 배포 시차는 분 단위라, 의도한
+ * 효과가 없으면서 이미 어긋난 서버로 나가는 요청만 3배가 됐습니다. 집계 API를
+ * 3초마다 부르는 화면이 붙으면서 실제로 문제가 됩니다.
  */
 const parseResponse = <T extends z.ZodType>(schema: T, data: unknown, path: string): z.infer<T> => {
   const result = schema.safeParse(data);


### PR DESCRIPTION
## 변경 사항

`INVALID_RESPONSE`를 재시도 대상에서 뺐습니다.

- `components/providers/QueryProvider.tsx` — `retry` 조건
- `lib/api/endpoints.ts` — 재시도 관련 주석

```diff
-            retry: (failureCount, error) => {
-              if (error instanceof ApiError && isClientError(error.code)) return false;
-              return failureCount < 2;
-            },
+            retry: (failureCount, error) => {
+              if (error instanceof ApiError) {
+                if (error.code === 'INVALID_RESPONSE') return false;
+                if (isClientError(error.code)) return false;
+              }
+
+              return failureCount < 2;
+            },
```

## 왜 재시도되고 있었나

`INVALID_RESPONSE`는 응답이 계약 스키마와 어긋날 때 `parseResponse`가 던지는 코드입니다. **백엔드가 준 게 아니라 FE가 만든 코드**라 `API_ERROR_STATUS` 표에 없습니다.

`isClientError`는 그 표를 보고 400번대면 재시도를 건너뛰는데, 표에 없으니 `undefined` → `false`가 나와 "재시도해도 되는 에러"로 분류됐습니다.

같은 요청에 같은 응답이 오는 결정적 실패라 재시도할 이유가 없습니다.

## 원래 근거가 성립하지 않습니다

`endpoints.ts` 주석에 이렇게 적혀 있었습니다.

> 배포 시차로 BE·FE 버전이 잠깐 어긋난 경우를 넘길 수 있어 그대로 둡니다.

재시도 3회는 지수 백오프를 포함해도 **3초 안에** 끝납니다. 배포 시차는 분 단위입니다. 3초로 배포가 끝나지 않으므로 의도한 효과가 없고, 이미 어긋난 서버로 나가는 요청만 3배가 됩니다.

## 지금 문제가 되는 이유

집계 API를 폴링하는 화면이 붙고 있습니다.

- `app/dev/msw/page.tsx` — 5초
- `hooks/useFeedbackSnapshot.ts` — 참가자 실시간 화면, 3초 (#54)

백엔드 집계에 버그가 하나 생기면 **3초마다 최대 3번씩** 요청이 나갑니다. #52에서 개수 필드에 `nonnegative`를 추가하면서 이 경로에 걸릴 면적도 넓어졌습니다.

## 쿼리별 `retry: false`가 아닌 이유

폴링 쿼리마다 옵션을 붙이는 방법도 있지만, 쿼리가 늘어날 때마다 기억해야 해서 언젠가 빠뜨립니다. `INVALID_RESPONSE`는 어느 쿼리에서 나오든 재시도가 무의미하므로 정책을 한 곳에 뒀습니다.

## 관련 이슈

Closes #56

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 5.3s
✓ Finished TypeScript in 5.4s
✓ Collecting page data using 11 workers in 1230ms
✓ Generating static pages using 11 workers (9/9) in 370ms
✓ Finalizing page optimization in 31ms
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- 4xx 재시도 정책과 기본 2회 재시도는 그대로입니다. `INVALID_RESPONSE`만 빠집니다

## 트러블슈팅 및 참고 사항

- **범위 밖:** 검증에 걸리면 응답 전체가 버려져서 음수와 무관한 필드(`recentFeedbacks` 등)까지 화면에서 사라집니다. "부분 실패를 어디까지 허용할 것인가"는 별개 문제라 여기서 다루지 않았습니다.
- `#12`에서 만들어진 파일이라 작성자 확인을 먼저 거쳤습니다(CLAUDE.md).
- `#52` 리뷰에서 나온 지적입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 잘못된 응답이나 4xx 오류 발생 시 불필요한 자동 재시도를 중단합니다.
  * 그 외 일시적인 오류는 최대 2회까지 자동으로 재시도해 서비스 이용 안정성을 유지합니다.

* **문서**
  * 오류별 재시도 동작과 배포 시차에 따른 예외 처리 기준을 최신 동작에 맞게 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->