### PR TITLE
feat(storage): 소감 제출 기록 저장 모듈 추가

### DIFF
--- a/lib/storage/submitted.test.ts
+++ b/lib/storage/submitted.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { hasSubmitted, listSubmitted, markSubmitted } from '@/lib/storage/submitted';
+
+/**
+ * 화면에 붙기 전이라 브라우저로 확인할 수 없습니다. 깨진 값·접근 차단·서버 렌더처럼
+ * 실제로 마주치지만 재현이 번거로운 경우를 여기서 봅니다.
+ *
+ * vitest 환경이 node라 window가 없습니다. 브라우저 경로는 stubGlobal로 만듭니다.
+ */
+
+const EVENT_CODE = 'ab3f9x';
+const OTHER_EVENT_CODE = 'kd7m2p';
+const key = `pulse:submitted:${EVENT_CODE}`;
+
+const stubBrowser = (initial: Record<string, string> = {}) => {
+  const map = new Map(Object.entries(initial));
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: (k: string): string | null => map.get(k) ?? null,
+      setItem: (k: string, v: string): void => {
+        map.set(k, v);
+      },
+    },
+  });
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('기록과 조회', () => {
+  it('기록한 세션을 찾는다', () => {
+    stubBrowser();
+    markSubmitted(EVENT_CODE, 101);
+    expect(hasSubmitted(EVENT_CODE, 101)).toBe(true);
+  });
+
+  it('같은 세션을 두 번 기록해도 하나만 남는다', () => {
+    stubBrowser();
+    markSubmitted(EVENT_CODE, 101);
+    markSubmitted(EVENT_CODE, 101);
+    expect([...listSubmitted(EVENT_CODE)]).toEqual([101]);
+  });
+
+  it('이벤트가 다르면 섞이지 않는다', () => {
+    stubBrowser();
+    markSubmitted(EVENT_CODE, 101);
+    expect(hasSubmitted(OTHER_EVENT_CODE, 101)).toBe(false);
+  });
+});
+
+describe('망가진 값', () => {
+  it('JSON이 아니면 빈 값으로 읽는다', () => {
+    stubBrowser({ [key]: '{{{' });
+    expect(listSubmitted(EVENT_CODE).size).toBe(0);
+  });
+
+  it('배열이 아니면 빈 값으로 읽는다', () => {
+    stubBrowser({ [key]: '{"a":1}' });
+    expect(listSubmitted(EVENT_CODE).size).toBe(0);
+  });
+
+  it('숫자가 아닌 항목은 걸러낸다', () => {
+    stubBrowser({ [key]: '[101,"102",null]' });
+    expect([...listSubmitted(EVENT_CODE)]).toEqual([101]);
+  });
+});
+
+describe('접근이 막힌 경우', () => {
+  it('읽기가 던져도 빈 값을 돌려준다', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => {
+          throw new Error('SecurityError');
+        },
+      },
+    });
+    expect(listSubmitted(EVENT_CODE).size).toBe(0);
+  });
+
+  it('쓰기가 던져도 예외가 새지 않는다', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => null,
+        setItem: () => {
+          throw new Error('QuotaExceededError');
+        },
+      },
+    });
+    expect(() => markSubmitted(EVENT_CODE, 101)).not.toThrow();
+  });
+});
+
+describe('서버 렌더', () => {
+  it('window가 없으면 빈 값이다', () => {
+    expect(listSubmitted(EVENT_CODE).size).toBe(0);
+    expect(hasSubmitted(EVENT_CODE, 101)).toBe(false);
+  });
+
+  it('window가 없으면 기록해도 던지지 않는다', () => {
+    expect(() => markSubmitted(EVENT_CODE, 101)).not.toThrow();
+  });
+});

