### PR TITLE
fix(feedback): 제출 성공 시 제출 기록을 남기도록 연결

### DIFF
--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -12,6 +12,7 @@ import { Textarea } from '@/components/ui/Textarea';
 import type { SessionView } from '@/lib/schemas/api';
 import { submitFeedback } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
+import { markSubmitted } from '@/lib/storage/submitted';
 
 /**
  * 제출 실패 사유별 문구입니다.
@@ -49,7 +50,13 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
       }),
     // 보낸 값을 그대로 돌려받습니다. 여기서 selectedId를 다시 읽으면
     // 응답을 기다리는 사이 선택이 바뀌었을 때 저장된 세션과 이동할 세션이 어긋납니다.
+
     onSuccess: (_data, sessionId) => {
+      // 서버가 중복 제출을 막지 않아 프론트가 기록해야 합니다(#92).
+      // 이 줄이 없으면 /live가 읽을 기록이 영영 안 생겨서 접근 제어가
+      // 전부 차단으로 떨어집니다 — 소감을 내고 넘어가도 못 봅니다.
+      markSubmitted(eventCode, sessionId);
+
       router.push(`/e/${eventCode}/live?sessionId=${sessionId}`);
     },
   });


### PR DESCRIPTION
## 변경 사항

제출 성공 시 `markSubmitted`를 부르도록 연결했습니다.

- `components/feedback/FeedbackForm.tsx` — import 한 줄, 호출 한 줄

```diff
 onSuccess: (_data, sessionId) => {
+  markSubmitted(eventCode, sessionId);
+
   router.push(`/e/${eventCode}/live?sessionId=${sessionId}`);
 },
```

## 문제

`lib/storage/submitted.ts`를 **부르는 곳이 없었습니다.**

```text
markSubmitted    쓰는 곳 없음          ← 이 PR
hasSubmitted     app/e/[code]/live  (#54)
listSubmitted    app/e/[code]/live  (#54)
```

`/live`는 이 기록으로 열람 권한을 가릅니다. 기록을 남기는 코드가 없으니 항상 빈 값이고, **정상적으로 소감을 낸 사람에게도 차단 화면이 뜹니다.**

#93에서 모듈만 먼저 내고 후속을 잇지 않았습니다. 당시 PR 본문에 적어둔 그대로 남아 있었습니다.

> 호출부는 없습니다. 이 PR은 계약만 만듭니다.

## 에러가 안 나는 종류입니다

**기록이 없는 것과 기록을 안 남긴 것이 구분되지 않습니다.** 화면은 멀쩡하고 콘솔도 조용합니다.

#54를 받은 담당자 입장에서는 "시크릿 모드인가" 또는 "캐시를 지웠나" 하고 넘어가게 됩니다. `localStorage`를 쓰는 기능이라 그 추측이 자연스럽고, 그래서 더 오래 안 잡힙니다.

#92에서 이 모듈을 만든 이유가 **정확히 그런 조용한 실패를 막으려는 것**이었는데 같은 방식으로 어긋났습니다. 계약을 파일 하나로 묶어놓고 정작 한쪽 끝을 안 연결했습니다.

## `sessionId`를 인자로 받는 이유

`mutationFn`에 넘긴 값을 그대로 돌려받습니다.

```tsx
mutationFn: (sessionId: number) => submitFeedback(eventCode, { sessionId, … }),
onSuccess: (_data, sessionId) => { … },
```

여기서 `selectedId`를 다시 읽으면 **응답을 기다리는 사이 선택이 바뀌었을 때** 저장한 세션과 이동할 세션이 어긋납니다.

위에 있던 주석이 이미 그 이유를 적어두고 있었습니다.

> 보낸 값을 그대로 돌려받습니다. 여기서 selectedId를 다시 읽으면 응답을 기다리는 사이 선택이 바뀌었을 때 **저장된 세션과** 이동할 세션이 어긋납니다.

"저장된 세션"이라고 되어 있는데 저장하는 코드가 없어서 지금까지는 반만 맞는 말이었습니다.

## 저장 실패는 무시합니다

`markSubmitted`는 예외를 던지지 않습니다(#93). 시크릿 모드나 용량 초과면 조용히 넘어갑니다.

**제출은 이미 끝났기 때문입니다.** 여기서 던지면 성공한 제출이 실패처럼 보입니다. 기록이 사라지면 이미 낸 사람이 작성창을 다시 볼 뿐이고, 명세도 그래서 "안내만 한다"고 했습니다.

## 관련 이슈

Closes #103

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 4.4s
✓ Finished TypeScript in 4.0s
✓ Collecting page data using 11 workers in 1047ms
✓ Generating static pages using 11 workers (9/9) in 312ms
✓ Finalizing page optimization in 26ms
```

`npm run test`

```text
 ✓ lib/storage/submitted.test.ts (10 tests) 7ms
 ✓ lib/api/endpoints.test.ts (6 tests) 71ms
 ✓ mocks/handlers.test.ts (54 tests) 194ms

 Test Files  3 passed (3)
      Tests  70 passed (70)
```

`/e/ab3f9x`에서 두 세션에 소감을 남기고 `localStorage`를 확인했습니다.

```text
pulse:submitted:ab3f9x     [101,102]
```

같은 세션에 다시 내도 늘어나지 않습니다 — `markSubmitted`가 중복을 거릅니다.

**접근 제어가 실제로 풀리는지는 확인할 수 없습니다.** 지금 dev의 `/live`는 스텁이라 이 기록을 읽지 않습니다. #54가 머지된 뒤에 확인 가능합니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- **저장 형식 변경 없음** — #92에서 확정한 `pulse:submitted:{eventCode}` 그대로
- 제출 실패 경로는 그대로입니다. `onSuccess`에만 들어갑니다

## 범위 밖

- **칩에 제출 여부 표시(✓)** — `Chip`에 아이콘 슬롯을 넣는 디자인 시스템 변경이 먼저 필요합니다. 별도 이슈
- **`/live` 화면 구조** — #54
- **유한하지 않은 `sessionId` 가드** — #99에서 처리 중. `SessionView.id`는 `z.int()`를 통과한 값이라 이 호출부에서는 문제가 없습니다
- **오래된 기록 정리** — #92에서 미루기로 했습니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 피드백 제출이 완료되면 해당 세션이 브라우저에 저장됩니다.
  * 제출 후 관련 라이브 세션으로 자동 이동합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->