### PR TITLE
feat(feedback): 세션 CLOSED 상태를 소감 입력 화면에 반영

### DIFF
--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -76,6 +76,11 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
             </Chip>
           ))}
         </div>
+        {sessions.some((session) => session.status === 'CLOSED') ? (
+          <p className="text-xs font-normal leading-4 text-text-tertiary">
+            아직 열리지 않은 세션은 선택할 수 없어요
+          </p>
+        ) : null}
       </section>
 
       <section className="flex flex-col gap-1">

--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -23,6 +23,7 @@ const ERROR_MESSAGE: Record<string, string> = {
   RATE_LIMIT_EXCEEDED: '너무 자주 보내셨어요. 잠시 후 다시 시도해주세요',
   EVENT_NOT_LIVE: '지금은 소감을 받지 않는 이벤트예요',
   SESSION_NOT_FOUND: '세션을 찾을 수 없어요. 새로고침 후 다시 시도해주세요',
+  SESSION_CLOSED: '이 세션은 소감을 받지 않아요',
 };
 
 const FALLBACK_MESSAGE = '소감을 보내지 못했어요. 잠시 후 다시 시도해주세요';
@@ -32,7 +33,12 @@ interface FeedbackFormProps {
 }
 
 const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
-  const [selectedId, setSelectedId] = useState<number | null>(null);
+  // CLOSED 세션은 목록에 남지만 고를 수 없습니다.
+  const openSessions = sessions.filter((session) => session.status === 'ACTIVE');
+
+  const [selectedId, setSelectedId] = useState<number | null>(
+    openSessions.length === 1 ? openSessions[0].id : null,
+  );
   const [text, setText] = useState('');
 
   const router = useRouter();
@@ -63,7 +69,7 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
             <Chip
               key={session.id}
               selected={session.id === selectedId}
-              disabled={isPending}
+              disabled={session.status === 'CLOSED' || isPending}
               onClick={() => setSelectedId(session.id)}
             >
               {session.title}

--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -78,7 +78,7 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
         </div>
         {sessions.some((session) => session.status === 'CLOSED') ? (
           <p className="text-xs font-normal leading-4 text-text-tertiary">
-            아직 열리지 않은 세션은 선택할 수 없어요
+            지금 소감을 받는 세션만 선택할 수 있어요
           </p>
         ) : null}
       </section>


### PR DESCRIPTION
## 변경 사항

세션 `CLOSED` 상태를 참가자 소감 입력 화면에 반영했습니다.

- `components/feedback/FeedbackForm.tsx` — 닫힌 세션 선택 차단, 안내 문구, `SESSION_CLOSED` 실패 사유

## 개발 과정 로그

| 커밋 | 내용 |
| --- | --- |
| 1 | `CLOSED` 세션 선택 차단과 실패 사유 추가 |
| 2 | 왜 선택되지 않는지 안내 문구 추가 |

## 닫힌 세션을 목록에서 지우지 않았습니다

`CLOSED` 세션도 칩으로 남기고 `disabled`만 걸었습니다.

지우는 게 깔끔해 보이지만, 참가자가 QR을 찍었는데 **자기가 들을 세션이 목록에 없으면 잘못 들어온 줄 압니다.** 회색으로라도 있으면 목록이 온전해집니다.

그리고 이 자리는 곧 **결과 보기 입구**가 됩니다. 아래 "지금은 제출 여부를 모릅니다"를 봐주세요.

## 안내 문구를 칩 밖에 뒀습니다

```tsx
{sessions.some((session) => session.status === 'CLOSED') ? (
  <p className="text-xs font-normal leading-4 text-text-tertiary">
    지금 소감을 받는 세션만 선택할 수 있어요
  </p>
) : null}
```

**왜 회색인지 대신 무엇을 할 수 있는지를 적었습니다.**

처음엔 "아직 열리지 않은 세션은 선택할 수 없어요"였는데, `CLOSED`는 **아직 안 연 세션과 받다가 멈춘 세션 둘 다**를 뜻합니다. 세션을 열고 닫는 토글이 생기면서 양방향이 됐거든요. 멈춘 세션에는 거짓말이 됩니다.

이유를 설명하려면 두 경우를 다 커버하는 문장을 찾아야 하는데, 그러면 문장이 길고 딱딱해집니다. 대신 긍정형으로 **선택 가능한 게 뭔지**만 말하면 `CLOSED`가 무슨 뜻인지 따질 필요가 없습니다. 나중에 제출 여부 분기가 들어와도 이 문장은 그대로 씁니다.

칩 안에 `(준비 중)` 같은 걸 넣을 수도 있었는데 대비 때문에 못 했습니다.

```text
Text/disabled  on  Background/muted  =  1.85:1
```

회색 칩 안의 글자는 **세션 이름조차 겨우 읽히는 수준**이라 거기에 설명을 더 넣으면 아무도 못 읽습니다. WCAG 1.4.3은 비활성 컨트롤을 예외로 두기 때문에 위반은 아니지만, *읽혀야 하는 정보*를 그 안에 넣는 순간 문제가 됩니다.

`disabled` 버튼은 **탭 순회에서도 빠집니다.** 키보드로 넘기는 사람은 회색 칩에 아예 닿지 못해서, 이유가 칩 밖에 있어야 전달됩니다.

문구는 `CLOSED`가 하나라도 있을 때만 뜹니다. 다 열려 있으면 불필요한 줄이 남지 않습니다.

## 색은 `Text/tertiary`입니다

이 화면의 보조 텍스트(`세션 선택`, `한줄 소감`, `0/200`)가 전부 `Text/tertiary`라 맞췄습니다. 여기만 진하면 그 줄이 튑니다.