--- a/lib/storage/submitted.ts
+++ b/lib/storage/submitted.ts
@@ -1,0 +1,68 @@
+/**
+ * 소감 제출 기록입니다.
+ *
+ * 서버가 중복 제출을 막지 않아(2026-08-07 명세) 프론트가 로컬에 남겨 안내만 합니다.
+ * 저장 형식은 #92에서 확정했습니다.
+ *
+ *   키   pulse:submitted:{eventCode}
+ *   값   sessionId 배열의 JSON        예: [101, 103]
+ *
+ * 이 파일이 키 문자열을 아는 유일한 곳입니다. 화면에서 localStorage를 직접 부르지
+ * 마세요. 오타가 나도 에러가 아니라 "안 남김"으로 조용히 읽혀서 찾기 어렵습니다.
+ */
+
+const storageKey = (eventCode: string) => `pulse:submitted:${eventCode}`;
+
+/**
+ * 서버에는 localStorage가 없어 항상 빈 배열입니다. 호출부는 첫 렌더에서
+ * "안 남김"으로 그렸다가 마운트 후 다시 그려야 합니다.
+ *
+ * Safari 시크릿 모드는 접근 자체를 막고, 값이 손상됐으면 JSON.parse가 던집니다.
+ * 둘 다 빈 배열로 떨어뜨려서 "기록 없음"과 같게 취급합니다.
+ */
+const read = (eventCode: string): number[] => {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = window.localStorage.getItem(storageKey(eventCode));
+    if (raw === null) return [];
+
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+
+    return parsed.filter((value): value is number => typeof value === 'number');
+  } catch {
+    return [];
+  }
+};
+
+/** 저장 실패는 무시합니다. 안내가 안 뜰 뿐 제출 자체는 이미 끝났습니다. */
+const write = (eventCode: string, sessionIds: number[]): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(storageKey(eventCode), JSON.stringify(sessionIds));
+  } catch {
+    // 용량 초과 또는 시크릿 모드
+  }
+};
+
+/** 제출 성공 후 부릅니다. 같은 세션이 두 번 들어가지 않습니다. */
+const markSubmitted = (eventCode: string, sessionId: number): void => {
+  const submitted = read(eventCode);
+  if (submitted.includes(sessionId)) return;
+
+  write(eventCode, [...submitted, sessionId]);
+};
+
+/** 한 세션만 볼 때 씁니다. 여러 개를 가릴 때는 listSubmitted를 쓰세요. */
+const hasSubmitted = (eventCode: string, sessionId: number): boolean =>
+  read(eventCode).includes(sessionId);
+
+/**
+ * 칩 여러 개를 한 번에 가릴 때 씁니다. hasSubmitted를 N번 부르면
+ * localStorage를 N번 읽습니다.
+ */
+const listSubmitted = (eventCode: string): Set<number> => new Set(read(eventCode));
+
+export { markSubmitted, hasSubmitted, listSubmitted };


### PR DESCRIPTION
## 변경 사항

소감 제출 기록을 브라우저에 남기는 모듈을 추가했습니다.

- `lib/storage/submitted.ts` — 신규
- `lib/storage/submitted.test.ts` — 신규

호출부는 없습니다. 이 PR은 계약만 만듭니다.

## 왜 모듈로 뺐는지

같은 값을 **두 사람이 다른 화면에서** 씁니다.

```text
쓰기   components/feedback/FeedbackForm.tsx   제출 성공 시
읽기   app/e/[code]/live/page.tsx             접근 제어 (#54)
읽기   components/feedback/FeedbackForm.tsx   칩 분기
```

각자 `localStorage.getItem('pulse:submitted:...')`를 손으로 쓰면 오타 하나로 어긋납니다.

문제는 **어긋나도 에러가 안 난다**는 것입니다. 조용히 "안 남김"으로 읽혀서, 이미 소감을 낸 사람이 작성창을 다시 봅니다. 화면은 멀쩡해 보이고 로그도 안 남습니다.

키 문자열을 아는 곳을 이 파일 하나로 묶었습니다.

## 저장 형식

#92에서 확정한 그대로입니다.

```text
저장소   localStorage
키       pulse:submitted:{eventCode}
값       sessionId 배열의 JSON        예: [101, 103]
```

