### PR TITLE
feat(auth): 로그인 페이지에 useAuth 연동

### DIFF
--- a/app/(host)/login/page.tsx
+++ b/app/(host)/login/page.tsx
@@ -5,19 +5,54 @@ import Link from 'next/link';
 import { Logo } from '@/components/brand/Logo';
 import { Field } from '@/components/ui/Field';
 import { Button } from '@/components/ui/Button';
-import { useState, type SubmitEvent } from 'react';
+import { useState, type SubmitEvent, ChangeEvent } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/hooks/useAuth';
+import { ApiError } from '@/lib/apiClient';
 
+type LoginInputs = {
+  email: string;
+  password: string;
+};
+
+const initialLoginInputs = {
+  email: '',
+  password: '',
+};
 const LoginPage = () => {
-  // API: POST /auth/login. useAuth() 훅과 라우트 가드는 실제 구현 시 연결합니다.
+  // API: POST /auth/login. useAuth() 훅 연결 완료. 라우트 가드는 별도 이슈에서 처리합니다.
   // 로그인 실패는 별도 라우트가 아니라 이 페이지 내부에서 처리합니다.
   // 401 응답(INVALID_CREDENTIALS)은 존재하지 않는 사용자와 비밀번호 불일치를 병합해서 내려주므로(API 명세서 확정),
   // 어느 필드가 틀렸는지는 표시하지 않습니다. 이메일·비밀번호 입력 필드 모두 invalid 스타일로 표시하고, 공통 에러 문구 하나만 보여줍니다.
   const [loginFailed, setLoginFailed] = useState(false);
+  const [loginFailedMessage, setLoginFailedMessage] = useState<string | null>(null);
+  const [loginInputs, setLoginInputs] = useState<LoginInputs>(initialLoginInputs);
 
-  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setLoginInputs((prev) => ({
+      ...prev,
+      [event.target.name]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
-    // TODO: useAuth 연동 후 실제 로그인 요청으로 교체해야 합니다. 지금은 항상 실패 상태를 보여줍니다.
-    setLoginFailed(true);
+
+    try {
+      await login(loginInputs.email, loginInputs.password);
+      router.push('/events');
+    } catch (error) {
+      setLoginFailed(true);
+
+      if (error instanceof ApiError && error.code === 'INVALID_CREDENTIALS') {
+        setLoginFailedMessage('이메일 또는 비밀번호가 올바르지 않습니다.');
+      } else {
+        setLoginFailedMessage('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
   };
 
   return (
@@ -31,6 +66,9 @@ const LoginPage = () => {
             type="email"
             placeholder="host@example.com"
             invalid={loginFailed}
+            onChange={handleChange}
+            name="email"
+            value={loginInputs.email}
           />
           <Field
             className="w-full"
@@ -38,13 +76,16 @@ const LoginPage = () => {
             type="password"
             placeholder="••••••••"
             invalid={loginFailed}
+            onChange={handleChange}
+            name="password"
+            value={loginInputs.password}
           />
           <p
             role="alert"
             aria-atomic="true"
             className={loginFailed ? 'text-xs text-negative-darker' : 'sr-only'}
           >
-            {loginFailed ? '이메일 또는 비밀번호가 올바르지 않습니다.' : null}
+            {loginFailed ? loginFailedMessage : null}
           </p>
           <Button type="submit" variant="primary" className="w-full">
             로그인

--- a/app/(host)/login/page.tsx
+++ b/app/(host)/login/page.tsx
@@ -40,6 +40,8 @@ const LoginPage = () => {
 
   const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setLoginFailed(false);
+    setLoginFailedMessage(null);
 
     try {
       await login(loginInputs.email, loginInputs.password);


### PR DESCRIPTION
## 변경 사항

로그인 페이지(`app/(host)/login/page.tsx`)에 `useAuth`(로그인 상태를 다루는 공통 훅, `hooks/useAuth.ts`)를 연동합니다.

- **AS-IS**
  `handleSubmit`(로그인 폼을 제출할 때 실행되는 함수)이 실제 서버 요청 없이, 제출하면 항상 실패 상태를 보여주는 임시 코드였습니다.
- **TO-BE**
  `useAuth().login`(실제로 로그인 요청을 서버에 보내는 함수)을 호출합니다.
  성공하면 이벤트 목록 화면(`/events`)으로 이동하고, 실패하면 에러 코드에 따라 다른 문구를 보여줍니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 4c5cf16 | feat(auth): 로그인 페이지에 useAuth 연동 | 로그인 폼을 `useAuth().login`에 연결하고, 성공·실패 시나리오를 처리했습니다. |
| c739b9d | fix(auth): 로그인 재시도 시 이전 실패 상태 초기화 | 코드래빗 리뷰에서 지적한, 재시도 중에도 이전 실패 문구·invalid 스타일이 남아 있던 문제를 수정했습니다. |

## 관련 이슈

- Closes #108

## 검증 방법

아래는 전부 이 PR을 반영한 뒤 기준입니다.

- `npx tsc --noEmit`·`npm run lint`·`npm run build`를 실행해 모두 통과를 확인했습니다.
- **로그인에 성공하는 경우**
  시드 계정(`host@example.com` / `pulse1234`)으로 브라우저에서 직접 로그인해 `/events`로 이동하는 것까지 확인했습니다.  
  콘솔에 `[MSW] POST /auth/login (200 OK)`가 찍혔습니다.
- **로그인에 실패하는 경우**
  `INVALID_CREDENTIALS`(자격 증명이 틀렸을 때 서버가 응답하는 에러 코드) 응답이면 기존 실패 문구("이메일 또는 비밀번호가 올바르지 않습니다.")를 보여줍니다.  
  그 외 에러(네트워크 오류 등)는 별도 fallback 문구("로그인에 실패했습니다. 잠시 후 다시 시도해주세요.")를 보여줍니다.
- **재시도하는 경우**
  한 번 실패한 뒤 입력값을 고쳐 다시 제출하면, 새 요청 결과가 오기 전까지 이전 실패 문구·invalid 스타일(입력창 테두리가 빨갛게 바뀌는 스타일)이 즉시 사라집니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

로그인 페이지를 새로고침한 직후, MSW 워커가 준비되기 전에 바로 제출하면 요청이 안 나갈 수 있습니다.  
"목 서버를 준비하고 있습니다…" 문구가 사라진 뒤 시도해야 합니다.

코드래빗이 이 PR에 액션 가능 코멘트 2건을 남겼습니다.  
재시도 시 이전 실패 상태 초기화(Minor) 건은 위 두 번째 커밋으로 반영했습니다.  
로그인 페이지 전체가 Client Component라는 지적(Major, SSR/SSG 경계 분리)은 이 PR 범위를 벗어나 이슈 #114 로 분리했습니다. 회원가입 페이지도 같은 구조라 함께 다룰 예정입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 페이지에서 이메일과 비밀번호를 입력해 실제 로그인을 수행할 수 있습니다.
  * 로그인에 성공하면 이벤트 페이지로 자동 이동합니다.

* **버그 수정**
  * 인증 실패 및 기타 오류 상황에 맞는 안내 메시지를 표시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
