### PR TITLE
feat(auth): 로그인 페이지 UI 구현

### DIFF
--- a/app/(host)/login/page.tsx
+++ b/app/(host)/login/page.tsx
@@ -1,8 +1,62 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Logo } from '@/components/brand/Logo';
+import { Field } from '@/components/ui/Field';
+import { Button } from '@/components/ui/Button';
+import { useState, type SubmitEvent } from 'react';
+
 const LoginPage = () => {
   // API: POST /auth/login. useAuth() 훅과 라우트 가드는 실제 구현 시 연결합니다.
-  // 로그인 실패(이메일/비밀번호 불일치)는 별도 라우트가 아니라 이 페이지 내부의
-  // 필드 에러 상태로 표시합니다.
-  return <div>로그인 화면 (준비 중)</div>;
+  // 로그인 실패는 별도 라우트가 아니라 이 페이지 내부에서 처리합니다.
+  // 401 응답(INVALID_CREDENTIALS)은 존재하지 않는 사용자와 비밀번호 불일치를 병합해서 내려주므로(API 명세서 확정),
+  // 어느 필드가 틀렸는지는 표시하지 않습니다. 이메일·비밀번호 입력 필드 모두 invalid 스타일로 표시하고, 공통 에러 문구 하나만 보여줍니다.
+  const [loginFailed, setLoginFailed] = useState(false);
+
+  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    // TODO: useAuth 연동 후 실제 로그인 요청으로 교체해야 합니다. 지금은 항상 실패 상태를 보여줍니다.
+    setLoginFailed(true);
+  };
+
+  return (
+    <div className="min-h-dvh flex justify-center items-center p-14 bg-background-default">
+      <div className="w-100 p-8 flex flex-col items-center gap-4 border border-border-default rounded-xl bg-background-default">
+        <Logo size="lg" />
+        <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit}>
+          <Field
+            className="w-full"
+            label="이메일"
+            type="email"
+            placeholder="host@example.com"
+            invalid={loginFailed}
+          />
+          <Field
+            className="w-full"
+            label="비밀번호"
+            type="password"
+            placeholder="••••••••"
+            invalid={loginFailed}
+          />
+          {loginFailed ? (
+            <p className="text-xs text-negative-darker">
+              이메일 또는 비밀번호가 올바르지 않습니다.
+            </p>
+          ) : null}
+          <Button type="submit" variant="primary" className="w-full">
+            로그인
+          </Button>
+        </form>
+        <p className="text-xs text-text-secondary">
+          계정이 없으신가요?{' '}
+          <Link href="/signup" className="font-medium text-primary-darker">
+            회원가입
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/app/(host)/login/page.tsx
+++ b/app/(host)/login/page.tsx
@@ -39,11 +39,13 @@ const LoginPage = () => {
             placeholder="••••••••"
             invalid={loginFailed}
           />
-          {loginFailed ? (
-            <p className="text-xs text-negative-darker">
-              이메일 또는 비밀번호가 올바르지 않습니다.
-            </p>
-          ) : null}
+          <p
+            role="alert"
+            aria-atomic="true"
+            className={loginFailed ? 'text-xs text-negative-darker' : 'sr-only'}
+          >
+            {loginFailed ? '이메일 또는 비밀번호가 올바르지 않습니다.' : null}
+          </p>
           <Button type="submit" variant="primary" className="w-full">
             로그인
           </Button>

--- a/components/ui/Field.tsx
+++ b/components/ui/Field.tsx
@@ -4,12 +4,12 @@ import { useId } from 'react';
 
 import { Input, type InputProps } from '@/components/ui/Input';
 
-interface FieldProps extends Omit<InputProps, 'id' | 'invalid' | 'aria-describedby'> {
+interface FieldProps extends Omit<InputProps, 'id' | 'aria-describedby'> {
   label: string;
   error?: string;
 }
 
-const Field = ({ label, error, className = '', ...props }: FieldProps) => {
+const Field = ({ label, error, invalid = false, className = '', ...props }: FieldProps) => {
   const id = useId();
   const errorId = `${id}-error`;
 
@@ -21,7 +21,7 @@ const Field = ({ label, error, className = '', ...props }: FieldProps) => {
       <Input
         {...props}
         id={id}
-        invalid={Boolean(error)}
+        invalid={invalid || Boolean(error)}
         aria-describedby={error ? errorId : undefined}
       />
       {error ? (


### PR DESCRIPTION
## 변경 사항

- 로그인 페이지(`app/(host)/login/page.tsx`)를 Figma 시안 기준으로 구현했습니다(성공·실패 시나리오 모두 포함).
- `Field.tsx`에 `invalid` prop을 직접 지정할 수 있게 API를 확장했습니다(로그인 실패 화면에서 문구 없이 테두리만 강조해야 하는 요구사항 때문입니다).

## 개발 과정 로그

커밋이 1개뿐이라 표는 생략합니다.

## 관련 이슈

- Closes #85

## 검증 방법

- `npm run lint` 통과 확인(0 problems).
- 브라우저에서 `/login`을 직접 열어 시안과 카드 레이아웃(로고·이메일/비밀번호 입력·버튼·회원가입 링크)을 대조했습니다.
- 아무 값도 입력하지 않고 로그인 버튼을 눌러, 이메일·비밀번호 입력창 테두리가 모두 빨갛게 바뀌고 공통 에러 문구("이메일 또는 비밀번호가 올바르지 않습니다.")가 한 번만 뜨는 것을 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음(`Field`의 `invalid` prop 추가는 하위 호환이며, `Field`는 현재 이 로그인 페이지에서만 쓰입니다)

## 트러블슈팅 및 참고 사항

- Figma에 `로그인 - 실패`라는 이름의 노드가 두 개 있었습니다. Claude Code가 Figma MCP로 조회하는 과정에서 하나(Description 주석만 있는 노드)만 먼저 확인하고, 실제 mockup(실패 문구가 적힌 노드)을 놓쳤다가 나중에 다시 확인해서 해결했습니다.
- `handleSubmit`은 아직 `useAuth` 연동 전이라, 제출하면 서버 요청 없이 항상 실패 상태를 보여주는 임시 코드입니다(`TODO` 주석 참고). 이슈 #68/PR #79 머지 후 실제 로그인 요청으로 교체해야 합니다.
- 로그인 실패 에러 문구는 시안에는 "이메일 또는 비밀번호가 올바르지 않아요"(해요체)로 적혀 있었지만, 이미 코드(MSW 기본 메시지)에 있던 "올바르지 않습니다"(하십시오체) 쪽으로 쓰기로 결정했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 로그인 준비 화면이 이메일과 비밀번호를 입력할 수 있는 로그인 폼으로 변경되었습니다.
  - 로그인 제출 버튼과 회원가입 링크가 추가되었습니다.

- **버그 수정**
  - 로그인 실패 시 이메일과 비밀번호 입력 필드가 오류 상태로 표시됩니다.
  - 공통 오류 메시지가 제공되어 로그인 실패 상황을 쉽게 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->