### PR TITLE
feat(auth): 회원가입 페이지 UI 구현

### DIFF
--- a/app/(host)/signup/page.tsx
+++ b/app/(host)/signup/page.tsx
@@ -1,8 +1,109 @@
+'use client';
+
+import Link from 'next/link';
+
+import { Logo } from '@/components/brand/Logo';
+import { Field } from '@/components/ui/Field';
+import { Button } from '@/components/ui/Button';
+import { ChangeEvent, type SubmitEvent, useState } from 'react';
+import { passwordSchema, signupRequestSchema } from '@/lib/schemas/api';
+
+type SignupInputs = {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+type SignupErrors = {
+  email?: string;
+  password?: string;
+  passwordConfirm?: string;
+};
+
+const initialSignupInputs: SignupInputs = {
+  email: '',
+  password: '',
+  passwordConfirm: '',
+};
+
 const SignupPage = () => {
-  // API: POST /auth/signup.
-  // 이메일 형식 오류·비밀번호 불일치는 별도 라우트가 아니라 이 페이지 내부의
-  // 필드 에러 상태로 표시합니다.
-  return <div>회원가입 화면 (준비 중)</div>;
+  // API: POST /auth/signup
+  // useAuth()의 signup 함수는 아직 없기 때문에(PR #79 미머지)
+  // 클라이언트 사전 검증까지만 하고 실제 서버 제출은 하지 않습니다.
+  const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
+  const [signupErrors, setSignupErrors] = useState<SignupErrors>({});
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSignupInputs((prev) => ({
+      ...prev,
+      [event.target.name]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
+    const passwordValidation = passwordSchema.safeParse(signupInputs.password);
+    const passwordConfirmError =
+      signupInputs.password !== signupInputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
+
+    setSignupErrors((prev) => ({
+      ...prev,
+      email: emailValidation.error?.issues[0].message,
+      password: passwordValidation.error?.issues[0].message,
+      passwordConfirm: passwordConfirmError,
+    }));
+  };
+
+  return (
+    <div className="min-h-dvh flex justify-center items-center p-14 bg-background-default">
+      <div className="w-100 p-8 flex flex-col items-center gap-4 border border-border-default rounded-xl bg-background-default">
+        <Logo size="lg" />
+        <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit} noValidate={true}>
+          <Field
+            onChange={handleChange}
+            className="w-full"
+            label="이메일"
+            name="email"
+            type="email"
+            placeholder="host@example.com"
+            value={signupInputs.email}
+            error={signupErrors.email}
+          />
+          <Field
+            onChange={handleChange}
+            className="w-full"
+            label="비밀번호"
+            name="password"
+            type="password"
+            placeholder="••••••••"
+            value={signupInputs.password}
+            error={signupErrors.password}
+          />
+          <Field
+            onChange={handleChange}
+            className="w-full"
+            label="비밀번호 확인"
+            name="passwordConfirm"
+            type="password"
+            placeholder="••••••••"
+            value={signupInputs.passwordConfirm}
+            error={signupErrors.passwordConfirm}
+          />
+          <Button type="submit" variant="primary" className="w-full">
+            회원가입
+          </Button>
+        </form>
+        <p className="text-xs text-text-secondary">
+          이미 계정이 있으신가요?{' '}
+          <Link href="/login" className="font-medium text-primary-darker">
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default SignupPage;

--- a/components/ui/Field.tsx
+++ b/components/ui/Field.tsx
@@ -22,13 +22,16 @@ const Field = ({ label, error, invalid = false, className = '', ...props }: Fiel
         {...props}
         id={id}
         invalid={invalid || Boolean(error)}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={errorId}
       />
-      {error ? (
-        <p id={errorId} className="text-xs font-normal leading-4 text-negative-darker">
-          {error}
-        </p>
-      ) : null}
+      <p
+        id={errorId}
+        className={error ? 'text-xs font-normal leading-4 text-negative-darker' : 'sr-only'}
+        role="alert"
+        aria-atomic="true"
+      >
+        {error}
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## 변경 사항

Figma 시안(node-id=3143-3757, 3200-3766, 3200-3819)을 기준으로 회원가입 페이지(`app/(host)/signup/page.tsx`)의 UI를 구현했습니다.

- 카드 레이아웃을 이미 구현되어 있는 공통 컴포넌트만 재사용해서 만들었습니다.
  - 카드 레이아웃: 로고, 이메일/비밀번호/비밀번호 확인 입력, 회원가입 버튼, 로그인 링크
  - 사용한 공통 컴포넌트: `Logo`, `Field`, `Button`
- 클라이언트 사전 검증(`signupRequestSchema`·`passwordSchema`)으로 이메일 형식·비밀번호 정책·비밀번호 확인 일치를 필드별로 검사합니다.
- `Field`(`components/ui/Field.tsx`)에 ARIA live region 패턴을 적용했습니다.

세부 설계 결정은 이슈 #87 본문에 정리해뒀습니다.

- 에러 표시 방식이 로그인 화면과 다른 이유
- 문구를 하십시오체로 통일한 이유
- 서버 응답이 아니라 클라이언트 검증으로 처리하기로 한 이유

## 개발 과정 로그

커밋이 1개라 생략합니다.

## 관련 이슈

- Closes #87

## 검증 방법

### 정상 시나리오

이메일 형식이 올바르고 비밀번호가 정책을 만족하며 비밀번호 확인이 일치하는 상태로 회원가입 버튼을 누르면, 클라이언트 사전 검증을 전부 통과합니다.  
이번 PR 범위에서는 `useAuth.signup`이 아직 없어서 실제 계정 생성이나 화면 이동 없이 여기서 끝납니다(범위는 이슈 #87 참고).

### 실패 시나리오 (브라우저에서 직접 입력해 확인)

- **이메일 형식이 올바르지 않은 채로 제출하면**
  이메일 필드만 invalid 스타일로 표시되고, 그 아래 "이메일 형식이 올바르지 않습니다."가 표시됩니다.
- **비밀번호가 정책(8자 이상 32자 이하, 영문과 숫자 각 1자 이상)을 위반한 채로 제출하면**
  비밀번호 필드만 invalid 스타일로 표시되고, 위반한 조건에 해당하는 문구가 표시됩니다.
- **비밀번호 확인이 비밀번호와 다른 채로 제출하면**
  비밀번호 확인 필드만 invalid 스타일로 표시되고, 그 아래 "비밀번호가 일치하지 않습니다."가 표시됩니다.

### 명령 실행 결과

- `npm run lint` — 통과 (에러·경고 0건)
- `npx tsc --noEmit -p .` — 통과 (에러 0건)

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음. `Field`의 `error` prop 사용처는 저장소 전체에서 회원가입 페이지 하나뿐이라(`grep` 확인), 이번 ARIA 패턴 변경이 다른 화면에 영향을 주지 않습니다.

## 트러블슈팅 및 참고 사항

- **`<Field type="email">`의 브라우저 기본 유효성 검사가 커스텀 검증을 가로막는 문제가 있었습니다.** 이메일 형식이 잘못된 값을 넣고 제출하면 `handleSubmit`이 호출되기도 전에 브라우저가 자체 팝업을 띄우고 `submit` 이벤트 자체를 막았습니다.  
  `<form>`에 `noValidate`를 추가해서 브라우저 자체 검사를 끄고, 우리가 만든 zod 기반 검증으로 완전히 대체해 해결했습니다.
- **서버 응답만으로는 어느 필드가 틀렸는지 구분할 수 없다는 근거를 API 명세서 원문에서 직접 확인했습니다.** 처음에는 MSW 핸들러 주석만 근거로 삼았는데, API 명세서(공통 규칙·에러 코드 표)에 `VALIDATION_ERROR`(400)의 사용처가 "모든 `@Valid` 실패"로 명시되어 있고 `POST /auth/signup` 절도 이메일 형식 오류와 비밀번호 정책 위반을 400 하나로 묶어놨다는 걸 확인해서, 클라이언트 사전 검증 방식을 최종 확정했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 해당 없음)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새 기능**
  - 회원가입 준비 화면을 이메일, 비밀번호, 비밀번호 확인 입력 폼으로 개선했습니다.
  - 입력값 검증 및 필드별 오류 메시지를 제공합니다.
  - 로그인 링크와 회원가입 버튼을 추가했습니다.

- **접근성 개선**
  - 오류 메시지가 보조 기술에 일관되게 전달되도록 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

