### PR TITLE
feat(event): 참가자 진입 화면에 이벤트 상태 분기 추가

### DIFF
--- a/app/e/[code]/not-found.tsx
+++ b/app/e/[code]/not-found.tsx
@@ -1,16 +1,12 @@
+import { EmptyState } from '@/components/ui/EmptyState';
+
 const EventNotFound = () => {
   return (
-    <main className="flex flex-col gap-6 px-5 py-4">
-      <div className="flex flex-col items-center gap-4 rounded-xl border border-border-subtle px-5 py-10">
-        <div className="flex flex-col items-center gap-1">
-          <p className="text-base font-medium leading-6 text-text-primary">
-            이벤트를 찾을 수 없어요
-          </p>
-          <p className="text-sm font-normal leading-5 text-text-secondary">
-            링크가 올바른지 다시 확인해 주세요
-          </p>
-        </div>
-      </div>
+    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+      <EmptyState
+        title="이벤트를 찾을 수 없어요"
+        description="링크가 올바른지 다시 확인해 주세요"
+      />
     </main>
   );
 };

--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,10 +1,13 @@
-import { fetchEventByCode, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { notFound } from 'next/navigation';
-import { ApiError } from '@/lib/apiClient';
+
 import { FeedbackForm } from '@/components/feedback/FeedbackForm';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { buttonStyle } from '@/components/ui/Button';
+import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
-
 interface EventEntryPageProps {
   params: Promise<{ code: string }>;
 }
@@ -13,6 +16,8 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
   const { code } = await params;
 
   // 서버에서 부릅니다. 두 요청이 서로를 안 기다리도록 병렬로 보냅니다.
+  // DRAFT·ENDED에서는 sessions를 안 쓰지만, 상태를 먼저 받고 결정하면
+  // 가장 흔한 LIVE 경로가 왕복 하나만큼 느려집니다. 응답 하나 버리는 게 낫습니다.
   const [event, sessions] = await Promise.all([
     fetchEventByCode(code),
     fetchSessionsByEventCode(code),
@@ -21,16 +26,64 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
     throw error;
   });
 
+  // 참가자는 DRAFT와 "세션이 아직 안 열림"을 구분할 수 없습니다. 둘 다 기다려야
+  // 하는 상태라 같은 화면을 보여줍니다. DRAFT는 세션이 미리 만들어져 있어도
+  // 막아야 합니다 — 폼이 뜨면 소감을 다 쓴 뒤에 EVENT_NOT_LIVE로 실패합니다.
+  //
+  // 세션 0개는 지금 API로는 나올 수 없습니다(DRAFT → LIVE 전환에 1개 이상 검사가
+  // 있고 삭제 API가 없음). 다만 그 검사가 목에만 있어서, 실제 서버가 빠뜨리면
+  // 칩 없는 폼이 뜨고 제출 버튼이 영원히 비활성이 됩니다. 조건 한 항목으로 막습니다.
+  const canSubmit = event.status === 'LIVE' && sessions.length > 0;
+  const isEnded = event.status === 'ENDED';
+
+  // 리포트는 ENDED일 때만 봅니다. 없거나 비공개면 똑같이 404가 오는데,
+  // 게스트에게 둘을 구분해 알리지 않기로 했습니다(#84).
+  // 404만 삼키고 나머지 오류는 그대로 던집니다 — 통신 실패까지 "리포트 없음"으로
+  // 읽으면 주최자가 공개해둔 리포트를 못 본 채로 화면이 멀쩡해 보입니다.
+  const hasReport =
+    isEnded &&
+    (await fetchPublicReport(code)
+      .then(() => true)
+      .catch((error: unknown) => {
+        if (error instanceof ApiError && error.code === 'REPORT_NOT_FOUND') return false;
+        throw error;
+      }));
+
   return (
-    <main className="flex flex-col gap-6 p-5">
+    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
       <section className="flex flex-col gap-1">
         <p className="text-xs font-normal leading-4 text-text-tertiary">이벤트</p>
         <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
-        <p className="text-sm font-normal leading-5 text-text-secondary">
-          {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
-        </p>
+        {canSubmit ? (
+          <p className="text-sm font-normal leading-5 text-text-secondary">
+            {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
+          </p>
+        ) : null}
       </section>
-      <FeedbackForm eventCode={code} sessions={sessions} />
+
+      {canSubmit ? (
+        <FeedbackForm eventCode={code} sessions={sessions} />
+      ) : isEnded ? (
+        <EmptyState
+          title="종료된 이벤트예요"
+          description={
+            hasReport
+              ? '소감 제출은 마감되었어요'
+              : '소감 제출은 마감되었어요\n주최자가 리포트를 준비하면 여기에 표시돼요'
+          }
+        >
+          {hasReport ? (
+            <Link href={`/e/${code}/report`} className={buttonStyle('primary', 'lg')}>
+              결과 리포트 보기
+            </Link>
+          ) : null}
+        </EmptyState>
+      ) : (
+        <EmptyState
+          title="지금은 소감을 받는 세션이 없어요"
+          description="세션이 열리면 여기서 남길 수 있어요"
+        />
+      )}
     </main>
   );
 };

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -32,6 +32,16 @@ const SIZE: Record<ButtonSize, string> = {
   sm: 'h-9',
 };
 
+/**
+ * 버튼 모양이 필요한데 `<button>`을 쓸 수 없을 때 씁니다.
+ *
+ * 이동은 `<a>`(`next/link`)여야 새 탭 열기·주소 복사·스크린리더 안내·prefetch가
+ * 살아 있는데, `<a>` 안에는 `<button>`을 넣을 수 없습니다(HTML 콘텐츠 모델에서
+ * interactive content가 제외됩니다). 그래서 요소는 링크로 두고 모양만 가져다 씁니다.
+ */
+const buttonStyle = (variant: ButtonVariant = 'primary', size: ButtonSize = 'md') =>
+  `${BASE} ${VARIANT[variant]} ${SIZE[size]}`;
+
 const Button = ({
   variant = 'primary',
   size = 'md',
@@ -39,13 +49,7 @@ const Button = ({
   className = '',
   ...props
 }: ButtonProps) => {
-  return (
-    <button
-      type={type}
-      className={`${BASE} ${VARIANT[variant]} ${SIZE[size]} ${className}`}
-      {...props}
-    />
-  );
+  return <button type={type} className={`${buttonStyle(variant, size)} ${className}`} {...props} />;
 };
 
-export { Button };
+export { Button, buttonStyle };

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,0 +1,39 @@
+import type { ComponentProps } from 'react';
+
+interface EmptyStateProps extends ComponentProps<'div'> {
+  title: string;
+  description?: string;
+}
+
+/**
+ * 본문 대신 상황을 알리는 카드입니다.
+ *
+ * 없는 이벤트·시작 전·종료 후처럼 보여줄 내용이 없을 때 씁니다.
+ * `children`은 카드 안 버튼 자리이고, 다음 행동이 있을 때만 넘깁니다.
+ */
+const EmptyState = ({
+  title,
+  description,
+  className = '',
+  children,
+  ...props
+}: EmptyStateProps) => {
+  return (
+    <div
+      className={`flex flex-col items-center gap-4 rounded-xl border border-border-subtle px-5 py-10 ${className}`}
+      {...props}
+    >
+      <div className="flex flex-col items-center gap-1 text-center">
+        <p className="text-base font-medium leading-6 text-text-primary">{title}</p>
+        {description ? (
+          <p className="whitespace-pre-line text-sm font-normal leading-5 text-text-secondary">
+            {description}
+          </p>
+        ) : null}
+      </div>
+      {children}
+    </div>
+  );
+};
+
+export { EmptyState };

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -148,6 +148,8 @@ focus는 `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:o
 그래서 요소는 링크로 두고 모양만 가져다 씁니다.
 
 ```tsx
+import Link from 'next/link';
+
 import { buttonStyle } from '@/components/ui/Button';
 
 <Link href={`/e/${code}/report`} className={buttonStyle('primary', 'lg')}>
@@ -822,11 +824,9 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 ## 결정 기록
 
-<<<<<<< HEAD
 - 2026.08.11 (#106) — `Button`·`Chip`에 `cursor-pointer` 추가. 비활성 커서만 정하고 기본 커서를 안 정해서, `<button>`의 브라우저 기본값인 `default`가 그대로 나왔음. #54가 화면에서 `className="cursor-pointer"`로 덧대고 있었는데 `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없어 컴포넌트로 올림. 칩 아이콘은 새 prop 없이 `children`으로 넣기로 함 — `gap-2.5`가 이미 있어 간격이 붙고, Figma의 `icon` Boolean과 대응됨
-=======
+  \=======
 - 2026.08.11 (#88) — 버튼 모양의 링크를 위해 `buttonStyle(variant, size)`를 export. `<a>` 안에 `<button>`을 넣을 수 없어(HTML 콘텐츠 모델) 요소는 `next/link`로 두고 모양만 가져옴. `as` prop으로 폴리모픽하게 만드는 방법도 있었지만 제네릭 타입이 복잡해지고 `type="button"` 기본값이 `<a>`로 새는 것도 막아야 해서 미룸. 사용처가 서넛 넘어가면 `LinkButton` 래퍼를 두기로 함
->>>>>>> 075ca4b (feat(ui): 상황 안내 카드 EmptyState 추가)
 - 2026.08.11 (#96) — `Text/tertiary` 토큰 값을 `#888780`에서 `#77766f`로 교체. 흰 배경 3.61:1 → 4.56:1로 12px 텍스트 AA를 넘김. 위 항목들의 3.13:1·3.61:1은 변경 전 값 기준임
 - 2026.08.10 (#75) — Banner 테두리를 점선으로 수정. #70에서 실선으로 만든 건 Figma JSON 추출 결과에 선 종류가 담기지 않아 확인 없이 가정한 실수였음. 기능적 이유는 없고 시안 그대로임 — 다른 컴포넌트는 실선이라 Banner만 예외이고, 실수가 아니니 통일하지 말 것
 - 2026.08.10 — Banner에 `info` 톤 추가. 참가자 소감 입력 화면의 안내 문구가 Banner와 생김새가 같아서 별도 컴포넌트(`Hint`) 대신 톤으로 편입함

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -136,6 +136,31 @@ focus는 `focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:o
 - 되돌릴 수 없는 동작은 danger 버튼 하나로 끝내지 말고 확인 다이얼로그를 거칩니다
 - 한 화면에 danger 버튼을 여러 개 두지 마세요. 강조가 분산되면 없는 것과 같습니다
 
+### 버튼 모양의 링크
+
+이동은 `<button onClick={router.push}>`가 아니라 `next/link`로 만듭니다.
+`<a>`여야 새 탭 열기(⌘클릭·가운데클릭)·주소 복사·prefetch가 살아 있고,
+스크린리더가 "링크"로 읽습니다.
+
+그런데 `<a>` 안에는 `<button>`을 넣을 수 없습니다. HTML 콘텐츠 모델에서
+`<a>`는 interactive content를 자식으로 받지 못합니다.
+
+그래서 요소는 링크로 두고 모양만 가져다 씁니다.
+
+```tsx
+import { buttonStyle } from '@/components/ui/Button';
+
+<Link href={`/e/${code}/report`} className={buttonStyle('primary', 'lg')}>
+  결과 리포트 보기
+</Link>;
+```
+
+기본값은 `Button`과 같은 `primary` · `md`입니다.
+
+**클릭이 이동인지 동작인지로 가릅니다.** 주소를 붙일 수 있으면 링크,
+결과에 따라 목적지가 달라지면 버튼입니다. `소감 남기기`는 제출이 성공해야
+이동하므로 버튼이고, `결과 리포트 보기`는 조건 없이 그 주소로 가므로 링크입니다.
+
 ### 사용 예
 
 ```tsx
@@ -797,13 +822,16 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 ## 결정 기록
 
+<<<<<<< HEAD
 - 2026.08.11 (#106) — `Button`·`Chip`에 `cursor-pointer` 추가. 비활성 커서만 정하고 기본 커서를 안 정해서, `<button>`의 브라우저 기본값인 `default`가 그대로 나왔음. #54가 화면에서 `className="cursor-pointer"`로 덧대고 있었는데 `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없어 컴포넌트로 올림. 칩 아이콘은 새 prop 없이 `children`으로 넣기로 함 — `gap-2.5`가 이미 있어 간격이 붙고, Figma의 `icon` Boolean과 대응됨
+=======
+- 2026.08.11 (#88) — 버튼 모양의 링크를 위해 `buttonStyle(variant, size)`를 export. `<a>` 안에 `<button>`을 넣을 수 없어(HTML 콘텐츠 모델) 요소는 `next/link`로 두고 모양만 가져옴. `as` prop으로 폴리모픽하게 만드는 방법도 있었지만 제네릭 타입이 복잡해지고 `type="button"` 기본값이 `<a>`로 새는 것도 막아야 해서 미룸. 사용처가 서넛 넘어가면 `LinkButton` 래퍼를 두기로 함
+>>>>>>> 075ca4b (feat(ui): 상황 안내 카드 EmptyState 추가)
 - 2026.08.11 (#96) — `Text/tertiary` 토큰 값을 `#888780`에서 `#77766f`로 교체. 흰 배경 3.61:1 → 4.56:1로 12px 텍스트 AA를 넘김. 위 항목들의 3.13:1·3.61:1은 변경 전 값 기준임
 - 2026.08.10 (#75) — Banner 테두리를 점선으로 수정. #70에서 실선으로 만든 건 Figma JSON 추출 결과에 선 종류가 담기지 않아 확인 없이 가정한 실수였음. 기능적 이유는 없고 시안 그대로임 — 다른 컴포넌트는 실선이라 Banner만 예외이고, 실수가 아니니 통일하지 말 것
 - 2026.08.10 — Banner에 `info` 톤 추가. 참가자 소감 입력 화면의 안내 문구가 Banner와 생김새가 같아서 별도 컴포넌트(`Hint`) 대신 톤으로 편입함
 - 2026.08.10 — 세 톤 모두에 `*/lighter` 테두리 추가. 배경만으로는 흰 화면과 1.1:1이라 경계가 약함. 누를 수 없는 요소라 3:1 규정 대상은 아니고 장식임
 - 2026.08.10 — 글자 굵기를 Medium에서 Regular로 변경. Banner는 흐름 안에 계속 남는 요소라 Medium이면 계속 시끄럽고, 강조는 색이 이미 하고 있음
-- 2026.08.05 — 모더레이션 버튼 높이 32 → 36으로 통일. size는 lg/md/sm 3종만 유지
 - 2026.08.07 (#66) — Card 컴포넌트를 만들지 않기로 확정하고 `미작성` 목록에서 제거. 흰 배경 + 테두리 박스가 여러 화면에 반복되지만 Stat(`background/muted`, 테두리 없음)·차트 카드(`background/default` + `border-subtle`)·FeedItem(상태마다 다름)이 배경·테두리·padding 모두 달라, 묶으면 variant가 세 개 생기고 결국 화면마다 `className`으로 덮어쓰게 됨. 세 번째로 같은 모양이 나오면 그때 다시 검토
 - 2026.08.07 (#61) — 토스트를 동시에 하나만 띄우기로 함. Pulse에서 둘이 겹칠 상황이 없고, 쌓기를 넣으면 스택 관리·최대 개수·순서 코드가 전부 따라옴. 연타하면 타이머가 리셋되는 셈이라 오히려 자연스러움
 - 2026.08.07 (#61) — 상태를 Context가 아니라 모듈 변수 + `useSyncExternalStore`로 둠. 호출부가 훅 없이 `showToast('...')`만 부르면 되고, 프로바이더가 하나 더 늘지 않음. 공유할 상태가 객체 하나뿐이라 Context의 이점이 없음
@@ -813,6 +841,10 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 - 2026.08.07 (#59) — 포커스 링 색을 `Primary/default`(2.62:1)에서 `Primary/darker`(5.55:1)로 교체. 브라우저 기본 표시를 지우고 이 링으로 대체했는데 어느 배경에서도 3:1을 못 넘겨, 키보드 사용자가 현재 위치를 알 수 없었음. Button·Chip·Input·Textarea·Header 5곳
 - 2026.08.07 (#59) — Input·Textarea의 **기본 상태** focus 테두리도 같은 `Primary/darker`로 통일. 링과 테두리 색이 갈라지면 규칙이 두 개가 되고 한쪽만 고쳐짐. 오류(`invalid`) 상태의 테두리는 `Negative/default`를 그대로 유지 — 문제가 안 풀렸는데 표시가 사라지면 안 되고, 포커스 위치는 링만으로도 보임
 - 2026.08.07 (#59) — `outline-2`·`outline-offset-2`를 px로 유지하기로 확정(#48 리뷰 지적). outline은 간격이 아니라 테두리와 같은 성격의 선이고, 글자 크기에 따라 포커스 링이 굵어질 이유가 없음
+- 2026.08.07 — ConfirmDialog를 네이티브 `<dialog>` + `showModal()`로 구현. 포커스 가두기·ESC·배경 차단·딤을 브라우저가 처리해서 Radix 도입 논의가 필요 없어짐. 스크롤 잠금만 `globals.css`의 `body:has(dialog[open])`로 보완. 신규 토큰은 `--color-overlay`(시안에 딤 배경이 없어 코드에서 정함) 하나
+- 2026.08.07 — 열림 상태를 `open` prop 하나로만 관리. `<dialog open>` 속성으로 열면 모달이 아니게 되어 포커스도 배경 차단도 사라짐. ESC는 `onCancel`에서 `preventDefault()` 후 `onClose()`만 호출해서, 브라우저가 먼저 닫고 React가 뒤늦게 아는 상황을 막음
+- 2026.08.07 — 컴포넌트 이름을 시안의 `Alert`에서 `ConfirmDialog`로 변경. Banner가 이미 `role="alert"`를 쓰고 있어 혼동됨. `Dialog`는 아무 내용이나 담는 껍데기로 읽히는데 이건 제목·설명·버튼이 정해진 확인 전용
+- 2026.08.07 — 버튼을 `actions` prop으로 받고 취소를 먼저 배치. 확인 버튼이 danger인지 primary인지는 도메인 사정이고, `showModal()`이 첫 포커스 가능 요소에 포커스를 주므로 파괴적 확인창에서는 취소가 먼저인 편이 안전함
 - 2026.08.06 (#14) — focus 규격은 시안에 정의가 없어 코드에서 정함 (`Primary/default` 2px, offset 2)
 - 2026.08.06 (#14) — primary·secondary hover 색 확정. 이때 추가한 신규 토큰은 `Primary/pressed`(#036176) 하나
 - 2026.08.06 (#16) — danger 배경을 `Negative/default`(3.87:1, AA 미달)에서 `Negative/darker`(10.21:1)로 교체. hover용 `Negative/pressed`(#4F1D0D) 신설. `Negative/default` 값은 그대로 둬서 부정 감정 차트·배지는 영향 없음
@@ -821,6 +853,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 - 2026.08.06 (#21) — Banner에서 `positive` variant 제거. 성공 알림은 Toast가 담당하므로 흐름 안에 남을 이유가 없음. 필요해지면 다시 추가
 - 2026.08.06 (#21) — Banner의 `type`은 기본값 없이 필수. 남은 둘 다 나쁜 소식이라 기본값을 두면 실패가 조용히 주의 색으로 뜰 수 있음
 - 2026.08.06 (#21) — 아이콘을 텍스트 글자에서 벡터로 교체하고 `icons.tsx`로 분리. `✔️` 같은 이모지는 지정한 색이 안 먹고 OS마다 다르게 렌더됨. 신규 토큰 없음
+- 2026.08.06 (#21) — Banner에 닫기 버튼을 넣지 않음. 현재 두 type이 모두 조건형이라, 닫으면 문제가 남아 있는데 표시만 사라짐. 공지형이 생기면 그때 `onClose` 추가
 - 2026.08.06 (#43) — Stat의 `muted` 값 색을 `Text/tertiary`(3.13:1)에서 `Text/secondary`(5.64:1)로 교체. 20px SemiBold가 WCAG '큰 텍스트' 기준에 걸치는 크기라 통과 여부가 해석에 달려 있었음
 - 2026.08.06 (#43) — Stat의 값 색을 `tone` prop으로 받음. 시안은 인스턴스마다 색을 덮어쓰고 있는데, 화면에서 손으로 지정하면 갈라짐
 - 2026.08.06 (#34) — Input과 Field를 두 파일로 분리. `aria-describedby`·`aria-invalid`를 화면마다 손으로 붙이면 반드시 빠뜨림. Field가 `useId`로 연결을 대신함
@@ -832,8 +865,4 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 - 2026.08.06 — Toast는 생김새만 만들고 띄우는 방식은 분리. 위치·스택·타이머는 컴포넌트가 아니라 훅과 뷰포트의 일이라 섞으면 Toast가 비대해짐. 신규 토큰은 `--shadow-toast` 하나
 - 2026.08.06 — Toast 폰트를 Regular로. Banner는 Medium인데, 어두운 배경 위 흰 글씨는 같은 굵기라도 두껍게 보여서 한 단계 낮춰야 균형이 맞음
 - 2026.08.06 (#23) — 컴포넌트가 계산하는 접근성 속성은 밖에서 못 바꾸게 막는다. props 타입에서 `Omit`으로 빼고 JSX에서도 `{...props}` 뒤에 배치한다. 타입만 막으면 느슨한 객체를 펼칠 때 런타임에서 뚫린다. 현재 대상은 Banner의 `role`, Chip의 `aria-pressed`, 아이콘의 `aria-hidden`
-- 2026.08.07 — ConfirmDialog를 네이티브 `<dialog>` + `showModal()`로 구현. 포커스 가두기·ESC·배경 차단·딤을 브라우저가 처리해서 Radix 도입 논의가 필요 없어짐. 스크롤 잠금만 `globals.css`의 `body:has(dialog[open])`로 보완. 신규 토큰은 `--color-overlay`(시안에 딤 배경이 없어 코드에서 정함) 하나
-- 2026.08.07 — 열림 상태를 `open` prop 하나로만 관리. `<dialog open>` 속성으로 열면 모달이 아니게 되어 포커스도 배경 차단도 사라짐. ESC는 `onCancel`에서 `preventDefault()` 후 `onClose()`만 호출해서, 브라우저가 먼저 닫고 React가 뒤늦게 아는 상황을 막음
-- 2026.08.07 — 컴포넌트 이름을 시안의 `Alert`에서 `ConfirmDialog`로 변경. Banner가 이미 `role="alert"`를 쓰고 있어 혼동됨. `Dialog`는 아무 내용이나 담는 껍데기로 읽히는데 이건 제목·설명·버튼이 정해진 확인 전용
-- 2026.08.07 — 버튼을 `actions` prop으로 받고 취소를 먼저 배치. 확인 버튼이 danger인지 primary인지는 도메인 사정이고, `showModal()`이 첫 포커스 가능 요소에 포커스를 주므로 파괴적 확인창에서는 취소가 먼저인 편이 안전함
-- 2026.08.06 (#21) — Banner에 닫기 버튼을 넣지 않음. 현재 두 type이 모두 조건형이라, 닫으면 문제가 남아 있는데 표시만 사라짐. 공지형이 생기면 그때 `onClose` 추가
+- 2026.08.05 — 모더레이션 버튼 높이 32 → 36으로 통일. size는 lg/md/sm 3종만 유지


### PR DESCRIPTION
## 변경 사항

참가자 진입 화면(`/e/{code}`)이 이벤트 상태를 보고 갈라집니다.

- `app/e/[code]/page.tsx` — 상태 분기
- `components/ui/EmptyState.tsx` — 신규. 상황 안내 카드
- `components/ui/Button.tsx` — `buttonStyle` export 추가
- `app/e/[code]/not-found.tsx` — `EmptyState`로 교체
- `components/ui/README.md` — 항목 둘, 결정 기록 한 줄

## 개발 과정 로그

| 커밋 | 내용 |
| --- | --- |
| 1 | 상황 안내 카드 `EmptyState` 추가 |
| 2 | 버튼 모양 링크를 위한 `buttonStyle` 분리 |
| 3 | 참가자 진입 화면에 이벤트 상태 분기 추가 |
| 4 | `buttonStyle` 사용 예에 `Link` import 추가 (리뷰 반영) |

## 화면이 다섯으로 갈립니다

```text
없는 이벤트                    notFound()
DRAFT  |  LIVE + 세션 0개       "지금은 소감을 받는 세션이 없어요"
LIVE + 세션 있음               소감 입력 폼 (기존)
ENDED + 리포트 공개            종료 안내 + [결과 리포트 보기]
ENDED + 리포트 없음            종료 안내 + 준비 중 문구
```

## `DRAFT`와 "세션이 안 열림"을 합쳤습니다

시안에 따로 그리려다 말았습니다. **참가자는 둘을 구분할 수 없습니다.**

이벤트 상태는 우리 쪽 개념입니다. 참가자에게는 둘 다 "지금은 못 남긴다"이고, 다음 행동도 "기다렸다 다시 온다"로 같습니다. 화면을 나누면 같은 말을 두 가지로 하게 됩니다.

#84에서 종료 후 화면 넷을 둘로 합친 것과 같은 기준입니다 — **참가자가 구분 못 하는 상태는 합칩니다.**

```tsx
const canSubmit = event.status === 'LIVE' && sessions.length > 0;
```

`DRAFT`는 세션이 미리 만들어져 있어도 막습니다. 폼이 뜨면 참가자가 소감을 다 쓴 뒤에 `EVENT_NOT_LIVE`로 실패합니다. #80에서 닫힌 세션을 자동 선택하지 않기로 한 것과 같은 이유입니다.

## 도달할 수 없는 조건을 남겼습니다

`sessions.length > 0`은 **지금 API로는 거짓이 될 수 없습니다.**

```ts
// mocks/handlers/event.ts
if (body.data.status === 'LIVE' && listSessionsOfEvent(event.id).length === 0) {
  return errorResponse('INVALID_EVENT_STATE_TRANSITION', '세션을 1개 이상 만들어야 시작할 수 있습니다.');
}
```

세션 삭제 API가 없고, `sessionUpdateRequestSchema`의 `status`도 `openSessionStatusSchema`(`DELETED` 제외)라 `PATCH`로 지울 수도 없습니다.

**그래도 남긴 이유는 이 검사가 MSW 목에만 있어서입니다.** 계약 우선 개발이라 목이 단일 소스지만, 실제 Spring이 같은 검사를 넣었는지는 별개입니다. 빠뜨리면 **세션 칩이 하나도 없는 폼**이 뜨고 `selectedId`가 `null`이라 제출 버튼이 영원히 비활성입니다. 참가자는 뭘 못 하는지 이유도 모릅니다.

조건 한 항목이라 남기고 근거를 주석에 적었습니다. 없으면 다음에 보는 사람이 "이게 언제 생기지?" 하고 지웁니다.

## 종료 후에는 리포트 유무만 봅니다

생성 전·생성 중·비공개·실패가 **전부 같은 404**로 옵니다.

```text
리포트 생성 전  ─┐
리포트 생성 중  ─┼─ REPORT_NOT_FOUND (404)
리포트 비공개   ─┤
리포트 실패     ─┘

리포트 공개     ─── PublicReport (200)
```

`publicReportSchema`에 `status`·`isPublic`이 없어서 참가자는 애초에 구분할 수 없고, 병합은 의도입니다(`mocks/handlers/report.ts`).

> 게스트 쪽에서 "없음"과 "비공개"를 같은 404로 병합하는 건 의도입니다… 비공개 리포트의 존재 자체를 알리지 않습니다.

**404만 삼키고 나머지 오류는 그대로 던집니다.**

```tsx
.catch((error: unknown) => {
  if (error instanceof ApiError && error.code === 'REPORT_NOT_FOUND') return false;
  throw error;
});
```

`.catch(() => false)`로 하면 통신 실패까지 "리포트 없음"으로 읽힙니다. 주최자가 공개해둔 리포트를 참가자가 못 보는데 **화면은 멀쩡해 보입니다.**

문구는 두 경우 모두에 참인 것으로 잡았습니다. "아직"이나 "준비 중"만 쓰면 비공개인 경우 거짓이 되고, "볼 수 없어요"만 쓰면 나중에 공개될 경우를 배제합니다.

## 이벤트·세션 조회는 병렬을 유지했습니다

`DRAFT`·`ENDED`에서는 `sessions`를 안 씁니다. 상태를 먼저 받고 필요할 때만 부르면 낭비가 없는데, 그러면 **가장 흔한 `LIVE` 경로가 왕복 하나만큼 느려집니다.**

응답 하나 버리는 편이 낫다고 봤습니다.

리포트만 순차입니다. `ENDED`일 때만 부르고, 그 경로는 드뭅니다.

## `EmptyState`를 뽑았습니다

같은 카드가 넷입니다. 이 PR에서 셋이 새로 생깁니다.

**값을 새로 정한 게 없습니다.** `not-found.tsx`에 있던 것이 시안 카드와 radius·테두리·여백·gap·폰트까지 한 군데도 안 어긋나서 그대로 옮겼습니다.

| | 시안 | 코드 |
| --- | --- | --- |
| radius | 12 | `rounded-xl` |
| 테두리 | `Border/subtle` | `border-border-subtle` |
| 여백 | 40 / 20 | `py-10 px-5` |
| 카드 gap | 16 | `gap-4` |
| 제목·설명 gap | 4 | `gap-1` |

두 가지만 더했습니다.

`text-center` — `items-center`는 블록을 가운데 놓을 뿐이라 설명이 두 줄이면 각 줄은 왼쪽 정렬입니다. `not-found`는 한 줄이라 안 드러났습니다.

`whitespace-pre-line` — 종료·비공개 설명이 35자인데 카드 안쪽이 약 22자/줄이라 자동 줄바꿈에 맡기면 `마감되었어요 주최자가` / `리포트를…`처럼 어중간하게 끊깁니다.

`not-found.tsx`를 같이 바꾼 건 **첫 사용처**라서입니다. 안 바꾸면 똑같은 카드가 두 벌 남습니다. 카드 12줄이 한 줄이 됐습니다.

## `결과 리포트 보기`는 버튼이 아니라 링크입니다

조건 없이 `/e/{code}/report`로 갑니다. 클릭 전에 목적지가 정해져 있으니 `<a>`가 맞습니다.

```text
소감 남기기        POST가 성공해야 이동. 목적지가 결과에 달려 있음   → 버튼
결과 리포트 보기   무조건 그 주소로                                → 링크
```

`<button onClick={router.push}>`로 만들면 새 탭 열기·주소 복사·prefetch가 사라지고 스크린리더가 "링크"로 안 읽습니다. **겉보기엔 똑같이 동작해서 테스트로도 안 잡힙니다.** `page.tsx`가 서버 컴포넌트라 `'use client'` 파일이 하나 더 늘기도 합니다.

그런데 `<a>` 안에는 `<button>`을 넣을 수 없습니다(HTML 콘텐츠 모델에서 interactive content 제외). 그래서 요소는 링크로 두고 모양만 가져다 씁니다.

```tsx
<Link href={`/e/${code}/report`} className={buttonStyle('primary', 'lg')}>
  결과 리포트 보기
</Link>
```

`Button` 안에서 만들던 문자열을 함수로 뺐을 뿐이라 **`Button`의 동작·모양·API는 그대로입니다.**

`as` prop으로 폴리모픽하게 만드는 방법도 있었는데 제네릭 타입이 복잡해지고 `type="button"` 기본값이 `<a>`로 새는 것도 막아야 합니다. 버튼 모양 링크가 서넛 나올 프로젝트에 감당할 복잡도가 아니라고 봤습니다. 사용처가 늘면 `LinkButton` 래퍼를 두겠습니다.

## 여백을 시안에 맞췄습니다

```diff
- <main className="flex flex-col gap-6 p-5">
+ <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
```

시안이 상하 16 좌우 20인데 코드가 사방 20이었습니다.

`max-w-md`는 **`layout.tsx` 헤더가 이미 쓰고 있어서** 넣었습니다. 안 넣으면 넓은 화면에서 로고만 가운데 오고 본문은 화면 끝까지 늘어납니다. `not-found.tsx`도 같습니다. `/live`는 이미 들어가 있고 `/report`는 담당자 몫이라, 이 PR로 참가자 화면 셋이 맞습니다.

설명 줄은 폼이 뜰 때만 보여줍니다. 상태 화면 셋은 시안에서 이벤트명까지만 있습니다 — 카드가 주인공이라 설명까지 넣으면 길어집니다.

## 관련 이슈

Closes #88

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.6s
✓ Finished TypeScript in 4.0s
✓ Collecting page data using 11 workers in 930ms
✓ Generating static pages using 11 workers (9/9) in 305ms
✓ Finalizing page optimization in 25ms
```

`npm run test`

```text
 ✓ lib/storage/submitted.test.ts (10 tests) 8ms
 ✓ lib/api/endpoints.test.ts (6 tests) 73ms
 ✓ mocks/handlers.test.ts (54 tests) 180ms

 Test Files  3 passed (3)
      Tests  70 passed (70)
```

브라우저에서 393px로 확인했습니다.

```text
/e/ab3f9x     LIVE + 세션 있음      소감 입력 폼
/e/kd7m2p     ENDED + 리포트 공개   종료 안내 + [결과 리포트 보기]
/e/zq1v8t     DRAFT                 "지금은 소감을 받는 세션이 없어요"
/e/abcdef     EVENT_NOT_FOUND       "이벤트를 찾을 수 없어요"
```

**리포트 없음은 목 데이터에 없어서 임시로 만들어 확인했습니다.** `seedReports[0].isPublic`을 `false`로 바꾸고 dev 서버를 재시작했습니다.

```text
/e/kd7m2p     버튼 사라짐
              "소감 제출은 마감되었어요"
              "주최자가 리포트를 준비하면 여기에 표시돼요"
              두 줄로 끊김
```

`whitespace-pre-line`이 동작하는지 확인할 수 있는 유일한 지점입니다. **커밋에는 포함하지 않았습니다.**

`/e/{code}`는 서버 컴포넌트라 서버 쪽 MSW를 탑니다. `seed.ts`를 고치고 브라우저만 새로고침하면 모듈 캐시 때문에 반영되지 않아 dev 서버를 껐다 켜야 했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- **신규 컴포넌트 `EmptyState`** — `components/ui/README.md`에 등재
- **`Button`에 `buttonStyle` export 추가** — 기존 API·렌더 결과는 그대로
- 목 데이터·핸들러 변경 없음

## 범위 밖

- **`/e/{code}/report` 화면** — #89. 이 PR은 링크만 겁니다
- **`/report`의 `max-w-md`** — 담당자가 다릅니다. 참가자 화면 넷 중 셋이 맞았고 하나 남았습니다
- **`LinkButton` 래퍼** — 지금 사용처가 하나입니다. 서넛 넘어가면
- **"열린 세션 하나짜리" 목 데이터** — #80에서 남긴 논의. 이 PR과 무관하게 여전히 없습니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이라 개발 과정 로그에 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 종료된 이벤트에서 공개 리포트가 있으면 결과를 확인할 수 있습니다.
  - 이벤트 상태와 세션 조건에 따라 제출 가능 여부를 안내합니다.
  - 진행 중이 아니거나 제출할 수 없는 상태에는 빈 상태 화면을 표시합니다.
  - 이벤트 및 리포트가 없는 화면의 안내 UI를 일관된 형태로 개선했습니다.
  - 버튼 스타일을 링크에도 일관되게 적용할 수 있습니다.

- **문서**
  - 버튼 스타일 링크 사용법과 UI 관련 결정 사항을 문서에 추가했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->