### PR TITLE
feat(live): 열람할 수 없는 세션을 제출 화면으로 돌려보냄

### DIFF
--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useQuery } from '@tanstack/react-query';
-import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { redirect, useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { Thermometer } from '@/components/feedback/Thermometer';
@@ -74,8 +74,10 @@ const LiveResult = () => {
    * 숫자가 아닌 값은 `Number()`가 `NaN`으로 만들어서 어떤 세션과도 매칭되지 않습니다.
    */
   const requestedId = Number(searchParams.get('sessionId'));
-  const selectedSession = sessions?.find((session) => session.id === requestedId) ?? null;
-
+  const allowedSession =
+    sessions?.find(
+      (session) => session.id === requestedId && submitted?.has(session.id) === true,
+    ) ?? null;
   /*
    * 방금 소감을 내고 넘어온 경우에만 등록 안내를 띄웁니다. 제출 화면이 붙여주는 플래그입니다.
    *
@@ -88,10 +90,6 @@ const LiveResult = () => {
    * 기록에 없는 세션은 집계를 아예 부르지 않습니다. 화면만 가리고 요청은 그대로 내보내면
    * 쿼리를 손으로 고쳐서 남의 세션 수치를 받아볼 수 있습니다.
    */
-  const allowedSession =
-    selectedSession !== null && submitted?.has(selectedSession.id) === true
-      ? selectedSession
-      : null;
 
   const {
     snapshot,
@@ -115,37 +113,7 @@ const LiveResult = () => {
   }
 
   // `allowedSession`으로 분기해야 아래에서 `allowedSession.title`이 좁혀집니다.
-  if (allowedSession === null) {
-    return (
-      <div className="flex flex-col gap-6">
-        {/* 이벤트명과 사유 배너는 제목에 붙어야 해서 바깥 `gap-6`에서 빼고 따로 묶습니다. */}
-        <div className="flex flex-col gap-1">
-          <p className="text-xs font-normal leading-4 text-text-tertiary">{event.title}</p>
-          {/* 실재하는 세션이면 어느 순서를 못 여는지 제목으로 알려줍니다. 없는 id로 들어왔으면
-              가리킬 세션이 없어서 화면 이름으로 대신합니다. */}
-          <h1 className="text-xl font-semibold leading-7 text-text-primary">
-            {selectedSession?.title ?? '실시간 반응'}
-          </h1>
-          {/* 못 여는 이유가 두 갈래라 문구를 나눕니다. 실재하는 세션이면 소감을 남기는 순간
-            열리지만, 없는 세션을 가리키는 id라면 남겨도 열리지 않아 같은 말을 하면 안 됩니다. */}
-          {selectedSession !== null ? (
-            <Banner type="info">소감을 남긴 순서의 반응만 볼 수 있어요</Banner>
-          ) : (
-            <Banner type="warning">찾을 수 없는 순서예요</Banner>
-          )}
-        </div>
-
-        <Button
-          variant="secondary"
-          size="lg"
-          className="w-full cursor-pointer"
-          onClick={handleWriteAnother}
-        >
-          소감 남기러 가기
-        </Button>
-      </div>
-    );
-  }
+  if (allowedSession === null) redirect(`/e/${code}`);
 
   // 백분율은 계산하지 않습니다. `Thermometer`가 개수를 받아 직접 나눕니다.
   const { POS, NEU, NEG } = snapshot?.sentimentBreakdown ?? { POS: 0, NEU: 0, NEG: 0 };


### PR DESCRIPTION
## 변경 사항

- 유효하지 않은 `sessionId`로 `/e/{code}/live`에 들어오면 안내 배너를 띄우는 대신 `/e/{code}`로 돌려보냅니다. PR #54 리뷰 코멘트에서 확정된 규칙입니다.
- 차단 화면(`소감을 남긴 순서의 반응만 볼 수 있어요` / `찾을 수 없는 순서예요` 배너 + `소감 남기러 가기` 버튼)을 제거했습니다.
- 함께 없어진 `실시간 반응` 제목 — 같은 화면의 `지금 청중 반응`·`5초마다 자동으로 갱신돼요`와 같은 말을 세 번 하게 된다는 지적을 반영했습니다.
- `selectedSession` / `allowedSession` 이분화를 하나로 합쳤습니다. 둘로 나뉜 이유가 "실재하지만 못 봄"과 "없는 세션"에 다른 문구를 띄우기 위해서였는데, 이제 결말이 같습니다.

| 쿼리 | 이전 | 이후 |
| --- | --- | --- |
| 없음 / 빈 값 / 배열 | `/e/{code}` (서버) | 그대로 |
| `?sessionId=abc` | `찾을 수 없는 순서예요` 배너 | `/e/{code}` |
| `?sessionId=999` | `찾을 수 없는 순서예요` 배너 | `/e/{code}` |
| 다른 이벤트의 세션 id | `찾을 수 없는 순서예요` 배너 | `/e/{code}` |
| 소감 안 남긴 세션 id | `소감을 남긴 순서의 반응만 볼 수 있어요` 배너 | `/e/{code}` |

## 관련 이슈

- Closes #109
- Refs #54

## 검증 방법

```
npm run lint     통과 (출력 없음)
npm run build    통과, TypeScript 16.8s, 정적 페이지 9/9 생성
npm run test     3 files / 71 tests 통과
```

컴포넌트 테스트는 추가하지 않았습니다. 이 레포의 vitest 설정에 jsdom·testing-library가 없어서(`lib`·`mocks`만 대상) 테스트를 붙이려면 인프라 도입이 선행돼야 하고, 그건 이 PR의 목적과 다릅니다.

수동 확인은 위 표의 다섯 경우와 **소감을 남긴 세션 id로 정상 진입하는 경우**를 함께 봤습니다. 마지막 항목이 실질적인 회귀 테스트입니다 — 로딩 게이트를 `redirect`보다 뒤에 두면 로딩 첫 프레임에 `allowedSession`이 `null`이라 정상 사용자까지 전부 튕깁니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**숫자 검증을 서버에 두지 않은 이유** — `?sessionId=abc`는 URL만 보면 알 수 있어서 `app/e/[code]/live/page.tsx`에서 끊을 수도 있었습니다. 그렇게 하지 않은 건 `Number('1e2')`가 `100`이 되는 식의 구멍이 있어 별도 검증 로직이 필요한데, `Number('abc')`가 `NaN`이라 어차피 어떤 세션과도 매칭되지 않아 추가 코드 없이 나머지 세 경우와 같은 경로로 흘러가기 때문입니다. 리다이렉트 규칙이 한 곳에 모이는 이점이 서버에서 한 프레임 일찍 끊는 이점보다 크다고 봤습니다.

**`useEffect` + `router.replace`가 아니라 렌더 중 `redirect()`인 이유** — effect는 한 프레임 늦어 스켈레톤이 한 번 스칩니다. 그리고 `redirect()`는 기본 타입이 `replace`라(`next/dist/docs/01-app/03-api-reference/04-functions/redirect.md`) 뒤로가기로 잘못된 URL에 다시 들어가는 일이 없습니다. 클라이언트 컴포넌트에서 렌더 중 호출은 공식 지원됩니다(이벤트 핸들러에서는 불가).

**`allowedSession` 계산에 optional chaining이 남은 이유** — 로딩 게이트 뒤로 옮기면 `?.`를 없앨 수 있지만, `useFeedbackSnapshot`이 `allowedSession?.id`를 받기 때문에 훅 호출보다 위에 있어야 합니다. 그 시점엔 `sessions`가 `undefined`, `submitted`가 `null`일 수 있습니다.

**남은 리뷰 지적** — PR #54 코멘트 중 이 PR 범위 밖은 이슈로 분리했습니다.

- #110 여백·스켈레톤 (`LiveSkeleton`의 PageHeading 자리, content·키워드 박스 패딩)
- #111 제출 완료 배너의 일회성 신호 방식 (쿼리 vs sessionStorage) — 결정 대기
- 워드클라우드(순위 5단계 + `d3-cloud`)는 아직 이슈를 만들지 않았습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
  - 유효한 세션과 로컬 제출 기록이 있는 경우에만 해당 세션의 결과를 조회할 수 있습니다.
  - 허용되지 않은 세션 접근 시 안내 화면 대신 제출 화면으로 자동 이동합니다.
  - 결과 조회 시 승인된 세션 정보만 사용하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->