### PR TITLE
fix(storage): 유한하지 않은 sessionId를 기록하지 않음

### DIFF
--- a/lib/storage/submitted.test.ts
+++ b/lib/storage/submitted.test.ts
@@ -65,9 +65,15 @@ describe('망가진 값', () => {
 
   it('유한하지 않은 세션은 기록하지 않는다', () => {
     stubBrowser();
+
     markSubmitted(EVENT_CODE, NaN);
     markSubmitted(EVENT_CODE, Infinity);
     markSubmitted(EVENT_CODE, -Infinity);
+
+    // listSubmitted만 보면 가드가 없어도 통과합니다. read가 숫자 아닌 항목을
+    // 걸러내서 "[null]"이 저장돼 있어도 빈 Set이 나오기 때문입니다.
+    // 저장 자체가 일어나지 않았는지를 원시 값으로 확인합니다.
+    expect(window.localStorage.getItem(`pulse:submitted:${EVENT_CODE}`)).toBeNull();
     expect(listSubmitted(EVENT_CODE).size).toBe(0);
   });
 });

--- a/lib/storage/submitted.test.ts
+++ b/lib/storage/submitted.test.ts
@@ -62,6 +62,14 @@ describe('망가진 값', () => {
     stubBrowser({ [key]: '[101,"102",null]' });
     expect([...listSubmitted(EVENT_CODE)]).toEqual([101]);
   });
+
+  it('유한하지 않은 세션은 기록하지 않는다', () => {
+    stubBrowser();
+    markSubmitted(EVENT_CODE, NaN);
+    markSubmitted(EVENT_CODE, Infinity);
+    markSubmitted(EVENT_CODE, -Infinity);
+    expect(listSubmitted(EVENT_CODE).size).toBe(0);
+  });
 });
 
 describe('접근이 막힌 경우', () => {

--- a/lib/storage/submitted.ts
+++ b/lib/storage/submitted.ts
@@ -47,8 +47,15 @@ const write = (eventCode: string, sessionIds: number[]): void => {
   }
 };
 
-/** 제출 성공 후 부릅니다. 같은 세션이 두 번 들어가지 않습니다. */
+/**
+ * 제출 성공 후 부릅니다. 같은 세션이 두 번 들어가지 않습니다.
+ *
+ * 유한하지 않은 값(NaN·Infinity)은 저장하지 않습니다. JSON.stringify가 이를 null로
+ * 바꾸고, read가 그 null을 걸러내 기록이 조용히 사라지기 때문입니다.
+ */
 const markSubmitted = (eventCode: string, sessionId: number): void => {
+  if (!Number.isFinite(sessionId)) return;
+
   const submitted = read(eventCode);
   if (submitted.includes(sessionId)) return;
 


### PR DESCRIPTION
## 변경 사항

`markSubmitted`가 유한하지 않은 `sessionId`를 저장하지 않도록 막았습니다.

```diff
 const markSubmitted = (eventCode: string, sessionId: number): void => {
+  if (!Number.isFinite(sessionId)) return;
+
   const submitted = read(eventCode);
   if (submitted.includes(sessionId)) return;

   write(eventCode, [...submitted, sessionId]);
 };
```

- `lib/storage/submitted.ts` — 검사 한 줄
- `lib/storage/submitted.test.ts` — 회귀 테스트 한 건

## 문제

`JSON.stringify`가 배열 안의 `NaN`·`Infinity`·`-Infinity`를 `null`로 바꿉니다.

```js
JSON.stringify([NaN])   →  "[null]"
```

`read`는 숫자가 아닌 항목을 거르므로 **다시 읽을 때 기록이 사라집니다.**

```text
markSubmitted(code, NaN)   성공한 것처럼 끝남
hasSubmitted(code, NaN)    false
```

에러도 로그도 없습니다. 이 모듈이 존재하는 이유가 그런 실패를 막으려는 건데, 정작 여기서 같은 방식으로 조용히 어긋나고 있었습니다.

## 어떻게 도달하는지

호출부가 스키마를 거친 값만 주면 생기지 않습니다. `SessionView.id`는 `z.int()`를 통과한 값이라 안전합니다.

그런데 `/live`가 쿼리스트링을 읽습니다.

```tsx
// /e/{code}/live?sessionId=abc
const sessionId = Number(searchParams.sessionId);   // NaN
```

이 모듈은 **다른 화면에서 가져다 쓰기로 한 공용 계약**입니다(#92). 검증을 거치지 않은 값이 들어올 수 있는 공개 함수라 경계에서 막는 게 맞습니다.

## 왜 별도 PR인지

PR #95 리뷰에서 지적됐는데 **수정 커밋이 머지에 못 들어갔습니다.** 커밋을 만든 시점과 머지 시점이 겹쳤습니다.

머지된 브랜치에 얹을 수 없어 dev에서 새로 따고 `cherry-pick`으로 옮겼습니다.

## 관련 이슈

Closes #98

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.6s
✓ Finished TypeScript in 4.5s
```

`npm run test`

```text
 ✓ lib/storage/submitted.test.ts (11 tests) 12ms
 ✓ lib/api/endpoints.test.ts (6 tests) 64ms
 ✓ mocks/handlers.test.ts (54 tests) 173ms

 Test Files  3 passed (3)
      Tests  71 passed (71)
```

`submitted.test.ts`가 10건에서 11건으로 늘었습니다. 추가한 케이스입니다.

```ts
it('유한하지 않은 세션은 기록하지 않는다', () => {
  stubBrowser();

  markSubmitted(EVENT_CODE, NaN);
  markSubmitted(EVENT_CODE, Infinity);
  markSubmitted(EVENT_CODE, -Infinity);

  expect(window.localStorage.getItem(`pulse:submitted:${EVENT_CODE}`)).toBeNull();
  expect(listSubmitted(EVENT_CODE).size).toBe(0);
});
```

**`listSubmitted`만 보면 이 테스트가 아무것도 안 잡습니다.** 리뷰에서 지적받아 고쳤습니다. 가드가 없다고 가정하고 따라가면 이렇습니다.

```text
write(code, [NaN])            →  setItem(key, "[null]")
JSON.parse("[null]")          →  [null]
filter(typeof v === 'number') →  []            ← read가 걸러냄
Set{}                         →  size 0        ← 가드 없이도 통과
```

`read`가 망가진 값을 걸러주는 게 이 모듈의 방어 기능인데, 그 방어가 테스트의 눈까지 가렸습니다. 원시 값을 직접 확인하도록 바꿨습니다.

키 문자열은 `storageKey`를 export하지 않고 테스트에 따로 적었습니다. 모듈에서 가져오면 키 생성이 틀렸을 때 테스트도 같이 틀려서 계약 검증이 되지 않습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- 호출부 변경 없음 — 정상 값의 동작은 그대로입니다

## 범위 밖

- **`hasSubmitted`·`listSubmitted`의 입력 검증** — 읽기만 하므로 `NaN`이 들어와도 `false`나 빈 집합이 나올 뿐 기록이 망가지지 않습니다. 저장 경로만 막았습니다
- **`FeedbackForm`에서 호출하기** — 별도 이슈

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.
