### PR TITLE
fix(ui): Button과 Chip에 pointer 커서 추가

### DIFF
--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -14,6 +14,7 @@ const BASE = [
   'text-base font-semibold leading-6',
   'transition-colors',
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker',
+  'cursor-pointer',
   'disabled:cursor-not-allowed disabled:border-transparent',
   'disabled:bg-neutral-subtle disabled:text-text-disabled',
 ].join(' ');

--- a/components/ui/Chip.tsx
+++ b/components/ui/Chip.tsx
@@ -10,6 +10,7 @@ const BASE = [
   'text-sm leading-5',
   'transition-colors',
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker',
+  'cursor-pointer',
   'disabled:cursor-not-allowed disabled:border-border-subtle',
   'disabled:bg-background-muted disabled:font-normal disabled:text-text-disabled',
 ].join(' ');

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -157,10 +157,11 @@ import { Button } from '@/components/ui/Button';
 
 ### Figma → 코드
 
-| Figma variant    | 코드                               |
-| ---------------- | ---------------------------------- |
-| `state=default`  | 기본값                             |
-| `state=selected` | **`selected` prop** — variant 아님 |
+| Figma variant    | 코드                                |
+| ---------------- | ----------------------------------- |
+| `state=default`  | 기본값                              |
+| `state=selected` | **`selected` prop** — variant 아님  |
+| `icon=true`      | **`children`에 아이콘** — prop 없음 |
 
 값이 둘뿐이고 켜고 끄는 성격이라 `variant="selected"`보다 `selected` 불리언이 자연스럽습니다.
 `<Chip selected={filter === 'A'}>`처럼 상태와 바로 연결됩니다.
@@ -205,12 +206,31 @@ focus는 Button과 같습니다. `focus-visible:outline-2 focus-visible:outline-
 
 ```tsx
 import { Chip } from '@/components/ui/Chip';
+import { CheckIcon } from '@/components/ui/icons';
 
 <Chip selected={sessionId === 'A'} onClick={() => handleSelect('A')}>
   세션 A
 </Chip>
 <Chip disabled>세션 C</Chip>
+
+<Chip>
+  <CheckIcon />
+  <span className="sr-only">소감을 남긴 세션, </span>
+  세션 B
+</Chip>
 ```
+
+아이콘은 prop이 아니라 `children`으로 넣습니다. `inline-flex`와 `gap-2.5`가 이미 있어서
+간격이 붙고, 아이콘이 `currentColor`를 쓰면 상태별 글자색을 그대로 따라옵니다.
+
+**`sr-only` 문구가 필요합니다.** 아이콘에 `aria-hidden="true"`가 붙어 있어 스크린리더에는
+✓의 의미가 전달되지 않습니다. `sr-only`는 `position: absolute`라 flex 아이템에서 빠지므로
+간격이 늘어나지 않습니다.
+
+아이콘이 없는 칩은 자식이 하나뿐이라 `gap`이 적용될 자리가 없습니다. 너비를 억지로
+맞추지 마세요 — Figma에서 Boolean을 `false`로 두면 자리까지 사라지는 것과 같습니다.
+
+````
 
 ---
 
@@ -250,7 +270,7 @@ Banner가 사라지는 방식은 세 가지입니다.
 {
   isFailed && <Banner type="negative">등록에 실패했어요</Banner>;
 }
-```
+````
 
 닫는 것은 코드가 합니다. 공지형은 아직 없습니다. 필요해지면 그때 `onClose` prop을 추가하세요.
 
@@ -777,6 +797,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 ## 결정 기록
 
