### PR TITLE
feat(feedback): 참가자 소감 입력 화면 구현

### DIFF
--- a/app/e/[code]/not-found.tsx
+++ b/app/e/[code]/not-found.tsx
@@ -1,0 +1,18 @@
+const EventNotFound = () => {
+  return (
+    <main className="flex flex-col gap-6 px-5 py-4">
+      <div className="flex flex-col items-center gap-4 rounded-xl border border-border-subtle px-5 py-10">
+        <div className="flex flex-col items-center gap-1">
+          <p className="text-base font-medium leading-6 text-text-primary">
+            이벤트를 찾을 수 없어요
+          </p>
+          <p className="text-sm dont-normal lading-5 text-text-secondary">
+            링크가 올바른지 다시 확인해 주세요
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default EventNotFound;

--- a/app/e/[code]/not-found.tsx
+++ b/app/e/[code]/not-found.tsx
@@ -6,7 +6,7 @@ const EventNotFound = () => {
           <p className="text-base font-medium leading-6 text-text-primary">
             이벤트를 찾을 수 없어요
           </p>
-          <p className="text-sm dont-normal lading-5 text-text-secondary">
+          <p className="text-sm font-normal leading-5 text-text-secondary">
             링크가 올바른지 다시 확인해 주세요
           </p>
         </div>

--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,31 +1,44 @@
+import { fetchEventByCode, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { Chip } from '@/components/ui/Chip';
 import { Textarea } from '@/components/ui/Textarea';
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
+import { notFound } from 'next/navigation';
+import { ApiError } from '@/lib/apiClient';
 
-const EventEntryPage = () => {
-  // API(openapi v0.3): GET /events/{eventCode}(이벤트 상세), GET /events/{eventCode}/sessions(세션 목록),
-  // POST /events/{eventCode}/feedbacks(소감 제출, X-Client-Id 헤더 포함).
-  // lib/api/endpoints.ts의 fetchSessionsByEventCode·submitFeedback이 이미 구현·테스트돼 있습니다(PR #12).
-  // submitFeedback은 getClientId()로 X-Client-Id 헤더를 이미 붙여서 보냅니다.
-  // 소감 제출에 성공하면 pulse_submitted_{sessionId}(제안값, 팀 확인 필요)를 저장해 /live 접근 제어에 씁니다.
+export const dynamic = 'force-dynamic';
+
+interface EventEntryPageProps {
+  params: Promise<{ code: string }>;
+}
+
+const EventEntryPage = async ({ params }: EventEntryPageProps) => {
+  const { code } = await params;
+
+  // 서버에서 부릅니다. 두 요청이 서로를 안 기다리도록 병렬로 보냅니다.
+  const [event, sessions] = await Promise.all([
+    fetchEventByCode(code),
+    fetchSessionsByEventCode(code),
+  ]).catch((error: unknown) => {
+    if (error instanceof ApiError && error.code === 'EVENT_NOT_FOUND') notFound();
+    throw error;
+  });
+
   return (
     <main className="flex flex-col gap-6 p-5">
       <section className="flex flex-col gap-1">
-        <p className="text-ts font-normal leading-4 text-text-tertiary">이벤트</p>
-        <h1 className="text-xl font-semibold leading-7 text-text-primary">
-          2026 프론트엔드 컨퍼런스
-        </h1>
+        <p className="text-xs font-normal leading-4 text-text-tertiary">이벤트</p>
+        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
         <p className="text-sm font-normal leading-5 text-text-secondary">
-          오늘 들은 세션에 한줄 소감을 남겨주세요
+          {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
         </p>
       </section>
       <section className="flex flex-col gap-1">
         <p className="text-xs font-normal leading-4 text-text-tertiary">세션 선택</p>
         <div className="flex flex-wrap gap-2">
-          <Chip selected>세션 A</Chip>
-          <Chip>세션 B</Chip>
-          <Chip>세션 C</Chip>
+          {sessions.map((session) => (
+            <Chip key={session.id}>{session.title}</Chip>
+          ))}
         </div>
       </section>
       <section className="flex flex-col gap-1">

--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,10 +1,48 @@
+import { Chip } from '@/components/ui/Chip';
+import { Textarea } from '@/components/ui/Textarea';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+
 const EventEntryPage = () => {
   // API(openapi v0.3): GET /events/{eventCode}(이벤트 상세), GET /events/{eventCode}/sessions(세션 목록),
   // POST /events/{eventCode}/feedbacks(소감 제출, X-Client-Id 헤더 포함).
   // lib/api/endpoints.ts의 fetchSessionsByEventCode·submitFeedback이 이미 구현·테스트돼 있습니다(PR #12).
   // submitFeedback은 getClientId()로 X-Client-Id 헤더를 이미 붙여서 보냅니다.
   // 소감 제출에 성공하면 pulse_submitted_{sessionId}(제안값, 팀 확인 필요)를 저장해 /live 접근 제어에 씁니다.
-  return <div>이벤트 진입 · 소감 제출 (준비 중)</div>;
+  return (
+    <main className="flex flex-col gap-6 p-5">
+      <section className="flex flex-col gap-1">
+        <p className="text-ts font-normal leading-4 text-text-tertiary">이벤트</p>
+        <h1 className="text-xl font-semibold leading-7 text-text-primary">
+          2026 프론트엔드 컨퍼런스
+        </h1>
+        <p className="text-sm font-normal leading-5 text-text-secondary">
+          오늘 들은 세션에 한줄 소감을 남겨주세요
+        </p>
+      </section>
+      <section className="flex flex-col gap-1">
+        <p className="text-xs font-normal leading-4 text-text-tertiary">세션 선택</p>
+        <div className="flex flex-wrap gap-2">
+          <Chip selected>세션 A</Chip>
+          <Chip>세션 B</Chip>
+          <Chip>세션 C</Chip>
+        </div>
+      </section>
+      <section className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-normal leading-4 text-text-tertiary">한줄 소감</p>
+          <p className="text-xs font-normal leading-4 text-text-tertiary">0/200</p>
+        </div>
+        <Textarea placeholder="이번 세션은 어떠셨나요?" maxLength={200} />
+      </section>
+      <Banner type="info" className="w-full">
+        제출하면 브라우저에서 감정을 자동 분석해요
+      </Banner>
+      <Button size="lg" className="w-full">
+        소감 남기기
+      </Button>
+    </main>
+  );
 };
 
 export default EventEntryPage;

--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,10 +1,7 @@
 import { fetchEventByCode, fetchSessionsByEventCode } from '@/lib/api/endpoints';
-import { Chip } from '@/components/ui/Chip';
-import { Textarea } from '@/components/ui/Textarea';
-import { Banner } from '@/components/ui/Banner';
-import { Button } from '@/components/ui/Button';
 import { notFound } from 'next/navigation';
 import { ApiError } from '@/lib/apiClient';
+import { FeedbackForm } from '@/components/feedback/FeedbackForm';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,27 +30,7 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
           {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
         </p>
       </section>
-      <section className="flex flex-col gap-1">
-        <p className="text-xs font-normal leading-4 text-text-tertiary">세션 선택</p>
-        <div className="flex flex-wrap gap-2">
-          {sessions.map((session) => (
-            <Chip key={session.id}>{session.title}</Chip>
-          ))}
-        </div>
-      </section>
-      <section className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <p className="text-xs font-normal leading-4 text-text-tertiary">한줄 소감</p>
-          <p className="text-xs font-normal leading-4 text-text-tertiary">0/200</p>
-        </div>
-        <Textarea placeholder="이번 세션은 어떠셨나요?" maxLength={200} />
-      </section>
-      <Banner type="info" className="w-full">
-        제출하면 브라우저에서 감정을 자동 분석해요
-      </Banner>
-      <Button size="lg" className="w-full">
-        소감 남기기
-      </Button>
+      <FeedbackForm eventCode={code} sessions={sessions} />
     </main>
   );
 };

--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { Chip } from '@/components/ui/Chip';
+import { Textarea } from '@/components/ui/Textarea';
+import type { SessionView } from '@/lib/schemas/api';
+
+interface FeedbackFormProps {
+  eventCode: string;
+  sessions: SessionView[];
+}
+
+const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [text, setText] = useState('');
+
+  return (
+    <>
+      <section className="flex flex-col gap-1">
+        <p className="text-xs font-normal leading-4 text-text-tertiary">세션 선택</p>
+        <div className="flex flex-wrap gap-2">
+          {sessions.map((session) => (
+            <Chip
+              key={session.id}
+              selected={session.id === selectedId}
+              onClick={() => setSelectedId(session.id)}
+            >
+              {session.title}
+            </Chip>
+          ))}
+        </div>
+      </section>
+
+      <section className="flex flex-col gap-1">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-normal leading-4 text-text-tertiary">한줄 소감</p>
+          <p className="text-xs font-normal leading-4 text-text-tertiary">{text.length}/200</p>
+        </div>
+        <Textarea
+          placeholder="이번 세션은 어떠셨나요?"
+          maxLength={200}
+          value={text}
+          onChange={(event) => setText(event.target.value)}
+        />
+      </section>
+
+      <Banner type="info" className="w-full">
+        제출하면 브라우저에서 감정을 자동 분석해요
+      </Banner>
+
+      <Button size="lg" className="w-full" disabled={selectedId === null || text.trim() === ''}>
+        소감 남기기
+      </Button>
+    </>
+  );
+};
+
+export { FeedbackForm };

--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -38,19 +38,22 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
   const router = useRouter();
 
   const { mutate, isPending, error } = useMutation({
-    mutationFn: () =>
+    mutationFn: (sessionId: number) =>
       submitFeedback(eventCode, {
-        sessionId: selectedId!,
+        sessionId,
         text: text.trim(),
         sentiment: 'UNKNOWN',
         toxic: false,
         keywords: [],
         taggerVersion: 'none',
       }),
-    onSuccess: () => {
-      router.push(`/e/${eventCode}/live?sessionId=${selectedId}`);
+    // 보낸 값을 그대로 돌려받습니다. 여기서 selectedId를 다시 읽으면
+    // 응답을 기다리는 사이 선택이 바뀌었을 때 저장된 세션과 이동할 세션이 어긋납니다.
+    onSuccess: (_data, sessionId) => {
+      router.push(`/e/${eventCode}/live?sessionId=${sessionId}`);
     },
   });
+
   return (
     <>
       <section className="flex flex-col gap-1">
@@ -60,6 +63,7 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
             <Chip
               key={session.id}
               selected={session.id === selectedId}
+              disabled={isPending}
               onClick={() => setSelectedId(session.id)}
             >
               {session.title}
@@ -95,7 +99,7 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
         size="lg"
         className="w-full"
         disabled={selectedId === null || text.trim() === '' || isPending}
-        onClick={() => mutate()}
+        onClick={() => mutate(selectedId!)}
       >
         {isPending ? '보내는 중...' : '소감 남기기'}
       </Button>

--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -1,13 +1,31 @@
 'use client';
 
 import { useState } from 'react';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
 
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
 import { Chip } from '@/components/ui/Chip';
 import { Textarea } from '@/components/ui/Textarea';
-import type { SessionView } from '@/lib/schemas/api';
 
+import type { SessionView } from '@/lib/schemas/api';
+import { submitFeedback } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+
+/**
+ * 제출 실패 사유별 문구입니다.
+ *
+ * 컴포넌트 밖에 두는 이유는 렌더할 때마다 객체를 새로 만들 필요가 없어서입니다.
+ * 표로 두면 사유가 늘 때 한 곳만 고치면 됩니다.
+ */
+const ERROR_MESSAGE: Record<string, string> = {
+  RATE_LIMIT_EXCEEDED: '너무 자주 보내셨어요. 잠시 후 다시 시도해주세요',
+  EVENT_NOT_LIVE: '지금은 소감을 받지 않는 이벤트예요',
+  SESSION_NOT_FOUND: '세션을 찾을 수 없어요. 새로고침 후 다시 시도해주세요',
+};
+
+const FALLBACK_MESSAGE = '소감을 보내지 못했어요. 잠시 후 다시 시도해주세요';
 interface FeedbackFormProps {
   eventCode: string;
   sessions: SessionView[];
@@ -17,6 +35,22 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [text, setText] = useState('');
 
+  const router = useRouter();
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: () =>
+      submitFeedback(eventCode, {
+        sessionId: selectedId!,
+        text: text.trim(),
+        sentiment: 'UNKNOWN',
+        toxic: false,
+        keywords: [],
+        taggerVersion: 'none',
+      }),
+    onSuccess: () => {
+      router.push(`/e/${eventCode}/live?sessionId=${selectedId}`);
+    },
+  });
   return (
     <>
       <section className="flex flex-col gap-1">
@@ -46,13 +80,24 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
           onChange={(event) => setText(event.target.value)}
         />
       </section>
-
+      {error ? (
+        <Banner type="negative" className="w-full">
+          {error instanceof ApiError
+            ? (ERROR_MESSAGE[error.code] ?? FALLBACK_MESSAGE)
+            : FALLBACK_MESSAGE}
+        </Banner>
+      ) : null}
       <Banner type="info" className="w-full">
         제출하면 브라우저에서 감정을 자동 분석해요
       </Banner>
 
-      <Button size="lg" className="w-full" disabled={selectedId === null || text.trim() === ''}>
-        소감 남기기
+      <Button
+        size="lg"
+        className="w-full"
+        disabled={selectedId === null || text.trim() === '' || isPending}
+        onClick={() => mutate()}
+      >
+        {isPending ? '보내는 중...' : '소감 남기기'}
       </Button>
     </>
   );


### PR DESCRIPTION
## 변경 사항

참가자가 QR로 들어와 세션을 고르고 한 줄 소감을 남기는 화면입니다.

- `app/e/[code]/page.tsx` — 이벤트·세션 조회, 이벤트 정보 표시
- `app/e/[code]/not-found.tsx` — 신규, 없는 이벤트 안내
- `components/feedback/FeedbackForm.tsx` — 신규, 세션 선택·소감 입력·제출

## 개발 과정 로그

| 커밋 | 내용 |
| --- | --- |
| 1 | 정적 마크업 — 시안과 간격·색 대조 |
| 2 | 이벤트·세션 데이터 연결과 404 화면 |
| 3 | 세션 선택과 글자수 상태 |
| 4 | 제출과 실패 안내 |

단계마다 브라우저에서 확인하며 진행했습니다. 한 번에 만들면 안 될 때 원인이 시안인지 API인지 상태인지 구분되지 않습니다.

## 서버와 클라이언트를 나눴습니다

```text
page.tsx           서버 — 데이터 조회, 이벤트 정보
FeedbackForm.tsx   클라 — 선택·입력·제출
```

참가자 화면은 SSR이 원칙입니다(CLAUDE.md). 페이지 전체에 `'use client'`를 붙이면 서버에서 데이터를 못 가져옵니다. 상호작용이 필요한 부분만 떼어냈습니다.

`/live`(#30)도 같은 구조입니다.

## 없는 이벤트

`EVENT_NOT_FOUND`만 `notFound()`로 보냅니다.

```tsx
.catch((error: unknown) => {
  if (error instanceof ApiError && error.code === 'EVENT_NOT_FOUND') notFound();
  throw error;
});
```

**다른 에러까지 404로 만들면 안 됩니다.** "이벤트가 없다"와 "서버가 죽었다"는 완전히 다른 상황인데, 사용자가 코드를 다시 찍어봐도 소용없으면서 그런 줄 알게 됩니다.

`not-found.tsx`를 `app/e/[code]/`에 둔 이유는 참가자와 호스트에게 할 말이 다르기 때문입니다. 참가자에게는 "링크를 확인해주세요"가 맞고 호스트에게는 "목록으로 돌아가기"가 맞습니다.

## 감정 태깅은 이 PR에 없습니다

`submitFeedback`이 요구하는 값을 태깅 실패로 보냅니다.

```ts
sentiment: 'UNKNOWN',
toxic: false,
keywords: [],
taggerVersion: 'none',
```

Transformers.js 태거가 아직 없습니다. 스키마 주석이 `UNKNOWN`을 "태깅 실패, 감정 분포 집계에서 제외"로 정의하고 있고, 대시보드에 `미분류 N건` Stat과 `미분류` Badge가 이미 있어 **받을 준비가 되어 있습니다.**

태거가 붙으면 이 화면은 값 네 개만 바꾸면 됩니다. 별도 이슈로 뺐습니다.

## 실패 안내

사유별 문구를 표로 두고, 표에 없으면 기본 문구로 넘어갑니다.

| 코드 | 문구 |
| --- | --- |
| `RATE_LIMIT_EXCEEDED` | 너무 자주 보내셨어요. 잠시 후 다시 시도해주세요 |
| `EVENT_NOT_LIVE` | 지금은 소감을 받지 않는 이벤트예요 |
| `SESSION_NOT_FOUND` | 세션을 찾을 수 없어요. 새로고침 후 다시 시도해주세요 |
| 그 외 | 소감을 보내지 못했어요. 잠시 후 다시 시도해주세요 |

`instanceof ApiError` 검사가 있는 이유는 네트워크가 끊기면 `TypeError`가 와서 `.code`가 없기 때문입니다.

**Toast가 아니라 Banner입니다**(#21 결정). Toast는 4초 뒤 사라져서 다른 곳을 보던 사용자가 놓칩니다.

## 시안과 다르게 한 것

`세션 선택` 라벨의 `*`를 뺐습니다. 별표만으로는 필수라는 게 전달되지 않고, 세션을 안 고르면 제출 버튼이 `disabled`라 어차피 넘어갈 수 없습니다.

## 관련 이슈

Closes #72

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.7s
✓ Finished TypeScript in 4.7s
✓ Collecting page data using 11 workers in 1165ms
✓ Generating static pages using 11 workers (9/9) in 325ms
✓ Finalizing page optimization in 30ms
```

브라우저에서 393px로 확인했습니다.

```text
/e/ab3f9x   정상 화면, 목 데이터로 이벤트 제목·세션 목록 표시
/e/zzzzzz   404 화면
/e/kd7m2p   ENDED 이벤트 — 제출 시 "지금은 소감을 받지 않는 이벤트예요"
```

Textarea 높이가 시안과 같은 96(`12 + 70 + 12 + 테두리 2`)인 것도 개발자 도구로 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- `app/e/[code]/layout.tsx`는 건드리지 않았습니다. 헤더는 #30에서 다룹니다

## 범위 밖

- **감정 태깅** — 별도 이슈
- **제출 후 재접근 안내** — 명세상 서버가 중복을 막지 않고 프론트가 로컬 저장으로 안내만 합니다. 저장 키 포맷이 팀 미확정이라 뺐습니다
- **`DRAFT`·`ENDED` 상태 분기** — 별도 이슈. 지금은 어느 상태든 폼이 뜹니다
- **세션 `CLOSED`** — #69 머지 후 별도 작업

## 확인 필요

공개 제출 엔드포인트에 CSRF 토큰이 필요한가요? #69에서 `XSRF-TOKEN` 쿠키 + `X-XSRF-TOKEN` 헤더가 도입되는데, `submitFeedback`은 `skipAuth`인 공개 엔드포인트입니다. 백엔드가 모든 POST에 CSRF를 걸면 참가자 제출이 막힙니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이라 개발 과정 로그에 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 페이지에서 이벤트 제목과 설명을 확인하고 세션을 선택할 수 있습니다.
  * 최대 200자의 소감을 작성하고 글자 수를 확인한 후 제출할 수 있습니다.
  * 제출 중에는 버튼이 비활성화되며, 완료 후 이벤트 라이브 페이지로 이동합니다.
  * 이벤트를 찾을 수 없을 때 안내 화면을 제공합니다.
  * 피드백 자동 감정 분석 안내와 상황별 오류 메시지를 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->