### PR TITLE
feat(event): 이벤트 목록 화면 구현

### DIFF
--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -1,6 +1,86 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchMyEvents } from '@/lib/api/endpoints';
+import EventCard from '@/components/events/EventCard';
+import useAuth from '@/hooks/useAuth';
+import { useMemo, useState } from 'react';
+import EventStatusFilterTabs, {
+  EventStatusFilter,
+} from '@/components/events/EventStatusFilterTabs';
+import { Header } from '@/components/layout/Header';
+import Link from 'next/link';
+import { Banner } from '@/components/ui/Banner';
+import EventListEmptyState from '@/components/events/EventListEmptyState';
+
 const EventsListPage = () => {
+  const [selectedTab, setSelectedTab] = useState<EventStatusFilter>('ALL');
+
   // API: GET/POST /events. "새 이벤트 만들기" 버튼은 /events/new로 이동합니다.
-  return <div>이벤트 목록 (준비 중)</div>;
+  const { user, logout } = useAuth();
+
+  const myEvents = useQuery({
+    queryKey: ['events', 'my'],
+    queryFn: fetchMyEvents,
+  });
+
+  const filteredEvents = useMemo(() => {
+    if (selectedTab === 'ALL') {
+      return myEvents.data ?? [];
+    }
+
+    return (myEvents.data ?? []).filter((event) => event.status === selectedTab);
+  }, [myEvents.data, selectedTab]);
+
+  let isEventsEmpty = false;
+  let isFilterEmpty = false;
+  let hasEvents = false;
+
+  if (myEvents.isSuccess) {
+    isEventsEmpty = myEvents.data.length === 0;
+    isFilterEmpty = myEvents.data.length > 0 && filteredEvents.length === 0;
+    hasEvents = filteredEvents.length > 0;
+  }
+
+  return (
+    <>
+      <Header email={user?.email ?? ''} onLogout={logout} />
+      <div className="px-20 py-8">
+        <div className="flex items-center justify-between gap-6">
+          <p className="text-xl font-semibold text-text-primary">내 이벤트</p>
+          <Link
+            href="/events/new"
+            className="inline-flex items-center justify-center gap-2.5 rounded-lg px-5 h-12 text-base font-semibold leading-6 bg-primary-darker text-text-inverse transition-colors hover:bg-primary-pressed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
+          >
+            + 새 이벤트
+          </Link>
+        </div>
+        {myEvents.isPending && <p>불러오는 중...</p>}
+        {myEvents.isError && <Banner type="negative">이벤트 목록을 불러오지 못했습니다.</Banner>}
+        {isEventsEmpty && (
+          <EventListEmptyState
+            title="아직 만든 이벤트가 없어요"
+            description="첫 이벤트를 만들고 참가자에게 링크를 공유해보세요"
+          />
+        )}
+        {isFilterEmpty && (
+          <EventListEmptyState
+            title="이 상태의 이벤트가 없어요"
+            description="다른 탭을 선택해보세요"
+          />
+        )}
+        {hasEvents && (
+          <>
+            <EventStatusFilterTabs selectedStatus={selectedTab} onChange={setSelectedTab} />
+            {filteredEvents.map((event) => (
+              <EventCard key={event.id} event={event} />
+            ))}
+          </>
+        )}
+      </div>
+    </>
+  );
 };
 
 export default EventsListPage;