다만 `Text/tertiary`는 흰 배경에서 **3.61:1**로 12px 기준 AA에 미달합니다. 이 줄만의 문제가 아니라 화면 곳곳에서 쓰이고 있어서, **토큰 값을 고치는 별도 이슈로 올리겠습니다.** 여기서 한 줄만 진하게 바꾸면 문제를 옮기는 것이지 푸는 게 아닙니다.

## 자동 선택은 열린 세션만 셉니다

```tsx
const openSessions = sessions.filter((session) => session.status === 'ACTIVE');

const [selectedId, setSelectedId] = useState<number | null>(
  openSessions.length === 1 ? openSessions[0].id : null,
);
```

`sessions.length === 1`로 하면 **닫힌 세션이 자동 선택돼서** 참가자가 소감을 다 쓴 뒤에야 409를 받습니다. #78 리뷰에서 "열린 세션이 하나면 자동 선택하라"는 요청이 있었는데, 그때는 `status`가 응답에 없어 미뤘던 부분입니다.

## 지금은 제출 여부를 모릅니다

이 PR은 **세션 상태만** 보고 칩을 가릅니다. 원래 필요한 분기는 이겁니다.

| | 안 남김 | 남김 |
| --- | --- | --- |
| `ACTIVE` | 선택 → 소감 작성 | → 실시간 결과 |
| `CLOSED` | 선택 불가 | → 실시간 결과 |

**"내가 이 세션에 소감을 냈나"가 진짜 축입니다.** 세션이 열려도 이전 세션이 자동으로 닫히지 않기로 했기 때문에, 지난 세션 대부분은 `ACTIVE`로 남습니다. 그 세션에 이미 소감을 낸 사람은 작성창이 아니라 결과를 봐야 합니다.

그 값이 `localStorage`에 있어야 하는데 **저장 키 포맷이 아직 미확정**입니다(별도 `question` 이슈). `/live` 스텁에도 `팀 확인 필요`로 남아 있습니다.

```tsx
// app/e/[code]/live/page.tsx
// pulse_submitted_{sessionId}(제안값, 팀 확인 필요) 존재 여부로 판단합니다.
```

그래서 이번에는 **`CLOSED` + 안 남김**에 해당하는 칸만 처리했습니다. 나머지 두 칸은 키가 정해진 뒤 별도 이슈로 잇겠습니다.

## 실패 사유를 하나 늘렸습니다

```ts
SESSION_CLOSED: '이 세션은 소감을 받지 않아요',
```

화면에서 막아도 **두 탭을 열어두고 그 사이에 호스트가 세션을 닫는 경우**가 있습니다. 서버가 409를 내면 이 문구가 뜹니다.

## 리베이스 기록

#78이 스쿼시로 머지되면서 dev에 새 SHA가 생겨, 이 브랜치가 들고 있던 #78 커밋들을 다시 얹으려다 충돌했습니다.

```bash
git rebase --onto origin/dev feature/72-feedback-form feature/80-session-closed
```

`--onto`로 이 브랜치 고유 커밋만 옮겼습니다. 충돌은 칩 한 줄에서만 났고 이렇게 합쳤습니다.

```tsx
disabled={session.status === 'CLOSED' || isPending}
```

앞은 이 PR, 뒤는 #78에서 들어온 값입니다.

## 관련 이슈

Closes #80

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

경고 없이 통과합니다.

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.3s
✓ Finished TypeScript in 4.0s
✓ Collecting page data using 11 workers in 1043ms
✓ Generating static pages using 11 workers (9/9) in 304ms
✓ Finalizing page optimization in 29ms
```

브라우저에서 393px로 확인했습니다.

```text
/e/ab3f9x   3부: Q&A가 회색 칩으로 뜨고 눌리지 않음
            "지금 소감을 받는 세션만 선택할 수 있어요" 표시됨
            취소된 세션(DELETED)은 목록에 없음

/e/kd7m2p   세션 둘 다 ACTIVE라 안내 문구가 뜨지 않음
```

**열린 세션이 하나뿐인 경우는 목 데이터에 없습니다.** `ab3f9x`는 열린 세션이 둘(`1부: 키노트`, `2부: 패널 토론`), `kd7m2p`도 둘입니다. 자동 선택 동작은 `mocks/data/seed.ts`에서 `id: 102`를 임시로 `CLOSED`로 바꿔 확인했습니다. 커밋에는 포함하지 않았습니다.

목 데이터에 "열린 세션 하나짜리" 이벤트를 추가할지는 별도로 논의하면 좋겠습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- 디자인 시스템 변경: 없음 (`Chip`은 기존 `disabled`를 그대로 씀)

## 범위 밖

- **`Text/tertiary` 토큰 대비** — 별도 이슈. 이 화면만의 문제가 아님
- **`Chip` disabled 글자색** — `Text/disabled`가 `Background/muted` 위에서 1.85:1인데, 토큰을 바꾸면 다른 화면 칩에도 영향이 감
- **이벤트 상태 분기(`DRAFT`·`ENDED`)** — #88
- **제출한 세션의 결과 보기** — 위 "지금은 제출 여부를 모릅니다" 참고. 로컬 저장 키가 확정돼야 합니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이라 개발 과정 로그에 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 세션 목록에서 활성 상태인 세션만 초기 선택 대상으로 표시합니다.
  - 활성 세션이 하나뿐인 경우 자동으로 선택됩니다.

- **버그 수정**
  - 종료된 세션은 선택할 수 없도록 제한했습니다.
  - 종료된 세션을 선택하려는 경우 안내 문구와 `SESSION_CLOSED` 오류 메시지를 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->