세션별 키(`pulse_submitted_{sessionId}`)를 안 쓴 이유는 #92에 적어뒀습니다. 참가자가 로그인을 안 해서 기기에 계속 쌓이는데, 이벤트 코드로 묶어야 나중에 통째로 지울 수 있습니다.

## 예외를 전부 빈 값으로 떨어뜨립니다

```ts
서버 렌더            window 없음        →  []
값이 없음            getItem null       →  []
JSON이 깨짐          parse 예외         →  []
배열이 아님          타입 불일치        →  []
숫자가 아닌 항목      필터링             →  걸러냄
Safari 시크릿 모드   접근 자체가 예외    →  []
```

전부 **"기록 없음"과 같게** 취급합니다. 기록이 사라지면 이미 낸 사람이 작성창을 다시 볼 뿐이고, 명세도 그래서 "안내만 한다"고 했습니다.

저장 실패도 무시합니다. 안내가 안 뜰 뿐 **제출 자체는 이미 끝났습니다.** 여기서 예외를 던지면 성공한 제출이 실패처럼 보입니다.

## 호출부가 알아야 할 것

**서버에서는 항상 빈 값입니다.** 첫 렌더는 "안 남김"으로 그려지고 마운트 후에 바뀝니다. 칩이 깜빡이는 걸 각 화면에서 처리해야 합니다. 이 모듈은 그 판단을 하지 않습니다.

**`hasSubmitted`를 반복해서 부르지 마세요.** 칩이 N개면 `localStorage`를 N번 읽습니다. 여러 개를 가릴 때는 `listSubmitted`로 한 번 읽어서 `Set`으로 쓰세요.

```ts
const submitted = listSubmitted(eventCode);
sessions.map((session) => submitted.has(session.id) ? … : …);
```

## 테스트를 같이 넣은 이유

이 모듈은 **정상 경로가 아니라 예외 경로 때문에 존재합니다.** 그런데 그 경로들이 브라우저로 재현하기 번거롭습니다 — Safari 시크릿 모드를 켜거나, `localStorage`에 깨진 값을 심거나, 서버 렌더 시점을 잡아야 합니다.

호출부가 아직 없어 화면으로 확인할 방법도 없습니다. 그리고 #92에서 "만드시면 따라가겠다"는 답을 받은 상태라, **계약이 지켜지는지 보여주는 게 있어야** 합니다.

`vitest` 환경이 `node`라 `window`가 없습니다. 서버 경로는 그대로 테스트되고, 브라우저 경로는 `stubGlobal`로 만들었습니다.

## 관련 이슈

Closes #93

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 4.4s
✓ Finished TypeScript in 5.0s
```

`npm run test`

```text
 ✓ lib/storage/submitted.test.ts (10 tests) 7ms
 ✓ lib/api/endpoints.test.ts (6 tests) 82ms
 ✓ mocks/handlers.test.ts (54 tests) 195ms

 Test Files  3 passed (3)
      Tests  70 passed (70)
```

새로 추가한 10건이 통과하고, 기존 60건도 그대로입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- **기존 파일 수정 없음** — 새 파일 두 개만 추가했습니다

## 범위 밖

- **`FeedbackForm`에서 호출하기** — 제출 성공 시 기록하고 칩을 가르는 건 별도 이슈. 칩을 어떻게 보여줄지 시안이 남아 있습니다
- **`/live` 접근 제어** — #54
- **오래된 기록 정리** — #92에서 미루기로 했습니다. 필요해지면 값에 제출 시각을 넣어야 합니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이벤트별 제출 세션을 브라우저에 저장하고 조회할 수 있습니다.
  * 동일한 세션의 중복 기록을 방지합니다.
  * 제출 여부 확인 및 제출 세션 목록 조회를 지원합니다.
  * 손상된 데이터나 지원되지 않는 환경에서도 안전하게 동작합니다.

* **테스트**
  * 정상 저장, 중복 제거, 이벤트별 분리 및 오류 처리 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->