--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -46,7 +46,7 @@ const EventsListPage = () => {
   return (
     <>
       <Header email={user?.email ?? ''} onLogout={logout} />
-      <div className="px-20 py-8">
+      <div className="flex flex-col gap-6 px-20 py-8">
         <div className="flex items-center justify-between gap-6">
           <p className="text-xl font-semibold text-text-primary">내 이벤트</p>
           <Link
@@ -64,6 +64,9 @@ const EventsListPage = () => {
             description="첫 이벤트를 만들고 참가자에게 링크를 공유해보세요"
           />
         )}
+        {myEvents.isSuccess && !isEventsEmpty && (
+          <EventStatusFilterTabs selectedStatus={selectedTab} onChange={setSelectedTab} />
+        )}
         {isFilterEmpty && (
           <EventListEmptyState
             title="이 상태의 이벤트가 없어요"
@@ -71,12 +74,11 @@ const EventsListPage = () => {
           />
         )}
         {hasEvents && (
-          <>
-            <EventStatusFilterTabs selectedStatus={selectedTab} onChange={setSelectedTab} />
+          <div className="flex flex-col gap-3">
             {filteredEvents.map((event) => (
               <EventCard key={event.id} event={event} />
             ))}
-          </>
+          </div>
         )}
       </div>
     </>

--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -13,6 +13,7 @@ import { Header } from '@/components/layout/Header';
 import Link from 'next/link';
 import { Banner } from '@/components/ui/Banner';
 import EventListEmptyState from '@/components/events/EventListEmptyState';
+import { buttonStyle } from '@/components/ui/Button';
 
 const EventsListPage = () => {
   const [selectedTab, setSelectedTab] = useState<EventStatusFilter>('ALL');
@@ -49,10 +50,7 @@ const EventsListPage = () => {
       <div className="flex flex-col gap-6 px-20 py-8">
         <div className="flex items-center justify-between gap-6">
           <p className="text-xl font-semibold text-text-primary">내 이벤트</p>
-          <Link
-            href="/events/new"
-            className="inline-flex items-center justify-center gap-2.5 rounded-lg px-5 h-12 text-base font-semibold leading-6 bg-primary-darker text-text-inverse transition-colors hover:bg-primary-pressed focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
-          >
+          <Link href="/events/new" className={buttonStyle('primary', 'md')}>
             + 새 이벤트
           </Link>
         </div>

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -1,0 +1,70 @@
+import { PulseEvent } from '@/lib/schemas/api';
+import { Badge } from '@/components/ui/Badge';
+import { ChevronRightIcon } from '@/components/ui/icons';
+import Link from 'next/link';
+import formatEventDate from '@/lib/formatEventDate';
+
+export interface EventCardProps {
+  event: PulseEvent;
+}
+
+const TONE_BY_STATUS: Record<
+  'LIVE' | 'DRAFT' | 'ENDED',
+  { tone: 'positive' | 'neutral' | 'outline'; label: string }
+> = {
+  LIVE: { tone: 'positive', label: 'LIVE' },
+  DRAFT: { tone: 'neutral', label: 'DRAFT' },
+  ENDED: { tone: 'outline', label: 'ENDED' },
+};
+
+const RIGHT_CONTENT_BY_STATUS = {
+  LIVE: (event: PulseEvent) => ({
+    label: `pulse.app/e/${event.code}`,
+    className: 'text-xs text-primary-darker',
+  }),
+  ENDED: () => ({
+    label: '리포트 공개됨',
+    className: 'text-xs text-text-secondary',
+  }),
+  DRAFT: () => ({ label: '', className: '' }),
+};
+
+const ROUTE_BY_STATUS = {
+  DRAFT: (event: PulseEvent) => `/events/${event.code}`,
+  LIVE: (event: PulseEvent) => `/events/${event.code}/dashboard`,
+  ENDED: (event: PulseEvent) => `/events/${event.code}/dashboard`,
+};
+
+const EventCard = ({ event }: EventCardProps) => {
+  if (event.status === 'DELETED') return;
+
+  const { tone, label } = TONE_BY_STATUS[event.status];
+
+  // TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가 추가되면 해당 날짜로 사용해야 함.
+  const datetime = formatEventDate(event.createdAt);
+  const rightContent = RIGHT_CONTENT_BY_STATUS[event.status](event);
+  const href = ROUTE_BY_STATUS[event.status](event);
+
+  return (
+    <Link
+      href={href}
+      className=" h-22.5 flex items-center justify-between p-4 rounded-xl border border-border-subtle"
+    >
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <Badge tone={tone}>{label}</Badge>
+          <span className="text-xs text-text-tertiary">
+            {event.status === 'DRAFT' ? '미공개' : datetime}
+          </span>
+        </div>
+        <p className="text-lg text-text-primary">{event.title}</p>
+      </div>
+      <div className="flex items-center gap-2">
+        <p className={rightContent.className}>{rightContent.label}</p>
+        <ChevronRightIcon className="h-4.5 w-4.5 text-text-primary" />
+      </div>
+    </Link>
+  );
+};
+
+export default EventCard;

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -48,7 +48,7 @@ const EventCard = ({ event }: EventCardProps) => {
   return (
     <Link
       href={href}
-      className=" h-22.5 flex items-center justify-between p-4 rounded-xl border border-border-subtle"
+      className="flex items-center justify-between p-4 rounded-xl border border-border-subtle"
     >
       <div className="flex flex-col gap-1">
         <div className="flex items-center gap-2">

--- a/components/events/EventListEmptyState.tsx
+++ b/components/events/EventListEmptyState.tsx
@@ -1,0 +1,22 @@
+import { InfoIcon } from '@/components/ui/icons';
+
+export interface EventListEmptyStateProps {
+  title: string;
+  description: string;
+}
+
+const EventListEmptyState = ({ title, description }: EventListEmptyStateProps) => {
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border border-dashed border-border-strong px-10 py-5 text-center">
+      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-background-muted">
+        <InfoIcon className="h-6 w-6 text-text-tertiary" />
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-base font-medium leading-6 text-text-primary">{title}</p>
+        <p className="text-sm font-normal leading-5 text-text-secondary">{description}</p>
+      </div>
+    </div>
+  );
+};
+
+export default EventListEmptyState;

--- a/components/events/EventStatusFilterTabs.tsx
+++ b/components/events/EventStatusFilterTabs.tsx
@@ -3,10 +3,10 @@ import { Chip } from '@/components/ui/Chip';
 
 export type EventStatusFilter = EventStatus | 'ALL';
 
-export type EventStatusFilterTabsProps = {
+export interface EventStatusFilterTabsProps {
   selectedStatus: EventStatusFilter;
   onChange: (status: EventStatusFilter) => void;
-};
+}
 
 const TABS: { label: string; value: EventStatusFilter }[] = [
   { label: '전체', value: 'ALL' },
@@ -22,7 +22,7 @@ const EventStatusFilterTabs = ({ selectedStatus, onChange }: EventStatusFilterTa
   // 상태를 직접 들고 있지 않고, 부모(page.tsx)가 상태를 관리하며, 이 컴포넌트는 보여주기만 한다.
 
   return (
-    <>
+    <div className="flex gap-2">
       {TABS.map((tab) => (
         <Chip
           key={tab.label}
@@ -32,7 +32,7 @@ const EventStatusFilterTabs = ({ selectedStatus, onChange }: EventStatusFilterTa
           {tab.label}
         </Chip>
       ))}
-    </>
+    </div>
   );
 };
 

--- a/components/events/EventStatusFilterTabs.tsx
+++ b/components/events/EventStatusFilterTabs.tsx
@@ -1,0 +1,39 @@
+import { EventStatus } from '@/lib/schemas/api';
+import { Chip } from '@/components/ui/Chip';
+
+export type EventStatusFilter = EventStatus | 'ALL';
+
+export type EventStatusFilterTabsProps = {
+  selectedStatus: EventStatusFilter;
+  onChange: (status: EventStatusFilter) => void;
+};
+
+const TABS: { label: string; value: EventStatusFilter }[] = [
+  { label: '전체', value: 'ALL' },
+  { label: 'DRAFT', value: 'DRAFT' },
+  { label: 'LIVE', value: 'LIVE' },
+  { label: 'ENDED', value: 'ENDED' },
+];
+
+const EventStatusFilterTabs = ({ selectedStatus, onChange }: EventStatusFilterTabsProps) => {
+  // 지금 선택된 탭이 뭔지(selectedStatus)와
+  // 사용자가 다른 탭을 눌렀을 때 부모에게 알리는 콜백(onChange)만 props로 받는
+  // 순수 표시용 컴포넌트이다.
+  // 상태를 직접 들고 있지 않고, 부모(page.tsx)가 상태를 관리하며, 이 컴포넌트는 보여주기만 한다.
+
+  return (
+    <>
+      {TABS.map((tab) => (
+        <Chip
+          key={tab.label}
+          selected={tab.value === selectedStatus}
+          onClick={() => onChange(tab.value)}
+        >
+          {tab.label}
+        </Chip>
+      ))}
+    </>
+  );
+};
+
+export default EventStatusFilterTabs;

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -35,5 +35,17 @@ const InfoIcon = (props: IconProps) => (
   </svg>
 );
 
-export { AlertIcon, CheckIcon, InfoIcon, XIcon };
+const ChevronRightIcon = (props: IconProps) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true" {...props}>
+    <path
+      d="M6.75 4.5L11.25 9L6.75 13.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export { AlertIcon, CheckIcon, InfoIcon, XIcon, ChevronRightIcon };
 export type { IconProps };

--- a/lib/formatEventDate.ts
+++ b/lib/formatEventDate.ts
@@ -1,0 +1,11 @@
+const formatEventDate = (isoString: string) => {
+  const eventDate = new Date(isoString);
+
+  const year = eventDate.getFullYear();
+  const month = eventDate.getMonth() + 1;
+  const day = eventDate.getDate();
+
+  return `${year}. ${month.toString().padStart(2, '0')}. ${day.toString().padStart(2, '0')}`;
+};
+
+export default formatEventDate;


### PR DESCRIPTION
## 변경 사항

이슈 #94(이벤트 목록 화면)를 구현합니다.  
로그인한 주최자가 자기 이벤트를 목록으로 보고, 상태별로 필터링하고, 카드를 눌러 알맞은 화면으로 이동할 수 있습니다.

- 새로 만든 컴포넌트는 3개입니다.
  - `EventStatusFilterTabs`: 상태 필터 탭입니다. 이미 구현되어 있는 `Chip`을 재사용합니다.
  - `EventListEmptyState`: 빈 상태 카드입니다.
  - `EventCard`: 이벤트 카드 한 장입니다.
- **`app/(host)/events/page.tsx`** 는 스켈레톤이었던 화면을 실제 데이터 연동 화면으로 교체합니다.
  - AS-IS: 지금은 "이벤트 목록 (준비 중)"이라는 문구만 있는 스켈레톤 상태입니다.
  - TO-BE: `useAuth`+`useQuery`로 실제 이벤트 목록을 가져와, 로딩·에러·빈 상태(이벤트 없음)·빈 상태(필터 결과 없음)·목록 다섯 가지 화면을 조립합니다.

## 개발 과정 로그 (커밋 순서, 오래된 순)

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| 5eab798 | feat(event): 이벤트 상태 필터 탭 컴포넌트 추가 | 전체·DRAFT·LIVE·ENDED 4개 탭입니다. 이미 구현되어 있는 `Chip`(선택 여부를 표시하는 공용 버튼 컴포넌트)을 재사용했습니다. |
| 51feb0e | feat(event): 이벤트 목록 빈 상태 카드 컴포넌트 추가 | 아이콘·제목·부제 구조입니다. 문구를 props로 받아 "이벤트 자체 없음"·"필터 결과 없음" 두 시나리오에서 재사용합니다. |
| 83f27e7 | feat(event): 이벤트 카드 컴포넌트 추가 | 이벤트 상태(LIVE·DRAFT·ENDED)에 따라 배지·오른쪽 정보·클릭 시 이동 경로가 전부 달라집니다. |
| 46efa17 | feat(event): 이벤트 목록 화면 데이터 연동 | 위 세 컴포넌트를 `useAuth`+`useQuery`로 가져온 실제 데이터와 조립합니다. |
| 9bb86fa | fix(event): 코드래빗 리뷰 반영 및 이벤트 목록 레이아웃 간격 조정 | CodeRabbit 리뷰에서 지적한 3건(상태 탭 노출 버그, 카드 고정 높이, props 타입 선언 방식)을 반영했습니다. 목록 영역의 세로·가로 간격도 함께 다듬었습니다. |
| e1e9581 | fix(event): 새 이벤트 버튼에 buttonStyle 적용 | 윤지님 리뷰 반영입니다. "+ 새 이벤트" 버튼의 스타일을 클래스 문자열로 직접 옮겨 적으면 `Button`이 나중에 바뀔 때 이 버튼은 따라가지 않는 문제가 있어, dev에 이미 머지되어 있는 `buttonStyle` 함수를 재사용하도록 바꿨습니다. |

## 관련 이슈

- Closes #94

## 검증 방법

### 정상적으로 동작하는 경우

- 시드 계정(`host@example.com`)으로 로그인한 뒤 `/events`에 접속했습니다.  
  이벤트 3개(LIVE·DRAFT·ENDED)가 각각 배지·날짜·오른쪽 표시(참가 링크/리포트 공개됨/미공개)까지 다르게 렌더링되는 걸 확인했습니다.
> <img width="800" alt="pulse-myEvents-all" src="https://github.com/user-attachments/assets/66f5b1a0-6950-4205-baf4-120ebc341595" />

- 상태 필터 탭(예: DRAFT)을 눌렀습니다.  
  해당 상태의 이벤트만 남도록 필터링되는 걸 확인했습니다.

> <img width="800" alt="pulse-myEvents-draft" src="https://github.com/user-attachments/assets/d2f0bf41-5a45-4bb8-afaa-99f245cd5666" />

- DRAFT 카드를 눌렀습니다.  
  `/events/{eventCode}`(수정 폼)로 이동하는 걸 확인했습니다.
 
> <img width="800" alt="DRAFT 카드 클릭" src="https://github.com/user-attachments/assets/a7146687-66ab-4c6a-aacb-2a7e9c584e3e" />

- LIVE·ENDED 카드를 눌렀습니다.  
  `/events/{eventCode}/dashboard`(대시보드)로 이동하는 걸 확인했습니다. 두 목적지 화면은 아직 실제 구현이 개발되지 않은 상태(각각 "준비 중" 스켈레톤)라, 경로 이동 자체만 확인했습니다.

> <img width="1978" height="1178" alt="LIVE 카드 클릭" src="https://github.com/user-attachments/assets/5198b889-c2ee-4c85-a0d8-f3ad36ce1d64" />

### 실패하는 경우

- `GET /events` 요청이 실패하는 상황을 재현했습니다.  
  `Banner`(`type="negative"`)로 "이벤트 목록을 불러오지 못했습니다" 문구가 뜨는 걸 확인했습니다. 새 계정으로 테스트하던 중 인증이 실패하는 상황이 재현되면서 우연히 같이 확인됐습니다.

> <img width="1754" height="533" alt="pulse-myEvents-error" src="https://github.com/user-attachments/assets/0bce5f8c-11d7-47df-87d0-ccd3fd382ab6" />

- `npx tsc --noEmit`: 에러 없음
- `npm run lint`: 경고·에러 없음

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**`Badge`(공용 배지 컴포넌트)에 ENDED 상태에 맞는 톤이 없어서 `outline`으로 대체했습니다.**  
이렇게 결정한 이유는 Figma 시안이 ENDED 배지를 Primary 파란 계열로 그렸지만, `Badge`의 `tone`이 `positive`·`neutral`·`negative`·`toxic`·`outline` 5가지뿐이라 해당하는 톤이 없었기 때문입니다. 추후 `Badge`에 `primary` 톤 추가를 고려해야 합니다.

**"+ 새 이벤트" 버튼은 `Button` 컴포넌트가 아니라 같은 스타일을 입힌 `Link`로 구현했습니다.**  
이렇게 결정한 이유는 이 버튼이 `/events/new`로 페이지 이동을 해야 하는데 `Button`은 `<button>` 태그로 되어 있어 페이지 이동 기능이 없고, `Link`(`<a>` 태그) 안에 `Button`(`<button>`)을 중첩하면 클릭 가능한 요소가 겹쳐 HTML 규격에 어긋나기 때문입니다.

- AS-IS: 처음 커밋에서는 `Button`의 스타일 클래스 문자열을 `Link`의 `className`에 직접 옮겨 적었습니다.
- TO-BE: 윤지님 리뷰를 반영해, dev에 이미 머지되어 있는 `buttonStyle`(`Button` 컴포넌트에서 스타일 클래스만 뽑아 반환하는 함수, `components/ui/Button.tsx`에서 export)을 재사용하도록 바꿨습니다. `Button`의 스타일이 나중에 바뀌어도 이 링크가 자동으로 따라가게 됩니다. `buttonStyle`은 PR #88(1차 export)·PR #102(첫 실사용 사례)를 거쳐 dev에 먼저 반영되어 있었습니다.

**로그인 페이지(`app/(host)/login/page.tsx`)가 아직 `useAuth`와 연동되어 있지 않아서, 로그인 화면으로는 인증 상태를 만들 수 없었습니다.**  
그래서 브라우저 콘솔에서 MSW(API를 흉내 내는 목 서버)가 가로채는 `POST /auth/login`을 직접 `fetch`로 호출해 인증 쿠키만 만든 뒤 `/events`로 이동하는 방식으로 확인했습니다. 로그인 페이지 코드는 건드리지 않았습니다.

**"이벤트 자체가 없음" 빈 상태는 확인하지 못했습니다.**  
새 계정으로 회원가입까지는 됐지만, 그 계정의 인증 쿠키가 페이지 새로고침을 넘기지 못하고 401로 풀리는 MSW 목 환경 특유의 문제가 있었습니다. 로그인 페이지가 `useAuth`와 연동되면 정식 플로우로 재확인이 필요합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
- 이벤트 목록에서 이벤트를 조회하고 상태별로 필터링할 수 있습니다.
- 이벤트 생성, 상세 페이지 및 대시보드로 이동할 수 있습니다.
- 이벤트 상태, 생성일, 공개 여부를 카드 형태로 확인할 수 있습니다.
- 로딩, 오류, 이벤트 없음 및 필터 결과 없음 상태를 안내합니다.
- 로그인 사용자 정보 표시와 로그아웃 기능을 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



