### PR TITLE
feat(report): 참가자 공개 리포트 화면 구현

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -77,7 +77,7 @@ const ReportPage = async ({ params }: ReportPageProps) => {
     );
   }
 
-  const { summaryText, sentimentBreakdown, topKeywords } = report;
+  const { summaryText, sentimentBreakdown, unclassifiedCount, topKeywords } = report;
   const counts = {
     positive: sentimentBreakdown.POS,
     neutral: sentimentBreakdown.NEU,
@@ -85,26 +85,32 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   };
 
   /**
-   * 게스트 응답에는 미분류(UNKNOWN) 건수가 없어 감정 세 칸의 합이 곧 총 소감 수입니다.
-   * 태깅에 실패한 소감은 이 숫자에서 빠집니다.
+   * `sentimentBreakdown`은 UNKNOWN을 뺀 집계라 세 칸의 합이 총 소감 수보다 작습니다.
+   * 태깅에 실패한 건수를 더해야 "몇 건을 받았는지"가 나옵니다(publicReportSchema 주석).
    */
-  const feedbackCount = counts.positive + counts.neutral + counts.negative;
+  const submissionCount = counts.positive + counts.neutral + counts.negative + unclassifiedCount;
 
-  // Donut 범례와 같은 숫자가 나오도록 반올림을 toRates 한 곳에 맡깁니다.
+  /**
+   * 긍정 비율의 분모에는 미분류를 넣지 않습니다. UNKNOWN은 "중립"이 아니라 분석 실패라,
+   * 분모에 넣으면 태깅이 많이 실패할수록 긍정 비율이 저절로 내려갑니다(metrics.ts와 같은 규칙).
+   * Donut 범례와 같은 숫자가 나오도록 반올림은 toRates 한 곳에 맡깁니다.
+   */
   const positiveRate = toRates(counts).positive;
 
   return (
     <main className={PAGE}>
       <header className="flex flex-col gap-1">
-        <time dateTime={event.createdAt} className="text-xs leading-4 text-text-tertiary">
-          {formatDate(event.createdAt)} · 참가자 {feedbackCount}명
-        </time>
+        {/* 소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다. */}
+        <p className="text-xs leading-4 text-text-tertiary">
+          <time dateTime={event.createdAt}>{formatDate(event.createdAt)}</time> · 소감{' '}
+          {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
+        </p>
 
         <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
       </header>
 
       <div className="grid grid-cols-3 gap-3">
-        <Stat label="총 소감" value={`${feedbackCount}`} />
+        <Stat label="총 소감" value={`${submissionCount}`} />
         <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
         <Stat label="세션" value={`${sessions.length}`} />
       </div>
@@ -115,7 +121,13 @@ const ReportPage = async ({ params }: ReportPageProps) => {
       </section>
 
       <section className={`${CARD} items-center`}>
-        <h2 className="self-start text-xs leading-4 text-text-tertiary">감정 분포</h2>
+        {/*
+          분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
+          총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
+        */}
+        <h2 className="self-start text-xs leading-4 text-text-tertiary">
+          감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
+        </h2>
         {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
         <Donut {...counts} className="py-2" />
       </section>

--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -27,7 +27,9 @@ const fetchReportOrNull = (code: string) =>
     return toNotFound(error);
   });
 
-const PAGE = 'mx-auto flex w-full max-w-3xl flex-col gap-6 p-5 md:p-8';
+// 폭은 형제 페이지(`/e/[code]`·not-found)와 같은 열에 맞춥니다. 레이아웃의 로고도 `max-w-md`라
+// 여기만 넓히면 넓은 화면에서 로고와 본문의 왼쪽 끝이 어긋납니다.
+const PAGE = 'mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4';
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle bg-background-default p-4';
 
 /**

--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -1,6 +1,123 @@
-const ReportPage = () => {
-  // API: GET /events/{eventCode}/report. 비공개 상태면 404로 처리합니다.
-  return <div>공개 리포트 (준비 중)</div>;
+import { notFound } from 'next/navigation';
+import { Donut } from '@/components/feedback/Donut';
+import { toRates } from '@/components/feedback/sentiment';
+import { Stat } from '@/components/ui/Stat';
+import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+
+interface ReportPageProps {
+  params: Promise<{ code: string }>;
+}
+
+/**
+ * 404로 넘길 에러입니다.
+ *
+ * 게스트 응답에서 "리포트 없음"·"비공개"·"생성 중"은 서버가 이미 REPORT_NOT_FOUND 하나로
+ * 합쳐서 줍니다(mocks/handlers/report.ts). 비공개 리포트의 존재 자체를 알리지 않으려는
+ * 의도라 화면에서도 구분하지 않습니다. 없는 이벤트 코드로 들어오면 EVENT_NOT_FOUND가
+ * 먼저 나오는데, 이것도 사용자 입장에서는 같은 "없는 페이지"입니다.
+ */
+const NOT_FOUND_CODES = ['REPORT_NOT_FOUND', 'EVENT_NOT_FOUND'];
+
+const toNotFound = (error: unknown): never => {
+  if (error instanceof ApiError && NOT_FOUND_CODES.includes(error.code)) {
+    notFound();
+  }
+  throw error;
+};
+
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle bg-background-default p-4';
+
+/**
+ * 서버 타임존에 따라 하루가 밀리지 않도록 Asia/Seoul로 고정합니다.
+ * Vercel 서버는 UTC라 자정 근처에 만든 이벤트의 날짜가 어긋납니다.
+ */
+const formatDate = (iso: string) => {
+  const parts = new Intl.DateTimeFormat('ko-KR', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date(iso));
+  const valueOf = (type: Intl.DateTimeFormatPartTypes) =>
+    parts.find((part) => part.type === type)?.value ?? '';
+
+  return `${valueOf('year')}.${valueOf('month')}.${valueOf('day')}`;
+};
+
+// 목 데이터가 매 요청 반영되도록 캐시하지 않습니다(app/dev/msw/ssr/page.tsx와 같은 이유).
+export const dynamic = 'force-dynamic';
+
+const ReportPage = async ({ params }: ReportPageProps) => {
+  const { code } = await params;
+
+  // 서로 기다릴 이유가 없어 병렬로 부릅니다. 셋 다 같은 404 규칙을 씁니다.
+  const [event, report, sessions] = await Promise.all([
+    fetchEventByCode(code).catch(toNotFound),
+    fetchPublicReport(code).catch(toNotFound),
+    fetchSessionsByEventCode(code).catch(toNotFound),
+  ]);
+
+  const { summaryText, sentimentBreakdown, topKeywords } = report;
+  const counts = {
+    positive: sentimentBreakdown.POS,
+    neutral: sentimentBreakdown.NEU,
+    negative: sentimentBreakdown.NEG,
+  };
+
+  /**
+   * 게스트 응답에는 미분류(UNKNOWN) 건수가 없어 감정 세 칸의 합이 곧 총 소감 수입니다.
+   * 태깅에 실패한 소감은 이 숫자에서 빠집니다.
+   */
+  const feedbackCount = counts.positive + counts.neutral + counts.negative;
+
+  // Donut 범례와 같은 숫자가 나오도록 반올림을 toRates 한 곳에 맡깁니다.
+  const positiveRate = toRates(counts).positive;
+
+  return (
+    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-5 md:p-8">
+      <header className="flex flex-col gap-1">
+        <time dateTime={event.createdAt} className="text-xs leading-4 text-text-tertiary">
+          {formatDate(event.createdAt)} · 참가자 {feedbackCount}명
+        </time>
+
+        <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
+      </header>
+
+      <div className="grid grid-cols-3 gap-3">
+        <Stat label="총 소감" value={`${feedbackCount}`} />
+        <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
+        <Stat label="세션" value={`${sessions.length}`} />
+      </div>
+
+      <section className={CARD}>
+        <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
+        <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
+      </section>
+
+      <section className={`${CARD} items-center`}>
+        <h2 className="self-start text-xs leading-4 text-text-tertiary">감정 분포</h2>
+        {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
+        <Donut {...counts} className="py-2" />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+        {/* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */}
+        <ul className="flex flex-wrap gap-2">
+          {topKeywords.map(({ keyword, count }) => (
+            <li
+              key={keyword}
+              className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
+            >
+              {keyword}
+              <span className="text-text-tertiary">{count}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </main>
+  );
 };
 
 export default ReportPage;

--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -9,23 +9,25 @@ interface ReportPageProps {
   params: Promise<{ code: string }>;
 }
 
-/**
- * 404로 넘길 에러입니다.
- *
- * 게스트 응답에서 "리포트 없음"·"비공개"·"생성 중"은 서버가 이미 REPORT_NOT_FOUND 하나로
- * 합쳐서 줍니다(mocks/handlers/report.ts). 비공개 리포트의 존재 자체를 알리지 않으려는
- * 의도라 화면에서도 구분하지 않습니다. 없는 이벤트 코드로 들어오면 EVENT_NOT_FOUND가
- * 먼저 나오는데, 이것도 사용자 입장에서는 같은 "없는 페이지"입니다.
- */
-const NOT_FOUND_CODES = ['REPORT_NOT_FOUND', 'EVENT_NOT_FOUND'];
-
+/** 이벤트가 없을 때만 not-found.tsx로 넘깁니다. */
 const toNotFound = (error: unknown): never => {
-  if (error instanceof ApiError && NOT_FOUND_CODES.includes(error.code)) {
-    notFound();
-  }
+  if (error instanceof ApiError && error.code === 'EVENT_NOT_FOUND') notFound();
   throw error;
 };
 
+/**
+ * 리포트가 없음·비공개·생성 중이면 서버가 REPORT_NOT_FOUND 하나로 합쳐서 줍니다
+ * (mocks/handlers/report.ts). 비공개 리포트의 존재를 알리지 않으려는 의도라 화면도 셋을
+ * 구분하지 않고 null 하나로 받습니다. 다만 "이벤트가 없음"은 별개라 여기서 걸러지지 않고
+ * toNotFound로 넘어갑니다 — 이벤트는 있는데 "링크를 확인하라"고 하면 틀린 안내입니다.
+ */
+const fetchReportOrNull = (code: string) =>
+  fetchPublicReport(code).catch((error: unknown) => {
+    if (error instanceof ApiError && error.code === 'REPORT_NOT_FOUND') return null;
+    return toNotFound(error);
+  });
+
+const PAGE = 'mx-auto flex w-full max-w-3xl flex-col gap-6 p-5 md:p-8';
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle bg-background-default p-4';
 
 /**
@@ -51,12 +53,29 @@ export const dynamic = 'force-dynamic';
 const ReportPage = async ({ params }: ReportPageProps) => {
   const { code } = await params;
 
-  // 서로 기다릴 이유가 없어 병렬로 부릅니다. 셋 다 같은 404 규칙을 씁니다.
+  // 서로 기다릴 이유가 없어 병렬로 부릅니다. sessions는 빈 상태에서 안 쓰지만, 리포트
+  // 유무를 보고 부르면 정상 경로가 한 왕복 느려져서 그냥 같이 보냅니다.
   const [event, report, sessions] = await Promise.all([
     fetchEventByCode(code).catch(toNotFound),
-    fetchPublicReport(code).catch(toNotFound),
+    fetchReportOrNull(code),
     fetchSessionsByEventCode(code).catch(toNotFound),
   ]);
+
+  if (report === null) {
+    return (
+      <main className={PAGE}>
+        {/* not-found.tsx의 빈 상태 카드와 같은 모양을 씁니다. */}
+        <div className="flex flex-col items-center gap-1 rounded-xl border border-border-subtle px-5 py-10">
+          <p className="text-base font-medium leading-6 text-text-primary">
+            공개된 리포트가 없어요
+          </p>
+          <p className="text-sm font-normal leading-5 text-text-secondary">
+            주최자가 공개하면 이 페이지에서 볼 수 있어요
+          </p>
+        </div>
+      </main>
+    );
+  }
 
   const { summaryText, sentimentBreakdown, topKeywords } = report;
   const counts = {
@@ -75,7 +94,7 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   const positiveRate = toRates(counts).positive;
 
   return (
-    <main className="mx-auto flex w-full max-w-3xl flex-col gap-6 p-5 md:p-8">
+    <main className={PAGE}>
       <header className="flex flex-col gap-1">
         <time dateTime={event.createdAt} className="text-xs leading-4 text-text-tertiary">
           {formatDate(event.createdAt)} · 참가자 {feedbackCount}명


### PR DESCRIPTION
## 변경 사항

- `app/e/[code]/report/page.tsx`를 스텁에서 실제 화면으로 구현했습니다. SSR에서 이벤트·공개 리포트·세션 목록을 `Promise.all`로 병렬 조회해 요약문, 감정 분포, 상위 키워드를 그립니다.
- 404 처리는 `EVENT_NOT_FOUND`만 `notFound()`로 보냅니다. 리포트가 없거나 비공개면(`REPORT_NOT_FOUND`) 페이지 안에서 빈 상태를 그립니다. `not-found.tsx`는 하위 세그먼트까지 덮기 때문에, 이벤트가 멀쩡한데도 "이벤트를 찾을 수 없어요 / 링크가 올바른지 다시 확인해 주세요"가 떠서 틀린 안내가 됩니다. 다만 게스트 응답에서 "리포트 없음 / 비공개 / 생성 중"이 하나의 코드로 합쳐져 오는 방침은 그대로 따라, 이 셋은 화면에서도 구분하지 않고 `null` 하나로 받습니다.
- **미분류(UNKNOWN) 건수를 집계에 반영했습니다.** `PublicReport`에 `unclassifiedCount`가 추가되면서(dev 리베이스로 들어옴) 이전 트러블슈팅 항목이 해소됐습니다. 자세한 내용은 아래 트러블슈팅 1번을 봐주세요.
- 감정 분포는 dev에 이미 있는 `components/feedback/Donut`을 그대로 씁니다. API가 `POS`/`NEU`/`NEG`, Donut이 `positive`/`neutral`/`negative`라 페이지에서 이름만 맞춰 넘깁니다. 반올림은 `toRates` 한 곳에 맡겨 범례와 상단 지표의 숫자가 어긋나지 않게 했습니다.
- 키워드 목록에 `Chip`을 쓰지 않았습니다. `Chip`은 `button` + `aria-pressed` 조합이라 읽기 전용 목록에 쓰면 스크린리더에 토글로 읽힙니다. `li`로 직접 그렸습니다.
- 날짜는 `Asia/Seoul`로 고정했습니다. Vercel 서버가 UTC라 고정하지 않으면 자정 근처에 만든 이벤트의 날짜가 하루 밀립니다.
- 본문 폭을 형제 페이지와 같은 `max-w-md`로 맞췄습니다. 이 페이지만 `max-w-3xl`이라 넓은 화면에서 레이아웃의 로고(`max-w-md`)와 본문의 왼쪽 끝이 어긋나 있었습니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| `33a78e9` | feat(report): 참가자 공개 리포트 화면 구현 | 공개 페이지라 CSR이 아닌 SSR로 구성. 요약·감정 분포·키워드를 한 화면에 |
| `504900f` | feat(report): 리포트가 없을 때 빈 상태를 페이지 안에서 렌더 | 리포트만 없는 경우까지 `notFound()`로 보내면 "링크를 확인하라"는 틀린 안내가 나감 |
| `09c81b4` | fix(report): 공개 리포트 집계에 미분류 건수를 반영 | 세 칸의 합을 총 소감으로 쓰면 태깅 실패분이 빠져 실제보다 적게 나옴 |
| `3aacde3` | fix(report): 본문 폭을 참가자 화면 공통 열에 맞춤 | 이 페이지만 넓어 로고 열과 왼쪽 끝이 어긋남 |

첫 커밋은 `REPORT_NOT_FOUND`와 `EVENT_NOT_FOUND`를 한 배열에 묶어 둘 다 `notFound()`로 넘겼습니다. 그 시점에는 `not-found.tsx`가 아직 dev에 없어서 문제가 드러나지 않았는데, 리베이스로 파일이 들어오면서 실제로 재현됐습니다. 두 번째 커밋이 그 대응입니다.

뒤의 두 커밋은 최신 dev(`4965a77`) 위로 다시 리베이스한 뒤 시안과 대조하면서 나왔습니다. 리베이스로 앞 두 커밋의 해시가 바뀌었습니다(`bf5f8b0`·`94aec7f` → `33a78e9`·`504900f`).

## 관련 이슈

- Closes #74
- Closes #89
- Refs #5
- Refs #84 (참가자에게 리포트 상태를 구분해서 알리지 않는 A안 결정)

## 검증 방법

`npm run test` — 4개 파일 87개 테스트 통과.

```
Test Files  4 passed (4)
     Tests  87 passed (87)
```

`npm run lint` — 통과(출력 없음).

`npm run build` — 통과. 라우트 표에서 `/e/[code]/report`가 `ƒ (Dynamic)`으로 잡혀 요청 시점 서버 렌더임을 확인했습니다.

```
├ ƒ /e/[code]/report
ƒ  (Dynamic)  server-rendered on demand
```

화면은 dev 서버에서 확인했습니다.

| 경로 | 목 상태 | 결과 |
| --- | --- | --- |
| `/e/kd7m2p/report` | 리포트 `GENERATED` + `isPublic=true` | 헤더 "소감 6개 (미분류 1개)", 총 소감 6, 긍정 비율 40%, 도넛 범례 40/40/20, "감정 분포 · 미분류 제외" |
| `/e/ab3f9x/report` | 리포트 행 없음 (LIVE) | 빈 상태 — "공개된 리포트가 없어요" |
| `/e/zq1v8t/report` | 리포트 행 없음 (DRAFT) | 빈 상태 |
| `/e/zzzzzz/report` | 없는 이벤트 코드 | `not-found.tsx` — "이벤트를 찾을 수 없어요" |

첫 행의 숫자는 시드(`mocks/data/seed.ts:330`)의 `POS 2 / NEU 2 / NEG 1` + `unclassifiedCount 1`과 맞습니다. 총 소감 6은 미분류를 포함한 값이고, 긍정 비율 40%는 미분류를 뺀 분모(5) 기준이라 두 숫자의 분모가 다릅니다. 그 차이를 "· 미분류 제외" 라벨이 설명합니다.

비공개 리포트는 브라우저로 직접 재현하지 못했습니다. `instrumentation.ts`가 서버 기동 시 한 번만 store를 만들어서, 시드를 `isPublic: false`로 바꿔도 HMR로는 재시드되지 않습니다. 대신 두 조각으로 갈음했습니다.

- `mocks/handlers.test.ts`의 "공개 여부를 끄면 게스트 조회는 404지만 주최자는 계속 볼 수 있다" — 비공개 → `REPORT_NOT_FOUND` 보장
- 위 표 2행 — `REPORT_NOT_FOUND` → 빈 상태 확인

"생성 중"도 `mocks/handlers/report.ts`가 `status !== 'GENERATED'`를 같은 코드로 합치므로 같은 경로입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**1. 미분류(UNKNOWN) 집계 — 해소됨**

이전 리비전에서 "게스트 응답에 미분류 건수가 없어 총 소감이 실제보다 적게 나온다"고 적고 백엔드 추가를 기다리기로 했던 항목입니다. 리베이스로 들어온 최신 dev에 `unclassifiedCount`가 이미 포함돼 있어(`lib/schemas/api.ts`의 `publicReportSchema`, `mocks/handlers/report.ts`의 게스트 응답) 이번에 반영했습니다.

- 총 소감 = `POS + NEU + NEG + unclassifiedCount`. 이전에는 세 칸의 합만 써서 목 기준 6건이 5건으로 나왔습니다.
- 헤더 문구를 "참가자 N명"에서 "소감 N개 (미분류 N개)"로 바꿨습니다. `LiveResult`의 같은 줄과 맞춘 형식입니다.
- **긍정 비율의 분모에는 미분류를 넣지 않았습니다.** `UNKNOWN`은 중립이 아니라 분석 실패라, 분모에 넣으면 태깅이 많이 실패할수록 긍정 비율이 저절로 내려갑니다. `components/dashboard/metrics.ts`가 쓰는 규칙과 같고, 그쪽 테스트("긍정 비율의 분모에서 미분류를 뺀다")가 이미 못 박고 있습니다.
- 그 결과 헤더의 총 소감(6)과 도넛의 분모(5)가 다릅니다. 이 차이가 그냥 보이면 오류로 읽히므로 감정 분포 제목에 "· 미분류 제외"를 붙였습니다. 미분류가 0이면 뺄 것이 없어 붙지 않습니다.

**2. `notFound()`가 HTTP 200으로 나갑니다 (Next.js 문서화된 동작)**

404 화면 자체는 정상적으로 뜨지만 상태 코드는 200입니다. Next.js 공식 문서가 명시한 동작입니다.

> Next.js will return a `200` HTTP status code for streamed responses, and `404` for non-streamed responses.
> (`node_modules/next/dist/docs/01-app/03-api-reference/03-file-conventions/not-found.md:13`)

이 페이지는 `dynamic = 'force-dynamic'`이고 스트리밍 응답이라 200 쪽에 해당합니다. 개발 환경만의 현상이 아니라 프로덕션에서도 같습니다.

검색엔진 인덱싱은 프레임워크가 처리합니다. 404 페이지가 스트리밍될 때 Next.js가 `<meta name="robots" content="noindex">`를 HTML에 넣어주고, 크롤러가 soft 404로 분류하더라도 인덱싱으로 이어지지 않습니다(`loading.md:109-111`).

남는 영향은 분석·모니터링 지표입니다. 없는 이벤트 코드로 들어온 접근이 로그에서 404가 아니라 200으로 집계됩니다. 문서가 제시하는 해법은 `proxy`에서 스트리밍 전에 리소스 존재를 확인하는 것인데(`loading.md:113-115`), 페이지 하나 때문에 프록시 레이어를 도입할 일은 아니라고 봅니다. 이벤트 코드가 6자리 랜덤이라 없는 코드로 들어오는 경우 자체가 드뭅니다.

#89 대응으로 범위도 좁아졌습니다. `notFound()`가 불리는 경우는 "이벤트 코드 자체가 없음" 하나뿐이고, 리포트가 없는 페이지는 정상 200으로 빈 상태를 렌더하므로 상태 코드와 내용이 어긋나지 않습니다.

**3. 목 환경에서 `curl`로 볼 수 있는 것과 없는 것**

`MswProvider`가 워커 등록 전까지 자식 렌더를 막고 이 게이트는 서버 렌더에도 걸립니다. 그래서 `curl`로 받은 응답에서 **HTML 본문**을 보면 페이지 내용이 없고 "목 서버를 준비하고 있습니다…"만 나옵니다.

다만 **RSC 페이로드에는 서버가 렌더한 결과가 그대로 실려 옵니다.** 서버 컴포넌트의 데이터 조회는 `instrumentation.ts`가 띄운 Node 쪽 MSW가 가로채므로 정상적으로 채워지고, 클라이언트 게이트는 그걸 화면에 표시할지만 정합니다. 그래서 아래처럼 페이로드를 훑으면 렌더된 문자열은 확인할 수 있습니다.

```
curl -s http://localhost:3000/e/kd7m2p/report | grep -oE "미분류[^<]*|감정 분포[^<]*"
```

레이아웃·시각적 확인은 여전히 브라우저로 해야 합니다. 프로덕션에서는 `isMockingEnabled`가 false라 게이트가 처음부터 열려 있어 해당하지 않습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 준비 중 화면을 실제 공개 리포트 페이지로 대체했습니다.
  * 이벤트 정보, 참가자 수, 긍정 비율, 세션 통계를 제공합니다.
  * AI 요약, 감정 분포 차트, 주요 키워드 목록을 확인할 수 있습니다.
  * 날짜를 서울 시간대 기준으로 표시합니다.

* **개선 사항**
  * 존재하지 않는 이벤트나 리포트는 안내 페이지로 처리합니다.
  * 비공개이거나 생성 중인 리포트에는 현재 상태를 안내합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