+- 2026.08.11 (#106) — `Button`·`Chip`에 `cursor-pointer` 추가. 비활성 커서만 정하고 기본 커서를 안 정해서, `<button>`의 브라우저 기본값인 `default`가 그대로 나왔음. #54가 화면에서 `className="cursor-pointer"`로 덧대고 있었는데 `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없어 컴포넌트로 올림. 칩 아이콘은 새 prop 없이 `children`으로 넣기로 함 — `gap-2.5`가 이미 있어 간격이 붙고, Figma의 `icon` Boolean과 대응됨
 - 2026.08.11 (#96) — `Text/tertiary` 토큰 값을 `#888780`에서 `#77766f`로 교체. 흰 배경 3.61:1 → 4.56:1로 12px 텍스트 AA를 넘김. 위 항목들의 3.13:1·3.61:1은 변경 전 값 기준임
 - 2026.08.10 (#75) — Banner 테두리를 점선으로 수정. #70에서 실선으로 만든 건 Figma JSON 추출 결과에 선 종류가 담기지 않아 확인 없이 가정한 실수였음. 기능적 이유는 없고 시안 그대로임 — 다른 컴포넌트는 실선이라 Banner만 예외이고, 실수가 아니니 통일하지 말 것
 - 2026.08.10 — Banner에 `info` 톤 추가. 참가자 소감 입력 화면의 안내 문구가 Banner와 생김새가 같아서 별도 컴포넌트(`Hint`) 대신 톤으로 편입함


### PR DESCRIPTION
## 변경 사항

`Button`과 `Chip` 위에서 커서가 손 모양으로 바뀝니다.

- `components/ui/Button.tsx` — `cursor-pointer` 한 줄
- `components/ui/Chip.tsx` — `cursor-pointer` 한 줄
- `components/ui/README.md` — 칩 아이콘 사용 규칙, 결정 기록

```diff
   'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker',
+  'cursor-pointer',
   'disabled:cursor-not-allowed …',
```

## 문제

두 컴포넌트 모두 **비활성 커서만 정하고 기본 커서를 안 정했습니다.**

```ts
// Button.tsx:17
'disabled:cursor-not-allowed disabled:border-transparent',

// Chip.tsx:13
'disabled:cursor-not-allowed disabled:border-border-subtle',
```

`<button>`의 브라우저 기본값은 `cursor: default`입니다. `<a href>`와 달리 pointer가 아니고, Tailwind preflight도 이 값을 건드리지 않습니다.

## 화면에서 이미 우회하고 있었습니다

#54가 `/live`에서 두 곳에 덧대고 있습니다.

```tsx
<Chip className="cursor-pointer" … />
```

주석의 근거는 이렇습니다.

> `cursor-pointer`는 `Chip`에 없어서 여기서 붙입니다. 공용 컴포넌트를 고치면 이 화면 밖 커서까지 바뀌어서 실시간 결과 화면 안에서만 처리했습니다.

**"화면 밖 커서까지 바뀐다"가 원하는 동작입니다.** `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없습니다. 지금은 `/live` 칩만 손 모양이고 `/e/{code}` 칩은 화살표라, **같은 컴포넌트가 화면마다 다르게 동작합니다.**

## 위치

`disabled:cursor-not-allowed` **바로 위**에 뒀습니다. 커서 규칙 둘이 붙어 있어야 비활성일 때 어떻게 되는지 같이 보입니다.

**문자열 순서는 동작에 영향이 없습니다.** Tailwind가 `disabled:` 변형을 기본 유틸리티보다 뒤에 내보내서, 비활성일 때는 `not-allowed`가 이깁니다.

## 칩 아이콘은 새 prop을 안 만듭니다

시안 `Chip` 마스터에 `icon` Boolean이 있습니다. 제출한 세션에 ✓를 붙이려고 만든 건데, 코드에는 prop이 필요 없습니다.

```tsx
<Chip>
  <CheckIcon />
  <span className="sr-only">소감을 남긴 세션, </span>
  세션 B
</Chip>
```

`Chip`이 이미 `inline-flex … gap-2.5`를 갖고 있어 간격이 붙고, `CheckIcon`이 `currentColor`를 써서 상태별 글자색을 따라옵니다. **`selected`·`disabled` 조합에 축을 하나 더 얹지 않아도 됩니다.**

`sr-only` 문구는 필수입니다. `CheckIcon`에 `aria-hidden="true"`가 붙어 있어 **스크린리더에는 ✓의 의미가 전달되지 않습니다.** 색과 모양으로만 구분하면 WCAG 1.4.1에도 걸립니다.

`sr-only`는 `position: absolute`라 flex 아이템에서 빠지므로 간격이 늘어나지 않습니다.

아이콘이 없는 칩은 자식이 하나뿐이라 `gap`이 적용될 자리가 없습니다. **너비를 억지로 맞출 필요가 없습니다** — Figma에서 Boolean을 `false`로 두면 자리까지 사라지는 것과 같습니다.

## 관련 이슈

Closes #106

## 검증 방법

`npm run lint`

```text
> pulse-frontend@0.1.0 lint
> eslint
```

`npm run build`

```text
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 3.9s
✓ Finished TypeScript in 4.6s
✓ Collecting page data using 11 workers in 959ms
✓ Generating static pages using 11 workers (9/9) in 312ms
✓ Finalizing page optimization in 25ms
```

`npm run test`

```text
 ✓ lib/storage/submitted.test.ts (10 tests) 9ms
 ✓ lib/api/endpoints.test.ts (6 tests) 73ms
 ✓ mocks/handlers.test.ts (54 tests) 206ms

 Test Files  3 passed (3)
      Tests  70 passed (70)
```

브라우저에서 확인했습니다.

```text
/e/ab3f9x   세션 칩 · 소감 남기기 버튼      손 모양
            3부: Q&A (disabled)           금지 표시
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- **API 변경 없음** — 클래스 한 줄씩입니다. 렌더 결과에서 커서만 바뀝니다
- **`Chip`에 새 prop 없음** — 아이콘은 `children`으로 넣습니다

## 범위 밖

- **`/live`의 `className="cursor-pointer"` 제거** — #54 담당자 몫입니다. 이 PR이 머지되면 필요 없어지지만, 남아 있어도 같은 값이라 문제는 없습니다
- **칩에 제출 여부를 반영하는 분기** — `FeedbackForm`에서 `listSubmitted`로 가르는 작업. #91이 같은 파일을 들고 있어 머지 후에 합니다
- **`Input`·`Textarea`의 커서** — 텍스트 입력은 `text` 커서가 맞습니다. 두 파일에도 `disabled:cursor-not-allowed`가 있지만 기본 커서를 정할 이유가 없습니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 버튼과 칩 UI에 마우스를 올렸을 때 클릭 가능한 요소임을 나타내는 포인터 커서가 적용되었습니다.

* **문서**
  * 칩 아이콘 사용법과 접근성 안내를 추가했습니다.
  * 버튼·칩의 상호작용 동작 및 예시를 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->