### PR TITLE
feat(dashboard): 주최자 실시간 모니터링 대시보드 구현

### DIFF
--- a/app/(host)/events/[eventCode]/dashboard/page.tsx
+++ b/app/(host)/events/[eventCode]/dashboard/page.tsx
@@ -1,14 +1,26 @@
+import { DashboardView } from '@/components/dashboard/DashboardView';
 import ModerationQueueModal from '@/components/moderation/ModerationQueueModal';
 
+/**
+ * 주최자 실시간 모니터링 대시보드입니다.
+ *
+ * 화면 전체가 클라이언트 아일랜드(`DashboardView`)입니다. CLAUDE.md가 대시보드를 CSR로
+ * 정해뒀고, 숫자·차트·피드가 전부 폴링 결과에서 나와서 서버가 미리 그릴 게 없습니다.
+ * `eventCode`도 아일랜드가 `useParams`로 직접 읽으므로 여기서 넘기지 않습니다.
+ *
+ * API: GET /admin/feedbacks?eventCode={eventCode}. 주최자 화면이라 공개 스냅샷
+ * (GET /events/{eventCode}/feedbacks)이 아니라 관리자 목록을 봅니다. 이유는
+ * `hooks/useDashboardFeed.ts`에 적어뒀습니다.
+ *
+ * 모더레이션 큐는 별도 라우트가 아니라 이 화면 위에 뜨는 모달입니다. 안쪽 구현과
+ * "전체보기" 연결은 별도 이슈입니다.
+ */
 const DashboardPage = () => {
-  // API: GET /events/{eventCode}/feedbacks. URL의 eventCode를 그대로 사용합니다.
-  // /live 화면과 같은 useLiveFeedback 훅을 재사용할 예정입니다.
-  // 모더레이션 큐는 별도 라우트가 아니라 "전체보기" 클릭 시 여는 모달입니다.
   return (
-    <div>
-      <p>실시간 모니터링 대시보드 (준비 중)</p>
+    <main className="flex flex-col gap-6 p-5 md:p-8">
+      <DashboardView />
       <ModerationQueueModal />
-    </div>
+    </main>
   );
 };
 

--- a/components/dashboard/DashboardSkeleton.tsx
+++ b/components/dashboard/DashboardSkeleton.tsx
@@ -1,0 +1,23 @@
+/**
+ * `DashboardView`의 로딩 자리표시자입니다.
+ *
+ * 첫 응답이 오기 전에 실제 화면을 그리면 집계가 전부 0으로 찍히는데, 소감이 진짜 0건인
+ * 이벤트와 화면상 구분이 안 됩니다. 그래서 수치 대신 회색 블록을 보여줍니다.
+ *
+ * 블록은 `aria-hidden`이지만 바깥 `role="status"`가 로딩 중이라는 사실을 알립니다.
+ * 전체를 가려버리면 스크린리더에서는 화면이 그냥 빈 것처럼 읽힙니다.
+ */
+const DashboardSkeleton = () => (
+  <div className="flex flex-col gap-4" role="status" aria-live="polite">
+    <span className="sr-only">대시보드를 불러오고 있어요</span>
+    <div aria-hidden="true" className="h-8 w-64 animate-pulse rounded-lg bg-background-muted" />
+    <div aria-hidden="true" className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {[0, 1, 2, 3].map((slot) => (
+        <div key={slot} className="h-20 animate-pulse rounded-lg bg-background-muted" />
+      ))}
+    </div>
+    <div aria-hidden="true" className="h-48 animate-pulse rounded-xl bg-background-muted" />
+  </div>
+);
+
+export { DashboardSkeleton };

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
 import {
@@ -23,21 +23,16 @@ import {
 } from '@/components/dashboard/metrics';
 import { Donut } from '@/components/feedback/Donut';
 import { FeedItem, type Sentiment as FeedItemSentiment } from '@/components/feedback/FeedItem';
+import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
 import { Chip } from '@/components/ui/Chip';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
-import { DASHBOARD_FEED_KEY, useDashboardFeed } from '@/hooks/useDashboardFeed';
-import { showToast } from '@/hooks/useToast';
-import {
-  deleteFeedback,
-  fetchMyEvents,
-  fetchSessionsByEventCode,
-  hideFeedback,
-  showFeedback,
-} from '@/lib/api/endpoints';
+import { useDashboardFeed } from '@/hooks/useDashboardFeed';
+import { useModerationActions } from '@/hooks/useModerationActions';
+import { fetchMyEvents, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import type { Feedback, Sentiment } from '@/lib/schemas/api';
 
@@ -51,9 +46,6 @@ import type { Feedback, Sentiment } from '@/lib/schemas/api';
  * 스냅샷을 쓰지 않는 이유는 `hooks/useDashboardFeed.ts`에 적어뒀습니다.
  */
 
-/** 모더레이션 큐 위젯이 미리 보여주는 건수입니다. 나머지는 "전체보기"로 넘깁니다. */
-const MODERATION_PREVIEW_LIMIT = 3;
-
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
 const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
 
@@ -66,7 +58,6 @@ const FEED_SENTIMENT: Record<Sentiment, FeedItemSentiment> = {
 
 const DashboardView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
-  const queryClient = useQueryClient();
 
   /** `null`이 "전체"입니다. 시안의 기본 선택값입니다. */
   const [sessionId, setSessionId] = useState<number | null>(null);
@@ -111,54 +102,10 @@ const DashboardView = () => {
     refreshIntervalMs,
   } = useDashboardFeed({ eventCode, sessionId });
 
-  const invalidateFeed = () => {
-    queryClient.invalidateQueries({ queryKey: [DASHBOARD_FEED_KEY] });
-  };
-
-  const hideMutation = useMutation({
-    mutationFn: hideFeedback,
-    onSuccess: () => {
-      invalidateFeed();
-      showToast('소감을 숨겼어요');
-    },
-  });
-
-  /*
-   * 숨김은 되돌릴 수 있는 상태입니다(요구사항 소감 상태 전이 4번). 종단 상태는 `DELETED`뿐이라,
-   * 숨긴 건은 큐에 남겨두고 같은 버튼으로 되돌립니다. 큐가 `includeHidden=true`로 받는 것도
-   * 이 되돌리기 때문입니다.
-   */
-  const showMutation = useMutation({
-    mutationFn: showFeedback,
-    onSuccess: () => {
-      invalidateFeed();
-      showToast('숨김을 해제했어요');
-    },
-  });
-
-  const deleteMutation = useMutation({
-    mutationFn: deleteFeedback,
-    onSuccess: () => {
-      invalidateFeed();
-      showToast('소감을 삭제했어요');
-    },
-  });
+  const moderation = useModerationActions();
 
   const handleSelectSession = (nextSessionId: number | null) => {
     setSessionId(nextSessionId);
-  };
-
-  const handleToggleHidden = (feedback: Feedback) => {
-    if (feedback.status === 'HIDDEN') {
-      showMutation.mutate(feedback.id);
-      return;
-    }
-
-    hideMutation.mutate(feedback.id);
-  };
-
-  const handleDelete = (feedbackId: number) => {
-    deleteMutation.mutate(feedbackId);
   };
 
   /*
@@ -261,9 +208,7 @@ const DashboardView = () => {
       </div>
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
-      {(hideMutation.isError || showMutation.isError || deleteMutation.isError) && (
-        <Banner type="negative">소감 처리에 실패했어요</Banner>
-      )}
+      {moderation.isError && <Banner type="negative">소감 처리에 실패했어요</Banner>}
 
       {isFeedPending ? (
         <DashboardSkeleton />
@@ -387,67 +332,12 @@ const DashboardView = () => {
             </section>
 
             <div className="flex flex-col gap-3">
-              <section className={CARD}>
-                <div className="flex items-center justify-between gap-2">
-                  <h2 className={CARD_TITLE}>모더레이션 큐</h2>
-                  <div className="flex items-center gap-2">
-                    <Badge tone="toxic">{toxicCount}건 대기</Badge>
-                    {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
-                    <span className="text-xs font-normal leading-4 text-text-tertiary">
-                      전체보기
-                    </span>
-                  </div>
-                </div>
-
-                {toxicItems.length === 0 ? (
-                  <EmptyState title="검토할 소감이 없어요" />
-                ) : (
-                  <ul className="flex flex-col gap-2">
-                    {toxicItems.slice(0, MODERATION_PREVIEW_LIMIT).map((feedback) => (
-                      <li key={feedback.id}>
-                        <FeedItem
-                          state={feedback.status === 'HIDDEN' ? 'hidden' : 'flagged'}
-                          sentiment="toxic"
-                          meta={toMeta(feedback)}
-                          content={feedback.text}
-                          actions={
-                            <>
-                              <Button
-                                variant="secondary"
-                                size="sm"
-                                /*
-                                 * 누른 항목만 잠급니다. `isPending`만 보면 미리보기 세 건이
-                                 * mutation 하나를 공유해서 누르지 않은 항목까지 같이 잠깁니다.
-                                 * `variables`는 `mutate`에 넘긴 id라 요청이 도는 동안 남습니다.
-                                 */
-                                disabled={
-                                  (hideMutation.isPending &&
-                                    hideMutation.variables === feedback.id) ||
-                                  (showMutation.isPending && showMutation.variables === feedback.id)
-                                }
-                                onClick={() => handleToggleHidden(feedback)}
-                              >
-                                {feedback.status === 'HIDDEN' ? '숨김 해제' : '숨기기'}
-                              </Button>
-                              <Button
-                                variant="danger"
-                                size="sm"
-                                disabled={
-                                  deleteMutation.isPending &&
-                                  deleteMutation.variables === feedback.id
-                                }
-                                onClick={() => handleDelete(feedback.id)}
-                              >
-                                삭제
-                              </Button>
-                            </>
-                          }
-                        />
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
+              <ModerationQueue
+                items={toxicItems}
+                waitingCount={toxicCount}
+                formatMeta={toMeta}
+                actions={moderation}
+              />
 
               <section className={CARD}>
                 <h2 className={CARD_TITLE}>상위 키워드</h2>

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -14,6 +14,13 @@ import {
 } from 'recharts';
 
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
+import {
+  buildTrend,
+  countKeywords,
+  summarizeSentiments,
+  toRelativeTime,
+  TREND_BUCKET_MS,
+} from '@/components/dashboard/metrics';
 import { Donut } from '@/components/feedback/Donut';
 import { FeedItem, type Sentiment as FeedItemSentiment } from '@/components/feedback/FeedItem';
 import { Badge } from '@/components/ui/Badge';
@@ -44,12 +51,6 @@ import type { Feedback, Sentiment } from '@/lib/schemas/api';
  * 스냅샷을 쓰지 않는 이유는 `hooks/useDashboardFeed.ts`에 적어뒀습니다.
  */
 
-/** 추이 차트의 가로 한 칸입니다. */
-const TREND_BUCKET_MS = 5 * 60_000;
-
-/** 상위 키워드 노출 개수입니다. 공개 스냅샷 계약(`TOP_KEYWORD_LIMIT`)과 같은 값입니다. */
-const KEYWORD_LIMIT = 10;
-
 /** 모더레이션 큐 위젯이 미리 보여주는 건수입니다. 나머지는 "전체보기"로 넘깁니다. */
 const MODERATION_PREVIEW_LIMIT = 3;
 
@@ -61,78 +62,6 @@ const FEED_SENTIMENT: Record<Sentiment, FeedItemSentiment> = {
   NEU: 'neutral',
   NEG: 'negative',
   UNKNOWN: 'none',
-};
-
-const toRelativeTime = (iso: string) => {
-  const minutes = Math.floor((Date.now() - Date.parse(iso)) / 60_000);
-
-  if (minutes < 1) return '방금';
-  if (minutes < 60) return `${minutes}분 전`;
-
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}시간 전`;
-
-  return `${Math.floor(hours / 24)}일 전`;
-};
-
-const toClock = (ms: number) =>
-  new Date(ms).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
-
-/** 추이 차트의 한 점입니다. 감정 키는 API의 `Sentiment`를 그대로 씁니다(`UNKNOWN` 제외). */
-interface TrendPoint {
-  label: string;
-  POS: number;
-  NEU: number;
-  NEG: number;
-}
-
-/**
- * 소감을 5분 칸으로 묶어 감정별 건수를 셉니다.
- *
- * 누적이 아니라 칸별 건수입니다. 누적은 언제 반응이 몰렸는지가 기울기로만 남아서,
- * 진행 중인 이벤트에서 "지금 분위기가 꺾였다"를 읽어내기 어렵습니다.
- *
- * 첫 소감 시각을 칸 경계로 내림해서 시작합니다. 그래야 폴링으로 뒤에 붙는 소감이
- * 앞 칸들의 경계를 밀지 않아 차트가 흔들리지 않습니다. `UNKNOWN`은 태깅 실패라
- * 감정선에 올리지 않습니다.
- */
-const buildTrend = (feedbacks: Feedback[]) => {
-  if (feedbacks.length === 0) return [];
-
-  const times = feedbacks.map((feedback) => Date.parse(feedback.createdAt));
-  const start = Math.floor(Math.min(...times) / TREND_BUCKET_MS) * TREND_BUCKET_MS;
-  const end = Math.max(...times);
-
-  const buckets: TrendPoint[] = [];
-  for (let at = start; at <= end; at += TREND_BUCKET_MS) {
-    buckets.push({ label: toClock(at), POS: 0, NEU: 0, NEG: 0 });
-  }
-
-  feedbacks.forEach((feedback) => {
-    if (feedback.sentiment === 'UNKNOWN') return;
-
-    const bucket = buckets[Math.floor((Date.parse(feedback.createdAt) - start) / TREND_BUCKET_MS)];
-    if (bucket) bucket[feedback.sentiment] += 1;
-  });
-
-  return buckets;
-};
-
-/** 빈도순 상위 키워드입니다. 같은 횟수면 가나다순으로 고정해서 폴링마다 순서가 바뀌지 않게 합니다. */
-const countKeywords = (feedbacks: Feedback[]) => {
-  const counts = new Map<string, number>();
-
-  feedbacks.forEach((feedback) => {
-    feedback.keywords.forEach((keyword) => {
-      counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
-    });
-  });
-
-  return [...counts]
-    .sort(([leftWord, leftCount], [rightWord, rightCount]) =>
-      rightCount === leftCount ? leftWord.localeCompare(rightWord) : rightCount - leftCount,
-    )
-    .slice(0, KEYWORD_LIMIT);
 };
 
 const DashboardView = () => {
@@ -287,17 +216,7 @@ const DashboardView = () => {
    */
   const visible = items.filter((feedback) => feedback.status === 'VISIBLE');
 
-  const positive = visible.filter((feedback) => feedback.sentiment === 'POS').length;
-  const neutral = visible.filter((feedback) => feedback.sentiment === 'NEU').length;
-  const negative = visible.filter((feedback) => feedback.sentiment === 'NEG').length;
-  const unclassified = visible.filter((feedback) => feedback.sentiment === 'UNKNOWN').length;
-
-  /*
-   * 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅이 실패했다는 뜻이라 "중립"과 다릅니다.
-   * 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다.
-   */
-  const classified = positive + neutral + negative;
-  const positiveRate = classified === 0 ? 0 : Math.round((positive / classified) * 100);
+  const { positive, neutral, negative, unclassified, positiveRate } = summarizeSentiments(visible);
 
   const toxicItems = items.filter((feedback) => feedback.toxic);
   const toxicCount = visible.filter((feedback) => feedback.toxic).length;

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -28,6 +28,7 @@ import {
   fetchMyEvents,
   fetchSessionsByEventCode,
   hideFeedback,
+  showFeedback,
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import type { Feedback, Sentiment } from '@/lib/schemas/api';
@@ -205,6 +206,19 @@ const DashboardView = () => {
     },
   });
 
+  /*
+   * 숨김은 되돌릴 수 있는 상태입니다(요구사항 소감 상태 전이 4번). 종단 상태는 `DELETED`뿐이라,
+   * 숨긴 건은 큐에 남겨두고 같은 버튼으로 되돌립니다. 큐가 `includeHidden=true`로 받는 것도
+   * 이 되돌리기 때문입니다.
+   */
+  const showMutation = useMutation({
+    mutationFn: showFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('숨김을 해제했어요');
+    },
+  });
+
   const deleteMutation = useMutation({
     mutationFn: deleteFeedback,
     onSuccess: () => {
@@ -217,8 +231,13 @@ const DashboardView = () => {
     setSessionId(nextSessionId);
   };
 
-  const handleHide = (feedbackId: number) => {
-    hideMutation.mutate(feedbackId);
+  const handleToggleHidden = (feedback: Feedback) => {
+    if (feedback.status === 'HIDDEN') {
+      showMutation.mutate(feedback.id);
+      return;
+    }
+
+    hideMutation.mutate(feedback.id);
   };
 
   const handleDelete = (feedbackId: number) => {
@@ -335,7 +354,7 @@ const DashboardView = () => {
       </div>
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
-      {(hideMutation.isError || deleteMutation.isError) && (
+      {(hideMutation.isError || showMutation.isError || deleteMutation.isError) && (
         <Banner type="negative">소감 처리에 실패했어요</Banner>
       )}
 
@@ -489,10 +508,10 @@ const DashboardView = () => {
                               <Button
                                 variant="secondary"
                                 size="sm"
-                                disabled={feedback.status === 'HIDDEN' || hideMutation.isPending}
-                                onClick={() => handleHide(feedback.id)}
+                                disabled={hideMutation.isPending || showMutation.isPending}
+                                onClick={() => handleToggleHidden(feedback)}
                               >
-                                숨기기
+                                {feedback.status === 'HIDDEN' ? '숨김 해제' : '숨기기'}
                               </Button>
                               <Button
                                 variant="danger"

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -508,7 +508,16 @@ const DashboardView = () => {
                               <Button
                                 variant="secondary"
                                 size="sm"
-                                disabled={hideMutation.isPending || showMutation.isPending}
+                                /*
+                                 * 누른 항목만 잠급니다. `isPending`만 보면 미리보기 세 건이
+                                 * mutation 하나를 공유해서 누르지 않은 항목까지 같이 잠깁니다.
+                                 * `variables`는 `mutate`에 넘긴 id라 요청이 도는 동안 남습니다.
+                                 */
+                                disabled={
+                                  (hideMutation.isPending &&
+                                    hideMutation.variables === feedback.id) ||
+                                  (showMutation.isPending && showMutation.variables === feedback.id)
+                                }
                                 onClick={() => handleToggleHidden(feedback)}
                               >
                                 {feedback.status === 'HIDDEN' ? '숨김 해제' : '숨기기'}
@@ -516,7 +525,10 @@ const DashboardView = () => {
                               <Button
                                 variant="danger"
                                 size="sm"
-                                disabled={deleteMutation.isPending}
+                                disabled={
+                                  deleteMutation.isPending &&
+                                  deleteMutation.variables === feedback.id
+                                }
                                 onClick={() => handleDelete(feedback.id)}
                               >
                                 삭제

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -25,10 +25,11 @@ import { DASHBOARD_FEED_KEY, useDashboardFeed } from '@/hooks/useDashboardFeed';
 import { showToast } from '@/hooks/useToast';
 import {
   deleteFeedback,
-  fetchEventByCode,
+  fetchMyEvents,
   fetchSessionsByEventCode,
   hideFeedback,
 } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
 import type { Feedback, Sentiment } from '@/lib/schemas/api';
 
 /**
@@ -151,13 +152,28 @@ const DashboardView = () => {
   /** `null`이 "전체"입니다. 시안의 기본 선택값입니다. */
   const [sessionId, setSessionId] = useState<number | null>(null);
 
+  /*
+   * 공개 조회(`GET /events/{eventCode}`)가 아니라 내 이벤트 목록을 받아 코드로 찾습니다.
+   *
+   * 공개 조회는 인증을 보지 않아서, 로그인하지 않은 사람이 주소를 직접 쳐도 제목과 세션 칩이
+   * 그대로 그려집니다. 소감만 401이 나서 "숫자가 전부 0인 멀쩡한 화면"처럼 보입니다.
+   * 남의 이벤트 코드를 넣었을 때도 마찬가지입니다. `/admin/feedbacks`는 내 소감만 거른 뒤
+   * eventCode로 다시 걸러서, 교집합이 비면 403이 아니라 빈 배열을 200으로 돌려줍니다.
+   *
+   * `GET /events`는 인증과 소유권을 서버가 한 번에 봅니다. 못 보는 이벤트면 목록에 아예
+   * 없으므로 두 경우 다 화면이 뜨기 전에 걸립니다.
+   *
+   * 세션 목록에는 이런 대안이 없습니다. API 명세상 세션은 쓰기만 소유자 전용이고 읽기는
+   * 공개 한 벌뿐입니다(게스트의 제출 대상 선택과 공용). 그래서 그대로 둡니다.
+   */
   const {
-    data: event,
+    data: events,
     isPending: isEventPending,
     isError: isEventError,
+    error: eventError,
   } = useQuery({
-    queryKey: ['event', eventCode],
-    queryFn: () => fetchEventByCode(eventCode),
+    queryKey: ['myEvents'],
+    queryFn: fetchMyEvents,
   });
 
   const {
@@ -208,12 +224,48 @@ const DashboardView = () => {
     deleteMutation.mutate(feedbackId);
   };
 
-  // 둘 중 하나만 실패해도 그릴 수 있는 화면이 없어서 사유를 나누지 않습니다.
-  if (isEventError || isSessionsError) {
+  /*
+   * 미인증만 사유를 나눕니다. 주최자 전용 화면이라 "잠시 실패했다"와 "애초에 볼 자격이 없다"는
+   * 다음 행동이 달라서, 하나로 뭉치면 로그인하면 되는 사람이 새로고침만 반복하게 됩니다.
+   *
+   * 로그인 화면으로 보내는 일까지는 하지 않습니다. host 화면 전체에 걸리는 라우트 가드가
+   * 아직 없고, 어디에 둘지는 이 화면 혼자 정할 문제가 아닙니다.
+   */
+  const isUnauthorized = eventError instanceof ApiError && eventError.code === 'UNAUTHORIZED';
+
+  if (isEventError) {
+    return (
+      <Banner type="negative">
+        {isUnauthorized ? '로그인이 필요한 화면이에요' : '이벤트 정보를 불러올 수 없어요'}
+      </Banner>
+    );
+  }
+
+  if (isEventPending) {
+    return <DashboardSkeleton />;
+  }
+
+  /*
+   * 목록에 없는 코드는 없는 이벤트이거나 남의 이벤트입니다. 주최자에게는 둘 다 "볼 수 없다"로
+   * 같아서 문구를 나누지 않습니다. 나누면 코드를 하나씩 넣어보며 남의 이벤트가 실재하는지
+   * 알아낼 수 있습니다.
+   */
+  const event = events.find((item) => item.code === eventCode) ?? null;
+
+  if (event === null) {
+    return <Banner type="negative">이 이벤트를 볼 수 없어요</Banner>;
+  }
+
+  /*
+   * 세션 판정을 이벤트 뒤로 미룹니다. 세션 목록은 공개 엔드포인트라 없는 코드에 404를 내는데,
+   * 먼저 보면 "볼 수 없는 이벤트"가 전부 "불러올 수 없어요"로 뭉개집니다. 여기까지 왔다면
+   * 이벤트는 실재하고 내 것이므로, 이 실패는 진짜 서버 문제입니다.
+   */
+  if (isSessionsError) {
     return <Banner type="negative">이벤트 정보를 불러올 수 없어요</Banner>;
   }
 
-  if (isEventPending || isSessionsPending) {
+  if (isSessionsPending) {
     return <DashboardSkeleton />;
   }
 

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -465,7 +465,7 @@ const DashboardView = () => {
                 <div className="flex items-center justify-between gap-2">
                   <h2 className={CARD_TITLE}>모더레이션 큐</h2>
                   <div className="flex items-center gap-2">
-                    <Badge tone="toxic">{toxicItems.length}건 대기</Badge>
+                    <Badge tone="toxic">{toxicCount}건 대기</Badge>
                     {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
                     <span className="text-xs font-normal leading-4 text-text-tertiary">
                       전체보기

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -13,6 +13,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import { Donut } from '@/components/feedback/Donut';
 import { FeedItem, type Sentiment as FeedItemSentiment } from '@/components/feedback/FeedItem';
 import { Badge } from '@/components/ui/Badge';
@@ -133,19 +134,6 @@ const countKeywords = (feedbacks: Feedback[]) => {
     )
     .slice(0, KEYWORD_LIMIT);
 };
-
-const DashboardSkeleton = () => (
-  <div className="flex flex-col gap-4" role="status" aria-live="polite">
-    <span className="sr-only">대시보드를 불러오고 있어요</span>
-    <div aria-hidden="true" className="h-8 w-64 animate-pulse rounded-lg bg-background-muted" />
-    <div aria-hidden="true" className="grid grid-cols-2 gap-3 md:grid-cols-4">
-      {[0, 1, 2, 3].map((slot) => (
-        <div key={slot} className="h-20 animate-pulse rounded-lg bg-background-muted" />
-      ))}
-    </div>
-    <div aria-hidden="true" className="h-48 animate-pulse rounded-xl bg-background-muted" />
-  </div>
-);
 
 const DashboardView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -1,0 +1,501 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useParams } from 'next/navigation';
+import { useState } from 'react';
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { Donut } from '@/components/feedback/Donut';
+import { FeedItem, type Sentiment as FeedItemSentiment } from '@/components/feedback/FeedItem';
+import { Badge } from '@/components/ui/Badge';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { Chip } from '@/components/ui/Chip';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Stat } from '@/components/ui/Stat';
+import { DASHBOARD_FEED_KEY, useDashboardFeed } from '@/hooks/useDashboardFeed';
+import { showToast } from '@/hooks/useToast';
+import {
+  deleteFeedback,
+  fetchEventByCode,
+  fetchSessionsByEventCode,
+  hideFeedback,
+} from '@/lib/api/endpoints';
+import type { Feedback, Sentiment } from '@/lib/schemas/api';
+
+/**
+ * 주최자 실시간 모니터링 대시보드입니다.
+ *
+ * 페이지가 아니라 여기가 화면 전체인 이유는 CLAUDE.md가 대시보드를 CSR로 정해뒀기
+ * 때문입니다. 어차피 첫 렌더에 그릴 게 없어서 페이지는 껍데기만 남깁니다.
+ *
+ * 숫자는 전부 `/admin/feedbacks` 원본에서 이 파일이 셉니다. 서버가 집계해주는 공개
+ * 스냅샷을 쓰지 않는 이유는 `hooks/useDashboardFeed.ts`에 적어뒀습니다.
+ */
+
+/** 추이 차트의 가로 한 칸입니다. */
+const TREND_BUCKET_MS = 5 * 60_000;
+
+/** 상위 키워드 노출 개수입니다. 공개 스냅샷 계약(`TOP_KEYWORD_LIMIT`)과 같은 값입니다. */
+const KEYWORD_LIMIT = 10;
+
+/** 모더레이션 큐 위젯이 미리 보여주는 건수입니다. 나머지는 "전체보기"로 넘깁니다. */
+const MODERATION_PREVIEW_LIMIT = 3;
+
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+const FEED_SENTIMENT: Record<Sentiment, FeedItemSentiment> = {
+  POS: 'positive',
+  NEU: 'neutral',
+  NEG: 'negative',
+  UNKNOWN: 'none',
+};
+
+const toRelativeTime = (iso: string) => {
+  const minutes = Math.floor((Date.now() - Date.parse(iso)) / 60_000);
+
+  if (minutes < 1) return '방금';
+  if (minutes < 60) return `${minutes}분 전`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+
+  return `${Math.floor(hours / 24)}일 전`;
+};
+
+const toClock = (ms: number) =>
+  new Date(ms).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
+
+/** 추이 차트의 한 점입니다. 감정 키는 API의 `Sentiment`를 그대로 씁니다(`UNKNOWN` 제외). */
+interface TrendPoint {
+  label: string;
+  POS: number;
+  NEU: number;
+  NEG: number;
+}
+
+/**
+ * 소감을 5분 칸으로 묶어 감정별 건수를 셉니다.
+ *
+ * 누적이 아니라 칸별 건수입니다. 누적은 언제 반응이 몰렸는지가 기울기로만 남아서,
+ * 진행 중인 이벤트에서 "지금 분위기가 꺾였다"를 읽어내기 어렵습니다.
+ *
+ * 첫 소감 시각을 칸 경계로 내림해서 시작합니다. 그래야 폴링으로 뒤에 붙는 소감이
+ * 앞 칸들의 경계를 밀지 않아 차트가 흔들리지 않습니다. `UNKNOWN`은 태깅 실패라
+ * 감정선에 올리지 않습니다.
+ */
+const buildTrend = (feedbacks: Feedback[]) => {
+  if (feedbacks.length === 0) return [];
+
+  const times = feedbacks.map((feedback) => Date.parse(feedback.createdAt));
+  const start = Math.floor(Math.min(...times) / TREND_BUCKET_MS) * TREND_BUCKET_MS;
+  const end = Math.max(...times);
+
+  const buckets: TrendPoint[] = [];
+  for (let at = start; at <= end; at += TREND_BUCKET_MS) {
+    buckets.push({ label: toClock(at), POS: 0, NEU: 0, NEG: 0 });
+  }
+
+  feedbacks.forEach((feedback) => {
+    if (feedback.sentiment === 'UNKNOWN') return;
+
+    const bucket = buckets[Math.floor((Date.parse(feedback.createdAt) - start) / TREND_BUCKET_MS)];
+    if (bucket) bucket[feedback.sentiment] += 1;
+  });
+
+  return buckets;
+};
+
+/** 빈도순 상위 키워드입니다. 같은 횟수면 가나다순으로 고정해서 폴링마다 순서가 바뀌지 않게 합니다. */
+const countKeywords = (feedbacks: Feedback[]) => {
+  const counts = new Map<string, number>();
+
+  feedbacks.forEach((feedback) => {
+    feedback.keywords.forEach((keyword) => {
+      counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
+    });
+  });
+
+  return [...counts]
+    .sort(([leftWord, leftCount], [rightWord, rightCount]) =>
+      rightCount === leftCount ? leftWord.localeCompare(rightWord) : rightCount - leftCount,
+    )
+    .slice(0, KEYWORD_LIMIT);
+};
+
+const DashboardSkeleton = () => (
+  <div className="flex flex-col gap-4" aria-hidden="true">
+    <div className="h-8 w-64 animate-pulse rounded-lg bg-background-muted" />
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      {[0, 1, 2, 3].map((slot) => (
+        <div key={slot} className="h-20 animate-pulse rounded-lg bg-background-muted" />
+      ))}
+    </div>
+    <div className="h-48 animate-pulse rounded-xl bg-background-muted" />
+  </div>
+);
+
+const DashboardView = () => {
+  const { eventCode } = useParams<{ eventCode: string }>();
+  const queryClient = useQueryClient();
+
+  /** `null`이 "전체"입니다. 시안의 기본 선택값입니다. */
+  const [sessionId, setSessionId] = useState<number | null>(null);
+
+  const {
+    data: event,
+    isPending: isEventPending,
+    isError: isEventError,
+  } = useQuery({
+    queryKey: ['event', eventCode],
+    queryFn: () => fetchEventByCode(eventCode),
+  });
+
+  const {
+    data: sessions,
+    isPending: isSessionsPending,
+    isError: isSessionsError,
+  } = useQuery({
+    queryKey: ['sessions', eventCode],
+    queryFn: () => fetchSessionsByEventCode(eventCode),
+  });
+
+  const {
+    feedbacks,
+    isPending: isFeedPending,
+    isError: isFeedError,
+    refreshIntervalMs,
+  } = useDashboardFeed({ eventCode, sessionId });
+
+  const invalidateFeed = () => {
+    queryClient.invalidateQueries({ queryKey: [DASHBOARD_FEED_KEY] });
+  };
+
+  const hideMutation = useMutation({
+    mutationFn: hideFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('소감을 숨겼어요');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('소감을 삭제했어요');
+    },
+  });
+
+  const handleSelectSession = (nextSessionId: number | null) => {
+    setSessionId(nextSessionId);
+  };
+
+  const handleHide = (feedbackId: number) => {
+    hideMutation.mutate(feedbackId);
+  };
+
+  const handleDelete = (feedbackId: number) => {
+    deleteMutation.mutate(feedbackId);
+  };
+
+  // 둘 중 하나만 실패해도 그릴 수 있는 화면이 없어서 사유를 나누지 않습니다.
+  if (isEventError || isSessionsError) {
+    return <Banner type="negative">이벤트 정보를 불러올 수 없어요</Banner>;
+  }
+
+  if (isEventPending || isSessionsPending) {
+    return <DashboardSkeleton />;
+  }
+
+  const openSessionCount = sessions.filter((session) => session.status === 'ACTIVE').length;
+
+  const items = feedbacks ?? [];
+
+  /*
+   * 숨긴 건은 집계와 피드에서 뺍니다. 목록을 `includeHidden=true`로 받는 건 모더레이션
+   * 큐가 이미 숨긴 건도 보여줘야 해서지, 숫자에 넣으려는 게 아닙니다.
+   */
+  const visible = items.filter((feedback) => feedback.status === 'VISIBLE');
+
+  const positive = visible.filter((feedback) => feedback.sentiment === 'POS').length;
+  const neutral = visible.filter((feedback) => feedback.sentiment === 'NEU').length;
+  const negative = visible.filter((feedback) => feedback.sentiment === 'NEG').length;
+  const unclassified = visible.filter((feedback) => feedback.sentiment === 'UNKNOWN').length;
+
+  /*
+   * 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅이 실패했다는 뜻이라 "중립"과 다릅니다.
+   * 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다.
+   */
+  const classified = positive + neutral + negative;
+  const positiveRate = classified === 0 ? 0 : Math.round((positive / classified) * 100);
+
+  const toxicItems = items.filter((feedback) => feedback.toxic);
+  const toxicCount = visible.filter((feedback) => feedback.toxic).length;
+
+  const trend = buildTrend(visible);
+  const keywords = countKeywords(visible);
+
+  const sessionTitle = (feedbackSessionId: number) =>
+    sessions.find((session) => session.id === feedbackSessionId)?.title ?? '삭제된 세션';
+
+  const toMeta = (feedback: Feedback) =>
+    `${toRelativeTime(feedback.createdAt)} · ${sessionTitle(feedback.sessionId)}`;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* 제목과 상태는 붙어 있어야 해서 바깥 `gap-4`에서 빼고 따로 묶습니다. */}
+      <div className="flex flex-col gap-1">
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
+          <Badge tone={event.status === 'LIVE' ? 'positive' : 'neutral'}>{event.status}</Badge>
+        </div>
+        {/* 전체 주소와 복사 버튼은 QR·링크 복사 이슈에서 붙습니다. */}
+        <p className="text-xs font-normal leading-4 text-text-tertiary">/e/{event.code}</p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        <Chip selected={sessionId === null} onClick={() => handleSelectSession(null)}>
+          전체
+        </Chip>
+        {sessions.map((session) => (
+          <Chip
+            key={session.id}
+            selected={sessionId === session.id}
+            onClick={() => handleSelectSession(session.id)}
+          >
+            {session.title}
+          </Chip>
+        ))}
+        <span className="ml-auto text-xs font-normal leading-4 text-text-tertiary">
+          총 {sessions.length}개 중 {openSessionCount}개 열림
+        </span>
+      </div>
+
+      {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
+      {(hideMutation.isError || deleteMutation.isError) && (
+        <Banner type="negative">소감 처리에 실패했어요</Banner>
+      )}
+
+      {isFeedPending ? (
+        <DashboardSkeleton />
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <Stat label="총 소감" value={`${visible.length}`} />
+            <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
+            <Stat label="독성 플래그" value={`${toxicCount}`} tone="toxic" />
+            <Stat label="미분류" value={`${unclassified}`} tone="muted" />
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-[16rem_1fr]">
+            <section className={CARD}>
+              <h2 className={CARD_TITLE}>감정 분포</h2>
+              <Donut positive={positive} neutral={neutral} negative={negative} className="py-2" />
+            </section>
+
+            <section className={CARD}>
+              <div className="flex items-center justify-between gap-2">
+                <h2 className={CARD_TITLE}>시간대별 감정 추이</h2>
+                {refreshIntervalMs !== null && (
+                  <span className="text-xs font-normal leading-4 text-text-tertiary">
+                    {refreshIntervalMs / 1000}초마다 갱신
+                  </span>
+                )}
+              </div>
+
+              {trend.length === 0 ? (
+                <p className="flex h-40 items-center justify-center text-sm text-text-tertiary">
+                  아직 그릴 소감이 없어요
+                </p>
+              ) : (
+                /* 색만으로는 세 선이 구분되지 않아 스크린리더용 설명을 따로 답니다. */
+                <div
+                  className="h-40"
+                  role="img"
+                  aria-label={`${TREND_BUCKET_MS / 60_000}분 단위 감정별 소감 건수 추이. 긍정 ${positive}건, 중립 ${neutral}건, 부정 ${negative}건.`}
+                >
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={trend} margin={{ top: 8, right: 8, bottom: 0, left: -24 }}>
+                      <CartesianGrid
+                        strokeDasharray="3 3"
+                        stroke="var(--color-border-subtle)"
+                        vertical={false}
+                      />
+                      <XAxis
+                        dataKey="label"
+                        tickLine={false}
+                        axisLine={false}
+                        tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
+                      />
+                      <YAxis
+                        allowDecimals={false}
+                        tickLine={false}
+                        axisLine={false}
+                        width={40}
+                        tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
+                      />
+                      <Tooltip
+                        contentStyle={{
+                          borderRadius: '0.5rem',
+                          border: '1px solid var(--color-border-subtle)',
+                          fontSize: '0.75rem',
+                        }}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="POS"
+                        name="긍정"
+                        stroke="var(--color-positive-default)"
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="NEU"
+                        name="중립"
+                        stroke="var(--color-neutral-default)"
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                      <Line
+                        type="monotone"
+                        dataKey="NEG"
+                        name="부정"
+                        stroke="var(--color-negative-default)"
+                        strokeWidth={2}
+                        dot={false}
+                      />
+                    </LineChart>
+                  </ResponsiveContainer>
+                </div>
+              )}
+            </section>
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <section className={CARD}>
+              <h2 className={CARD_TITLE}>실시간 소감 피드</h2>
+
+              {visible.length === 0 ? (
+                <EmptyState
+                  title="아직 들어온 소감이 없어요"
+                  description="참가자가 소감을 남기면 여기에 바로 올라와요"
+                />
+              ) : (
+                <ul className="flex max-h-80 flex-col gap-2 overflow-y-auto">
+                  {visible.map((feedback) => (
+                    <li key={feedback.id}>
+                      <FeedItem
+                        state="normal"
+                        sentiment={FEED_SENTIMENT[feedback.sentiment]}
+                        meta={toMeta(feedback)}
+                        content={feedback.text}
+                      />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+
+            <div className="flex flex-col gap-3">
+              <section className={CARD}>
+                <div className="flex items-center justify-between gap-2">
+                  <h2 className={CARD_TITLE}>모더레이션 큐</h2>
+                  <div className="flex items-center gap-2">
+                    <Badge tone="toxic">{toxicItems.length}건 대기</Badge>
+                    {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
+                    <span className="text-xs font-normal leading-4 text-text-tertiary">
+                      전체보기
+                    </span>
+                  </div>
+                </div>
+
+                {toxicItems.length === 0 ? (
+                  <EmptyState title="검토할 소감이 없어요" />
+                ) : (
+                  <ul className="flex flex-col gap-2">
+                    {toxicItems.slice(0, MODERATION_PREVIEW_LIMIT).map((feedback) => (
+                      <li key={feedback.id}>
+                        <FeedItem
+                          state={feedback.status === 'HIDDEN' ? 'hidden' : 'flagged'}
+                          sentiment="toxic"
+                          meta={toMeta(feedback)}
+                          content={feedback.text}
+                          actions={
+                            <>
+                              <Button
+                                variant="secondary"
+                                size="sm"
+                                disabled={feedback.status === 'HIDDEN' || hideMutation.isPending}
+                                onClick={() => handleHide(feedback.id)}
+                              >
+                                숨기기
+                              </Button>
+                              <Button
+                                variant="danger"
+                                size="sm"
+                                disabled={deleteMutation.isPending}
+                                onClick={() => handleDelete(feedback.id)}
+                              >
+                                삭제
+                              </Button>
+                            </>
+                          }
+                        />
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              <section className={CARD}>
+                <h2 className={CARD_TITLE}>상위 키워드</h2>
+
+                {keywords.length === 0 ? (
+                  <p className="text-sm text-text-tertiary">아직 모인 키워드가 없어요</p>
+                ) : (
+                  <ul className="flex flex-wrap gap-2">
+                    {keywords.map(([keyword, count]) => (
+                      <li key={keyword}>
+                        <Badge tone="outline">
+                          {keyword} {count}
+                        </Badge>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+            </div>
+          </div>
+
+          <section className={`${CARD} flex-row items-center justify-between`}>
+            <div className="flex flex-col gap-1">
+              <h2 className="text-base font-semibold leading-6 text-text-primary">
+                AI 요약 리포트
+              </h2>
+              <p className="text-xs font-normal leading-4 text-text-tertiary">
+                이벤트를 종료하면 생성할 수 있어요
+              </p>
+            </div>
+            {/* 실제 생성 호출은 이벤트 종료 이슈에서 붙습니다. 여기서는 조건만 맞춥니다. */}
+            <Button variant="secondary" disabled={event.status !== 'ENDED'}>
+              요약 생성
+            </Button>
+          </section>
+        </>
+      )}
+    </div>
+  );
+};
+
+export { DashboardView };

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -134,14 +134,15 @@ const countKeywords = (feedbacks: Feedback[]) => {
 };
 
 const DashboardSkeleton = () => (
-  <div className="flex flex-col gap-4" aria-hidden="true">
-    <div className="h-8 w-64 animate-pulse rounded-lg bg-background-muted" />
-    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+  <div className="flex flex-col gap-4" role="status" aria-live="polite">
+    <span className="sr-only">대시보드를 불러오고 있어요</span>
+    <div aria-hidden="true" className="h-8 w-64 animate-pulse rounded-lg bg-background-muted" />
+    <div aria-hidden="true" className="grid grid-cols-2 gap-3 md:grid-cols-4">
       {[0, 1, 2, 3].map((slot) => (
         <div key={slot} className="h-20 animate-pulse rounded-lg bg-background-muted" />
       ))}
     </div>
-    <div className="h-48 animate-pulse rounded-xl bg-background-muted" />
+    <div aria-hidden="true" className="h-48 animate-pulse rounded-xl bg-background-muted" />
   </div>
 );
 

--- a/components/dashboard/metrics.test.ts
+++ b/components/dashboard/metrics.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { buildTrend, countKeywords, summarizeSentiments } from '@/components/dashboard/metrics';
+import type { Feedback, Sentiment } from '@/lib/schemas/api';
+
+/**
+ * 대시보드 숫자를 정하는 계산입니다. 화면에 붙은 뒤에는 눈으로 검산하기 어렵습니다.
+ * 22건이 들어온 화면에서 "긍정 40%"가 맞는지 세어볼 수 없어서 여기서 봅니다.
+ *
+ * 칸 라벨(`09:05`)은 `toLocaleTimeString`이 실행 환경 시간대를 따르므로 문자열을
+ * 박아두지 않습니다. 대신 칸이 몇 개인지, 경계가 5분에 맞춰졌는지, 뒤에 소감이
+ * 붙어도 앞 칸이 그대로인지를 봅니다.
+ */
+
+/** 09:03 — 일부러 5분 경계가 아닌 시각입니다. 내림이 실제로 도는지 보려는 것입니다. */
+const FIRST_AT = Date.parse('2026-08-13T09:03:00.000Z');
+
+const at = (minutesLater: number) => new Date(FIRST_AT + minutesLater * 60_000).toISOString();
+
+const makeFeedback = (overrides: Partial<Feedback> = {}): Feedback => ({
+  id: 1,
+  sessionId: 101,
+  text: '소감',
+  sentiment: 'POS',
+  keywords: [],
+  createdAt: at(0),
+  toxic: false,
+  taggerVersion: 'v1',
+  status: 'VISIBLE',
+  ...overrides,
+});
+
+const withSentiments = (...sentiments: Sentiment[]) =>
+  sentiments.map((sentiment, index) => makeFeedback({ id: index + 1, sentiment }));
+
+/** 라벨에서 분만 뽑습니다. `09:05` → 5 */
+const minuteOf = (label: string) => Number(label.split(':')[1]);
+
+describe('buildTrend', () => {
+  it('소감이 없으면 빈 배열이다', () => {
+    expect(buildTrend([])).toEqual([]);
+  });
+
+  it('첫 칸의 경계를 5분 단위로 내린다', () => {
+    const [first] = buildTrend([makeFeedback()]);
+
+    expect(minuteOf(first.label) % 5).toBe(0);
+  });
+
+  it('같은 5분 안의 소감은 한 칸에 모인다', () => {
+    const trend = buildTrend([
+      makeFeedback({ id: 1, createdAt: at(0) }),
+      makeFeedback({ id: 2, createdAt: at(1), sentiment: 'NEG' }),
+    ]);
+
+    expect(trend).toHaveLength(1);
+    expect(trend[0]).toMatchObject({ POS: 1, NEU: 0, NEG: 1 });
+  });
+
+  it('소감이 없는 칸도 자리를 채운다', () => {
+    // 09:03과 09:17 → 09:00 · 09:05 · 09:10 · 09:15 네 칸
+    const trend = buildTrend([
+      makeFeedback({ id: 1, createdAt: at(0) }),
+      makeFeedback({ id: 2, createdAt: at(14) }),
+    ]);
+
+    expect(trend).toHaveLength(4);
+    expect(trend.map((point) => point.POS)).toEqual([1, 0, 0, 1]);
+  });
+
+  it('뒤에 붙는 소감이 앞 칸의 경계를 밀지 않는다', () => {
+    const before = buildTrend([makeFeedback()]);
+    const after = buildTrend([makeFeedback(), makeFeedback({ id: 2, createdAt: at(14) })]);
+
+    expect(after[0].label).toBe(before[0].label);
+  });
+
+  it('UNKNOWN은 감정선에 올리지 않는다', () => {
+    const trend = buildTrend([makeFeedback({ sentiment: 'UNKNOWN' })]);
+
+    expect(trend).toHaveLength(1);
+    expect(trend[0]).toMatchObject({ POS: 0, NEU: 0, NEG: 0 });
+  });
+});
+
+describe('countKeywords', () => {
+  it('빈도순으로 준다', () => {
+    const keywords = countKeywords([
+      makeFeedback({ id: 1, keywords: ['데모', '속도'] }),
+      makeFeedback({ id: 2, keywords: ['데모'] }),
+    ]);
+
+    expect(keywords).toEqual([
+      ['데모', 2],
+      ['속도', 1],
+    ]);
+  });
+
+  it('같은 횟수면 가나다순으로 고정한다', () => {
+    const keywords = countKeywords([makeFeedback({ keywords: ['진행', '내용', '발표'] })]);
+
+    expect(keywords.map(([keyword]) => keyword)).toEqual(['내용', '발표', '진행']);
+  });
+
+  it('열 개까지만 준다', () => {
+    const many = Array.from({ length: 12 }, (_, index) => `키워드${index}`);
+
+    expect(countKeywords([makeFeedback({ keywords: many })])).toHaveLength(10);
+  });
+});
+
+describe('summarizeSentiments', () => {
+  it('감정별로 센다', () => {
+    const summary = summarizeSentiments(withSentiments('POS', 'POS', 'NEU', 'NEG', 'UNKNOWN'));
+
+    expect(summary).toMatchObject({ positive: 2, neutral: 1, negative: 1, unclassified: 1 });
+  });
+
+  it('긍정 비율의 분모에서 미분류를 뺀다', () => {
+    // 분류된 건 POS 1 · NEU 1뿐이라 50%입니다. 미분류를 넣으면 25%가 됩니다.
+    const summary = summarizeSentiments(withSentiments('POS', 'NEU', 'UNKNOWN', 'UNKNOWN'));
+
+    expect(summary.positiveRate).toBe(50);
+  });
+
+  it('분류된 소감이 하나도 없으면 0%다', () => {
+    expect(summarizeSentiments(withSentiments('UNKNOWN')).positiveRate).toBe(0);
+    expect(summarizeSentiments([]).positiveRate).toBe(0);
+  });
+});

--- a/components/dashboard/metrics.ts
+++ b/components/dashboard/metrics.ts
@@ -1,0 +1,133 @@
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 대시보드가 소감 원본에서 뽑아내는 계산입니다.
+ *
+ * 화면에서 떼어낸 이유는 두 가지입니다. 숫자를 정하는 규칙(미분류를 분모에서 빼는 것,
+ * 칸 경계를 내림하는 것)이 렌더 코드 사이에 흩어져 있으면 나중에 한쪽만 바뀝니다.
+ * 그리고 `vitest`가 `environment: 'node'`라, 순수 함수로 있어야 테스트가 붙습니다.
+ *
+ * 선례는 두 감정 차트가 공유하는 `components/feedback/sentiment.ts`입니다.
+ */
+
+/** 추이 차트의 가로 한 칸입니다. */
+const TREND_BUCKET_MS = 5 * 60_000;
+
+/** 상위 키워드 노출 개수입니다. 공개 스냅샷 계약(`TOP_KEYWORD_LIMIT`)과 같은 값입니다. */
+const KEYWORD_LIMIT = 10;
+
+const toClock = (ms: number) =>
+  new Date(ms).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit', hour12: false });
+
+const toRelativeTime = (iso: string) => {
+  const minutes = Math.floor((Date.now() - Date.parse(iso)) / 60_000);
+
+  if (minutes < 1) return '방금';
+  if (minutes < 60) return `${minutes}분 전`;
+
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}시간 전`;
+
+  return `${Math.floor(hours / 24)}일 전`;
+};
+
+/** 추이 차트의 한 점입니다. 감정 키는 API의 `Sentiment`를 그대로 씁니다(`UNKNOWN` 제외). */
+interface TrendPoint {
+  label: string;
+  POS: number;
+  NEU: number;
+  NEG: number;
+}
+
+/** 감정별 건수와 긍정 비율입니다. */
+interface SentimentSummary {
+  positive: number;
+  neutral: number;
+  negative: number;
+  unclassified: number;
+  positiveRate: number;
+}
+
+/**
+ * 소감을 5분 칸으로 묶어 감정별 건수를 셉니다.
+ *
+ * 누적이 아니라 칸별 건수입니다. 누적은 언제 반응이 몰렸는지가 기울기로만 남아서,
+ * 진행 중인 이벤트에서 "지금 분위기가 꺾였다"를 읽어내기 어렵습니다.
+ *
+ * 첫 소감 시각을 칸 경계로 내림해서 시작합니다. 그래야 폴링으로 뒤에 붙는 소감이
+ * 앞 칸들의 경계를 밀지 않아 차트가 흔들리지 않습니다. `UNKNOWN`은 태깅 실패라
+ * 감정선에 올리지 않습니다.
+ */
+const buildTrend = (feedbacks: Feedback[]) => {
+  if (feedbacks.length === 0) return [];
+
+  const times = feedbacks.map((feedback) => Date.parse(feedback.createdAt));
+  const start = Math.floor(Math.min(...times) / TREND_BUCKET_MS) * TREND_BUCKET_MS;
+  const end = Math.max(...times);
+
+  const buckets: TrendPoint[] = [];
+  for (let at = start; at <= end; at += TREND_BUCKET_MS) {
+    buckets.push({ label: toClock(at), POS: 0, NEU: 0, NEG: 0 });
+  }
+
+  feedbacks.forEach((feedback) => {
+    if (feedback.sentiment === 'UNKNOWN') return;
+
+    const bucket = buckets[Math.floor((Date.parse(feedback.createdAt) - start) / TREND_BUCKET_MS)];
+    if (bucket) bucket[feedback.sentiment] += 1;
+  });
+
+  return buckets;
+};
+
+/** 빈도순 상위 키워드입니다. 같은 횟수면 가나다순으로 고정해서 폴링마다 순서가 바뀌지 않게 합니다. */
+const countKeywords = (feedbacks: Feedback[]) => {
+  const counts = new Map<string, number>();
+
+  feedbacks.forEach((feedback) => {
+    feedback.keywords.forEach((keyword) => {
+      counts.set(keyword, (counts.get(keyword) ?? 0) + 1);
+    });
+  });
+
+  return [...counts]
+    .sort(([leftWord, leftCount], [rightWord, rightCount]) =>
+      rightCount === leftCount ? leftWord.localeCompare(rightWord) : rightCount - leftCount,
+    )
+    .slice(0, KEYWORD_LIMIT);
+};
+
+/**
+ * 감정별로 세고 긍정 비율까지 냅니다.
+ *
+ * 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅이 실패했다는 뜻이라 "중립"과 다릅니다.
+ * 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다.
+ *
+ * 세는 일과 나누는 일을 한 함수에 둔 이유가 이것입니다. 떨어져 있으면 분모를 다시 만들 때
+ * 미분류를 빼는 규칙이 따라오지 않습니다.
+ */
+const summarizeSentiments = (feedbacks: Feedback[]): SentimentSummary => {
+  const positive = feedbacks.filter((feedback) => feedback.sentiment === 'POS').length;
+  const neutral = feedbacks.filter((feedback) => feedback.sentiment === 'NEU').length;
+  const negative = feedbacks.filter((feedback) => feedback.sentiment === 'NEG').length;
+  const unclassified = feedbacks.filter((feedback) => feedback.sentiment === 'UNKNOWN').length;
+
+  const classified = positive + neutral + negative;
+
+  return {
+    positive,
+    neutral,
+    negative,
+    unclassified,
+    positiveRate: classified === 0 ? 0 : Math.round((positive / classified) * 100),
+  };
+};
+
+export {
+  TREND_BUCKET_MS,
+  buildTrend,
+  countKeywords,
+  summarizeSentiments,
+  toRelativeTime,
+  type TrendPoint,
+};

--- a/components/moderation/ModerationQueue.tsx
+++ b/components/moderation/ModerationQueue.tsx
@@ -53,6 +53,12 @@ const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: Moderatio
         {items.slice(0, PREVIEW_LIMIT).map((feedback) => {
           const isHidden = feedback.status === 'HIDDEN';
 
+          /*
+           * 두 버튼이 같은 판정을 씁니다. 조치별로 나누면 숨기기가 도는 동안 삭제가 열려 있어서
+           * 같은 소감의 상태 전이가 경쟁합니다.
+           */
+          const isPending = actions.isItemPending(feedback.id);
+
           return (
             <li key={feedback.id}>
               <FeedItem
@@ -65,7 +71,7 @@ const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: Moderatio
                     <Button
                       variant="secondary"
                       size="sm"
-                      disabled={actions.isTogglePending(feedback.id)}
+                      disabled={isPending}
                       onClick={() => actions.toggleHidden(feedback)}
                     >
                       {isHidden ? '숨김 해제' : '숨기기'}
@@ -73,7 +79,7 @@ const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: Moderatio
                     <Button
                       variant="danger"
                       size="sm"
-                      disabled={actions.isRemovePending(feedback.id)}
+                      disabled={isPending}
                       onClick={() => actions.remove(feedback.id)}
                     >
                       삭제

--- a/components/moderation/ModerationQueue.tsx
+++ b/components/moderation/ModerationQueue.tsx
@@ -1,0 +1,92 @@
+import { FeedItem } from '@/components/feedback/FeedItem';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import type { ModerationActions } from '@/hooks/useModerationActions';
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 대시보드의 모더레이션 큐 위젯입니다. 독성으로 표시된 소감을 몇 건만 미리 보여주고
+ * 항목마다 숨기기·삭제를 답니다.
+ *
+ * 조치 자체는 `useModerationActions`가 알고 이 컴포넌트는 그리기만 합니다. 그래서
+ * "처리 실패" 배너를 화면 상단에 둘지 카드 안에 둘지도 이 파일이 정하지 않습니다.
+ *
+ * 숨긴 항목은 목록에서 빼지 않습니다. 되돌릴 수 있는 상태라 같은 자리에서 해제해야 합니다.
+ */
+
+/** 미리 보여주는 건수입니다. 나머지는 "전체보기"로 넘깁니다. */
+const PREVIEW_LIMIT = 3;
+
+/*
+ * 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직
+ * 없어서 두 줄이 겹치는데, 이 위젯 하나 때문에 공용 컴포넌트를 새로 만들지는 않았습니다.
+ */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+interface ModerationQueueProps {
+  /** 독성으로 표시된 소감입니다. 이미 숨긴 건도 들어옵니다. */
+  items: Feedback[];
+  /** "N건 대기"에 쓰는 값입니다. 처리를 끝낸 건은 빠진 숫자여야 합니다. */
+  waitingCount: number;
+  /** 소감 하나의 메타 문구를 만듭니다. 세션 제목을 아는 건 화면 쪽이라 밖에서 받습니다. */
+  formatMeta: (feedback: Feedback) => string;
+  actions: ModerationActions;
+}
+
+const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: ModerationQueueProps) => (
+  <section className={CARD}>
+    <div className="flex items-center justify-between gap-2">
+      <h2 className={CARD_TITLE}>모더레이션 큐</h2>
+      <div className="flex items-center gap-2">
+        <Badge tone="toxic">{waitingCount}건 대기</Badge>
+        {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
+        <span className="text-xs font-normal leading-4 text-text-tertiary">전체보기</span>
+      </div>
+    </div>
+
+    {items.length === 0 ? (
+      <EmptyState title="검토할 소감이 없어요" />
+    ) : (
+      <ul className="flex flex-col gap-2">
+        {items.slice(0, PREVIEW_LIMIT).map((feedback) => {
+          const isHidden = feedback.status === 'HIDDEN';
+
+          return (
+            <li key={feedback.id}>
+              <FeedItem
+                state={isHidden ? 'hidden' : 'flagged'}
+                sentiment="toxic"
+                meta={formatMeta(feedback)}
+                content={feedback.text}
+                actions={
+                  <>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      disabled={actions.isTogglePending(feedback.id)}
+                      onClick={() => actions.toggleHidden(feedback)}
+                    >
+                      {isHidden ? '숨김 해제' : '숨기기'}
+                    </Button>
+                    <Button
+                      variant="danger"
+                      size="sm"
+                      disabled={actions.isRemovePending(feedback.id)}
+                      onClick={() => actions.remove(feedback.id)}
+                    >
+                      삭제
+                    </Button>
+                  </>
+                }
+              />
+            </li>
+          );
+        })}
+      </ul>
+    )}
+  </section>
+);
+
+export { ModerationQueue };

--- a/hooks/useDashboardFeed.ts
+++ b/hooks/useDashboardFeed.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchModerationQueue } from '@/lib/api/endpoints';
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 주최자 대시보드가 보는 소감 목록입니다. 지금은 폴링이고 나중에 SSE로 승급합니다.
+ *
+ * 참가자 화면의 `useFeedbackSnapshot`과 나란히 있지만 보는 엔드포인트가 다릅니다. 저쪽은
+ * 서버가 집계해서 내려주는 공개 스냅샷이고, 이쪽은 `/admin/feedbacks`의 원본 목록입니다.
+ * 대시보드가 원본을 받아야 하는 이유는 세 가지입니다.
+ *
+ * 1. 독성 플래그 개수 — 공개 스냅샷의 `FeedbackView`에는 `toxic`이 없습니다. 모더레이션
+ *    신호를 공개 엔드포인트로 내보내지 않기로 한 계약이라 집계에도 안 실립니다.
+ * 2. 시간대별 감정 추이 — 스냅샷은 "지금"만 알려줘서 시계열을 만들 수 없습니다. 원본의
+ *    `createdAt`을 버킷으로 묶어야 나옵니다.
+ * 3. 숨기기·삭제 — 액션 대상이 되려면 `id`와 `status`가 필요합니다.
+ *
+ * `includeHidden`을 켜서 받는 이유는 모더레이션 큐가 이미 숨긴 건도 보여줘야 하기
+ * 때문입니다. 집계와 피드에서 빼는 일은 화면이 `status`로 거릅니다.
+ *
+ * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을
+ * 아는 코드는 이 파일에만 둡니다. `refetchInterval`을 밖으로 내보내지 않는 것도 같은 이유입니다.
+ */
+
+const REFRESH_INTERVAL_MS = 5_000;
+
+/** 숨기기·삭제 뒤 목록을 다시 받을 때 쓰는 키 앞자리입니다. */
+const DASHBOARD_FEED_KEY = 'dashboardFeed';
+
+interface UseDashboardFeedParams {
+  eventCode: string;
+  /** `null`이면 이벤트 전체입니다. 세션 필터의 "전체"가 이 값입니다. */
+  sessionId: number | null;
+}
+
+interface UseDashboardFeedResult {
+  feedbacks: Feedback[] | undefined;
+  isPending: boolean;
+  isError: boolean;
+  /**
+   * 화면이 "N초마다 갱신돼요"를 그릴 때 쓰는 값입니다.
+   * SSE로 바뀌면 `null`이 됩니다.
+   */
+  refreshIntervalMs: number | null;
+}
+
+const useDashboardFeed = ({
+  eventCode,
+  sessionId,
+}: UseDashboardFeedParams): UseDashboardFeedResult => {
+  const { data, isPending, isError } = useQuery({
+    queryKey: [DASHBOARD_FEED_KEY, eventCode, sessionId],
+    queryFn: () =>
+      fetchModerationQueue({
+        eventCode,
+        sessionId: sessionId ?? undefined,
+        includeHidden: true,
+      }),
+    refetchInterval: REFRESH_INTERVAL_MS,
+  });
+
+  return {
+    feedbacks: data,
+    isPending,
+    isError,
+    refreshIntervalMs: REFRESH_INTERVAL_MS,
+  };
+};
+
+export { useDashboardFeed, DASHBOARD_FEED_KEY };

--- a/hooks/useDashboardFeed.ts
+++ b/hooks/useDashboardFeed.ts
@@ -3,7 +3,8 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchModerationQueue } from '@/lib/api/endpoints';
-import type { Feedback } from '@/lib/schemas/api';
+import { ApiError } from '@/lib/apiClient';
+import { isClientError, type Feedback } from '@/lib/schemas/api';
 
 /**
  * 주최자 대시보드가 보는 소감 목록입니다. 지금은 폴링이고 나중에 SSE로 승급합니다.
@@ -30,6 +31,13 @@ const REFRESH_INTERVAL_MS = 5_000;
 /** 숨기기·삭제 뒤 목록을 다시 받을 때 쓰는 키 앞자리입니다. */
 const DASHBOARD_FEED_KEY = 'dashboardFeed';
 
+/**
+ * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를 거르는
+ * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴링도 하지 않습니다.
+ */
+const isPermanentFailure = (error: Error | null): boolean =>
+  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
 interface UseDashboardFeedParams {
   eventCode: string;
   /** `null`이면 이벤트 전체입니다. 세션 필터의 "전체"가 이 값입니다. */
@@ -41,8 +49,8 @@ interface UseDashboardFeedResult {
   isPending: boolean;
   isError: boolean;
   /**
-   * 화면이 "N초마다 갱신돼요"를 그릴 때 쓰는 값입니다.
-   * SSE로 바뀌면 `null`이 됩니다.
+   * 화면이 "N초마다 갱신돼요"를 그릴 때 쓰는 값입니다. 주기 갱신이 돌고 있지 않으면 `null`입니다.
+   * 폴링을 멈춘 실패에서 그렇고, SSE로 바뀌면 항상 `null`이 됩니다.
    */
   refreshIntervalMs: number | null;
 }
@@ -51,7 +59,7 @@ const useDashboardFeed = ({
   eventCode,
   sessionId,
 }: UseDashboardFeedParams): UseDashboardFeedResult => {
-  const { data, isPending, isError } = useQuery({
+  const { data, isPending, isError, error } = useQuery({
     queryKey: [DASHBOARD_FEED_KEY, eventCode, sessionId],
     queryFn: () =>
       fetchModerationQueue({
@@ -59,14 +67,24 @@ const useDashboardFeed = ({
         sessionId: sessionId ?? undefined,
         includeHidden: true,
       }),
-    refetchInterval: REFRESH_INTERVAL_MS,
+    /*
+     * 폴링 타이머는 에러 상태에서도 그대로 돕니다. `QueryObserver`가 간격을 다시 잴 때 보는 건
+     * `enabled`와 간격값뿐이라 실패 여부는 아예 안 봅니다. 그래서 로그인이 풀린 화면이 401을
+     * 5초마다 새로 받아냅니다. `retry`가 이미 4xx를 거르고 있어서 재시도로도 안 잡힙니다.
+     *
+     * 5xx·네트워크 끊김은 계속 돌립니다. 저쪽은 다음 번에 성공할 수 있는 실패라, 여기서 같이
+     * 멈추면 순간 장애 한 번에 진행 중인 이벤트의 대시보드가 영영 멈춥니다. `refetchOnWindowFocus`도
+     * 꺼져 있어서 탭을 다시 봐도 살아나지 않고, 남는 복구 수단이 새로고침뿐입니다.
+     */
+    refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
   });
 
   return {
     feedbacks: data,
     isPending,
     isError,
-    refreshIntervalMs: REFRESH_INTERVAL_MS,
+    /* 폴링이 멈춘 뒤에도 "5초마다 갱신"을 그리면 거짓말이 됩니다. 화면은 `null`이면 라벨을 감춥니다. */
+    refreshIntervalMs: isPermanentFailure(error) ? null : REFRESH_INTERVAL_MS,
   };
 };
 

--- a/hooks/useModerationActions.ts
+++ b/hooks/useModerationActions.ts
@@ -20,9 +20,14 @@ interface ModerationActions {
   /** `HIDDEN`이면 숨김 해제, 아니면 숨김입니다. */
   toggleHidden: (feedback: Feedback) => void;
   remove: (feedbackId: number) => void;
-  /** 이 소감의 숨김 전환이 서버 응답을 기다리는 중인지 봅니다. */
-  isTogglePending: (feedbackId: number) => boolean;
-  isRemovePending: (feedbackId: number) => boolean;
+  /**
+   * 이 소감에 건 조치가 서버 응답을 기다리는 중인지 봅니다. 셋 중 무엇이든 걸립니다.
+   *
+   * 조치별로 나누지 않은 이유는 같은 소감의 상태 전이가 서로 경쟁하기 때문입니다.
+   * 숨기기가 도는 동안 삭제 버튼이 열려 있으면 두 요청이 같은 소감을 두고 겹치고,
+   * 진 쪽이 `FEEDBACK_ALREADY_DELETED`로 떨어져 쓸데없는 실패 배너를 띄웁니다.
+   */
+  isItemPending: (feedbackId: number) => boolean;
   /** 세 조치 중 하나라도 실패했는지 봅니다. 화면이 배너를 그릴 때 씁니다. */
   isError: boolean;
 }
@@ -68,7 +73,10 @@ const useModerationActions = (): ModerationActions => {
    * 공유해서, 한 건을 처리하는 동안 누르지 않은 항목의 버튼까지 잠깁니다. `variables`에는
    * `mutate`에 넘긴 id가 요청이 도는 동안 남아 있어서, 대상이 누구인지 여기서 가릅니다.
    *
-   * 이 비교를 화면마다 다시 쓰게 두면 한 곳만 빠뜨렸을 때 같은 버그가 되살아납니다.
+   * 반대로 같은 소감 안에서는 조치를 나누지 않고 셋을 함께 잠급니다. 나누면 숨기기가 도는
+   * 동안 삭제가 열려 있어서 같은 소감의 상태 전이가 경쟁합니다.
+   *
+   * 이 판정을 화면마다 다시 쓰게 두면 한 곳만 빠뜨렸을 때 같은 버그가 되살아납니다.
    */
   return {
     toggleHidden: (feedback) => {
@@ -82,11 +90,10 @@ const useModerationActions = (): ModerationActions => {
     remove: (feedbackId) => {
       deleteMutation.mutate(feedbackId);
     },
-    isTogglePending: (feedbackId) =>
+    isItemPending: (feedbackId) =>
       (hideMutation.isPending && hideMutation.variables === feedbackId) ||
-      (showMutation.isPending && showMutation.variables === feedbackId),
-    isRemovePending: (feedbackId) =>
-      deleteMutation.isPending && deleteMutation.variables === feedbackId,
+      (showMutation.isPending && showMutation.variables === feedbackId) ||
+      (deleteMutation.isPending && deleteMutation.variables === feedbackId),
     isError: hideMutation.isError || showMutation.isError || deleteMutation.isError,
   };
 };

--- a/hooks/useModerationActions.ts
+++ b/hooks/useModerationActions.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { DASHBOARD_FEED_KEY } from '@/hooks/useDashboardFeed';
+import { showToast } from '@/hooks/useToast';
+import { deleteFeedback, hideFeedback, showFeedback } from '@/lib/api/endpoints';
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 주최자가 소감 하나에 취할 수 있는 조치입니다. 숨기기·숨김 해제·삭제 세 가지입니다.
+ *
+ * 훅으로 묶은 이유는 두 화면이 같은 조치를 쓰기 때문입니다. 지금은 대시보드의 모더레이션
+ * 큐 위젯이고, "전체보기" 모달(`components/moderation/ModerationQueueModal.tsx`)이
+ * 같은 API 세 개를 씁니다. 성공 후 목록을 다시 받는 일과 토스트 문구가 두 곳에 흩어지면
+ * 한쪽만 바뀝니다.
+ */
+
+interface ModerationActions {
+  /** `HIDDEN`이면 숨김 해제, 아니면 숨김입니다. */
+  toggleHidden: (feedback: Feedback) => void;
+  remove: (feedbackId: number) => void;
+  /** 이 소감의 숨김 전환이 서버 응답을 기다리는 중인지 봅니다. */
+  isTogglePending: (feedbackId: number) => boolean;
+  isRemovePending: (feedbackId: number) => boolean;
+  /** 세 조치 중 하나라도 실패했는지 봅니다. 화면이 배너를 그릴 때 씁니다. */
+  isError: boolean;
+}
+
+const useModerationActions = (): ModerationActions => {
+  const queryClient = useQueryClient();
+
+  const invalidateFeed = () => {
+    queryClient.invalidateQueries({ queryKey: [DASHBOARD_FEED_KEY] });
+  };
+
+  const hideMutation = useMutation({
+    mutationFn: hideFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('소감을 숨겼어요');
+    },
+  });
+
+  /*
+   * 숨김은 되돌릴 수 있는 상태입니다(요구사항 소감 상태 전이 4번). 종단 상태는 `DELETED`뿐이라,
+   * 숨긴 건은 큐에 남겨두고 같은 버튼으로 되돌립니다. 큐가 `includeHidden=true`로 받는 것도
+   * 이 되돌리기 때문입니다.
+   */
+  const showMutation = useMutation({
+    mutationFn: showFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('숨김을 해제했어요');
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: deleteFeedback,
+    onSuccess: () => {
+      invalidateFeed();
+      showToast('소감을 삭제했어요');
+    },
+  });
+
+  /*
+   * 잠금 판정이 id를 받는 이유입니다. `isPending`만 보면 목록의 모든 항목이 mutation 하나를
+   * 공유해서, 한 건을 처리하는 동안 누르지 않은 항목의 버튼까지 잠깁니다. `variables`에는
+   * `mutate`에 넘긴 id가 요청이 도는 동안 남아 있어서, 대상이 누구인지 여기서 가릅니다.
+   *
+   * 이 비교를 화면마다 다시 쓰게 두면 한 곳만 빠뜨렸을 때 같은 버그가 되살아납니다.
+   */
+  return {
+    toggleHidden: (feedback) => {
+      if (feedback.status === 'HIDDEN') {
+        showMutation.mutate(feedback.id);
+        return;
+      }
+
+      hideMutation.mutate(feedback.id);
+    },
+    remove: (feedbackId) => {
+      deleteMutation.mutate(feedbackId);
+    },
+    isTogglePending: (feedbackId) =>
+      (hideMutation.isPending && hideMutation.variables === feedbackId) ||
+      (showMutation.isPending && showMutation.variables === feedbackId),
+    isRemovePending: (feedbackId) =>
+      deleteMutation.isPending && deleteMutation.variables === feedbackId,
+    isError: hideMutation.isError || showMutation.isError || deleteMutation.isError,
+  };
+};
+
+export { useModerationActions, type ModerationActions };


### PR DESCRIPTION
## 변경 사항

이슈 #115의 대시보드 본체를 구현했습니다. 시안의 ④ 세션 필터, ⑤ 숨기기, ⑥ 삭제, ⑦ 요약 생성 버튼(비활성 상태), ⑧ 실시간 갱신, ⑩ 세션 상태가 들어갔습니다.

- `hooks/useDashboardFeed.ts` (신규) — `GET /admin/feedbacks` 폴링 훅입니다. `includeHidden=true`로 한 번 받아서 집계·피드·모더레이션 큐가 나눠 씁니다.
- `components/dashboard/DashboardView.tsx` (신규) — 화면 전체입니다. 대시보드가 CSR이라 페이지는 껍데기만 두고 여기가 본체입니다.
- `app/(host)/events/[eventCode]/dashboard/page.tsx` — 스켈레톤을 걷어내고 위 아일랜드를 렌더링합니다.

**공개 스냅샷(`GET /events/{eventCode}/feedbacks`)을 쓰지 않았습니다.** 이유가 셋입니다.

1. 독성 플래그 개수 — `FeedbackView`에 `toxic`이 없습니다. 모더레이션 신호를 공개 엔드포인트로 내보내지 않기로 한 계약이라 집계에도 안 실립니다.
2. 시간대별 감정 추이 — 스냅샷은 "지금"만 알려줘서 시계열을 만들 수 없습니다. 원본의 `createdAt`을 버킷으로 묶어야 나옵니다.
3. 숨기기·삭제 — 액션 대상이 되려면 `id`와 `status`가 필요합니다.

이슈 본문에 있던 "`useFeedbackSnapshot`의 `enabled: sessionId !== null` 조정" 항목은 그래서 하지 않았습니다. 대시보드가 다른 엔드포인트를 보게 되면서 필요가 없어졌고, 참가자 화면(`/e/{code}/live`)의 갱신 주기도 건드리지 않습니다.

**이벤트 조회도 공개에서 소유자 전용으로 바꿨습니다(2번 커밋).** 아래 트러블슈팅 1번에 사유를 적었습니다.

**후속 수정 5건을 더 올렸습니다(3~7번 커밋).** 로딩 스켈레톤이 스크린리더에 아무것도 알리지 않던 문제, 모더레이션 "N건 대기"가 이미 숨긴 소감까지 세던 문제, 인증이 풀린 화면이 401을 5초마다 반복 요청하던 문제, **숨긴 소감을 화면에서 되돌릴 수 없던 문제**, 그리고 한 건을 처리하는 동안 큐의 다른 항목 버튼까지 잠기던 문제입니다. 폴링 건은 트러블슈팅 5번, 뒤의 두 건은 트러블슈팅 6번에 적었습니다.

**숨김 해제(6번 커밋)는 원래 "이 PR 범위 밖"으로 남겨뒀던 항목입니다.** 리뷰에서 "API상 전환이 되는 걸로 아는데 토글이어야 하지 않냐"는 지적을 받아 이 PR에서 처리했습니다. 아래 트러블슈팅 4번에 있던 미해결 항목이 그래서 없어졌습니다.

**마지막으로 화면을 파일 다섯 개로 나눴습니다(8~11번 커밋).** `DashboardView.tsx`가 505줄로 레포에서 가장 큰 파일이 됐고(2위 `LiveResult.tsx`의 2.5배), 한 파일에 컴포넌트가 둘이었으며, 모더레이션 큐가 대시보드 파일 안에 있었습니다. 트러블슈팅 7번에 적었습니다. **ndopy 님이 리뷰에서 요청한 계산 로직 테스트도 이때 붙였습니다**(71개 → 83개).

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| 4084871 | feat(dashboard): 주최자 실시간 모니터링 대시보드 구현 | 시안의 화면을 채웠습니다. 데이터 소스로 관리자 목록을 고른 근거는 위에 적었습니다. |
| 8e618d1 | refactor(dashboard): 이벤트 조회를 소유자 전용 목록으로 바꿈 | 리뷰 중 "관리자 전용 화면인데 공개 엔드포인트를 쓴다"는 지적을 받아, 인증·소유권을 서버가 보게 고쳤습니다. |
| ba722b1 | fix(dashboard): 로딩 스켈레톤을 스크린리더에 알림 | 스켈레톤 전체가 `aria-hidden`이라 로딩 중이라는 사실이 전혀 전달되지 않았습니다. 첫 진입과 세션 전환에서 화면이 그냥 빈 것처럼 읽혔습니다. |
| bbd0f3d | fix(dashboard): 모더레이션 대기 건수에서 숨긴 소감을 제외 | "N건 대기"가 `includeHidden=true` 목록을 세서 처리를 끝낸 건까지 대기로 잡혔습니다. 숨기기를 눌러도 숫자가 줄지 않았습니다. 같은 화면의 "독성 플래그" `Stat`이 쓰는 값으로 맞췄습니다. |
| bcdedd4 | fix(dashboard): 인증 오류에서 소감 폴링을 멈춤 | 401이 5초마다 반복되던 문제입니다. 트러블슈팅 5번. |
| 79085aa | fix(dashboard): 숨긴 소감을 큐에서 되돌릴 수 있게 함 | "숨기기"가 `HIDDEN`에서 `disabled`라 실수로 숨긴 건을 푸는 경로가 없었습니다. `/show`는 이미 있어서 버튼을 토글로 바꿨습니다. 트러블슈팅 6번. |
| ec68a82 | fix(dashboard): 처리 중 버튼 잠금을 누른 항목으로 좁힘 | `isPending`이 mutation 단위라 한 건을 처리하는 동안 미리보기 세 건의 같은 버튼이 전부 잠겼습니다. 트러블슈팅 6번. |
| a5bb149 | refactor(dashboard): 로딩 스켈레톤을 별도 컴포넌트로 분리 | 한 파일에 컴포넌트가 둘이라 "파일명 = 컴포넌트명" 규칙과 어긋났습니다. `components/live/LiveSkeleton.tsx` 선례를 따랐습니다. |
| d18f67e | refactor(dashboard): 집계 계산을 metrics 모듈로 분리 | 숫자를 정하는 규칙이 렌더 코드 사이에 흩어져 있었습니다. `components/feedback/sentiment.ts`와 같은 방식입니다. |
| 4c06b33 | test(dashboard): 집계 계산에 테스트 추가 | ndopy 님이 요청한 항목입니다. 계산이 순수 함수가 되면서 붙일 수 있게 됐습니다. |
| b346c3a | refactor(moderation): 모더레이션 큐를 컴포넌트와 훅으로 분리 | 도메인이 다른 코드가 대시보드 파일에 섞여 있었습니다. 액션 3종은 `useModerationActions`로 묶어 전체보기 모달이 재사용합니다. |
| 1fa5dc0 | fix(moderation): 처리 중 잠금을 항목 단위로 합침 | 잠금이 조치별로 나뉘어 있어서 숨기기 요청 중 같은 소감의 삭제 버튼이 열려 있었습니다. 트러블슈팅 6번. |

## 관련 이슈

- Refs #115

## 스크린샷

경우별로 12장을 찍었습니다. 파일명이 곧 경우입니다.

| 파일 | 경우 | 확인한 것 |
| --- | --- | --- |
| `01-live-desktop-top` | LIVE 정상(`ab3f9x`) 상단 | 22건 · 긍정 40% · 독성 3 · 미분류 2, 도넛과 추이 |
| `02-live-desktop-bottom` | LIVE 정상 하단 | 피드 · 모더레이션 큐 · 상위 키워드 · AI 요약 |
| `03-session-filter-selected` | 세션 필터 "1부: 키노트" | 8건 · 29% · 독성 1 · 미분류 1. 추이 가로축도 09:00~09:15로 좁아짐 |
| `04-hide-toast` | 숨기기 | "소감을 숨겼어요" 토스트 + 22→21건, 독성 3→2, 해당 항목이 숨김 상태로 바뀜 |
| `05-delete-toast` | 삭제 | "소감을 삭제했어요" 토스트 + 큐 4건→3건 |
| `06-empty-no-feedback` | 소감 0건(`zq1v8t`, DRAFT) | 배너 없이 빈 상태 3종 |
| `07-ended-event-top` | 종료된 이벤트(`kd7m2p`) 상단 | `ENDED` 배지, 6건 · 40% |
| `08-ended-report-button-enabled` | 종료된 이벤트 하단 | "요약 생성" 버튼이 활성 상태(LIVE에서는 비활성) |
| `09-forbidden-unknown-event` | 없는 코드 또는 남의 이벤트 | "이 이벤트를 볼 수 없어요" |
| `10-unauthorized-login-required` | 비로그인 | "로그인이 필요한 화면이에요". 제목·세션 칩이 먼저 그려지는 반쪽 화면이 사라짐 |
| `11-mobile-375-top` | 모바일 375px 상단 | `Stat` 2열, 칩 2줄 줄바꿈 |
| `12-mobile-375-bottom` | 모바일 375px 하단 | 차트·피드가 세로로 쌓임 |

못 찍은 경우가 둘 있습니다.

- **로딩 스켈레톤** — MSW가 한 프레임 만에 응답해서 화면으로는 못 잡았습니다. 프레임 단위 계측으로만 확인했습니다(트러블슈팅 3번).
- **로그인한 주최자에게 일어나는 진짜 실패(5xx·네트워크 끊김)** — MSW에 해당 핸들러가 없어 재현하지 못했습니다.
<img width="1536" height="686" alt="01-live-desktop-top" src="https://github.com/user-attachments/assets/ea1ad3ee-5265-4481-927f-5cbec18cf1cf" />
<img width="1536" height="686" alt="02-live-desktop-bottom" src="https://github.com/user-attachments/assets/99b7e834-9d0f-4e2d-b6d5-61d43fa02b97" />
<img width="1536" height="686" alt="03-session-filter-selected" src="https://github.com/user-attachments/assets/b50a3b11-4fc0-4747-bed6-3f6b74d15dfd" />
<img width="1536" height="686" alt="04-hide-toast" src="https://github.com/user-attachments/assets/dc9576c3-b61c-4a13-8094-6b8067bf479b" />
<img width="1536" height="686" alt="05-delete-toast" src="https://github.com/user-attachments/assets/80a5054a-32fb-481d-ada9-2fdd8f2ca91d" />
<img width="1536" height="686" alt="06-empty-no-feedback" src="https://github.com/user-attachments/assets/6ea64eec-1f25-43bf-80a7-3f56ca23cd82" />
<img width="1536" height="686" alt="07-ended-event-top" src="https://github.com/user-attachments/assets/e84f06f4-be17-4550-a0f0-b585677a445c" />
<img width="1536" height="686" alt="08-ended-report-button-enabled" src="https://github.com/user-attachments/assets/3d759be8-4642-4925-93c8-baa4acdf997a" />
<img width="1536" height="686" alt="09-forbidden-unknown-event" src="https://github.com/user-attachments/assets/0cbdcbf6-a37c-4eda-80e8-283433386584" />
<img width="1536" height="686" alt="10-unauthorized-login-required" src="https://github.com/user-attachments/assets/9df33c49-a7b0-4b63-b9bd-fff4506c4249" />
<img width="209" height="371" alt="11-mobile-375-top" src="https://github.com/user-attachments/assets/936d169e-892c-46bb-b75c-7a3e3c209a5d" />
<img width="209" height="371" alt="12-mobile-375-bottom" src="https://github.com/user-attachments/assets/b2a97459-bd09-4f04-ab70-1f1273947b83" />

## 검증 방법

MSW 목을 켠 `npm run dev`에서 **`host@example.com`으로 로그인한 상태로** 확인했습니다.

| 확인 항목 | 결과 |
| --- | --- |
| 집계·키워드·최신 소감 렌더 | ✅ 스크린샷 01·02 |
| 폴링 갱신 | ✅ MSW 콘솔 로그로 간격 확인 |
| 세션 칩 전체 ↔ 세션별 전환 | ✅ 스크린샷 03. 통계·차트·피드·큐가 모두 따라 바뀜. 다만 트러블슈팅 3번 참고 |
| 숨기기·삭제 동작 | ✅ 스크린샷 04·05. 숨긴 건이 집계와 피드에서 빠지고 큐에는 숨김 상태로 남음 |
| 소감 0건 빈 상태 | ✅ 스크린샷 06 |
| 종료된 이벤트에서 요약 생성 버튼 활성 | ✅ 스크린샷 08 |
| 볼 수 없는 이벤트 | ✅ 스크린샷 09 |
| 비로그인 | ✅ 스크린샷 10 |
| 모바일 폭 | ✅ 스크린샷 11·12. 375px에서 `Stat` 2열(161.6px×2), `scrollWidth === innerWidth === 375`, 가로로 넘치는 자식 요소 0개 |
| 로그인한 주최자의 실패 화면 | ⚠️ **미재현.** MSW에 5xx 핸들러가 없습니다 |
| 인증 오류에서 폴링 정지 (5번 커밋) | ⚠️ **브라우저 미재현.** 비로그인 상태에서 401 반복이 실제로 멎는지는 다시 찍지 않았습니다 |
| 대기 건수 집계 (4번 커밋) | ✅ 확인 했습니다. |
| 숨김 해제 토글 (6번 커밋) | ✅ 확인했습니다. 숨기기 → 22건·40%·독성 3·3건 대기가 21건·42%·독성 2·2건 대기로 바뀌고 라벨이 "숨김 해제"로, 다시 누르니 원래 값으로 정확히 복귀 |
| 처리 중 잠금 범위 (7·12번 커밋) | ✅ 확인 했습니다. |
| 분리 후 렌더가 같은지 (8~11번 커밋) | ✅ 확인했습니다. `ab3f9x` 전체(22건·40%·독성 3·미분류 2), 세션 필터 "1부: 키노트"(8건·29%·독성 1·미분류 1), 소감 0건(`zq1v8t`)이 분리 전 스크린샷과 같은 값 |

명령 결과입니다. **12번 커밋(`1fa5dc0`)까지 올린 상태에서 네 개를 모두 다시 돌렸습니다.**

```
$ npm run lint
(출력 없음 — 위반 없음)

$ npx tsc --noEmit
(출력 없음)

$ npm run test
Test Files  4 passed (4)
     Tests  83 passed (83)
  Duration  2.75s

$ npm run build
✓ Compiled successfully in 11.1s
✓ Generating static pages using 7 workers (9/9) in 898ms
ƒ /events/[eventCode]/dashboard
```

**테스트가 71개에서 83개로 늘었습니다.** ndopy 님이 요청한 계산 로직(`buildTrend`·`countKeywords`·긍정 비율)에 12개를 붙였습니다. 계산이 컴포넌트 안에 있을 때는 `vitest`가 `environment: 'node'`라 손댈 수 없었는데, `metrics.ts`로 빼면서 가능해졌습니다.

**아직 테스트가 없는 곳은 그대로 남아 있습니다.** 폴링 정지(`refetchInterval`이 에러 상태에서 `false`를 돌려주는지)와 화면 단위 동작(숨김 해제 토글, 잠금 범위)입니다. 앞엣것은 훅이라, 뒤엣것은 컴포넌트 렌더라 지금 `node` 환경에서는 붙일 수 없습니다. jsdom을 들이는 판단이 필요해서 이 PR에서는 하지 않았습니다.

### 리뷰어가 직접 볼 때

**로그인이 전제 조건입니다.** 로그인 페이지가 아직 실제 로그인을 하지 않아서(#108), 콘솔에서 아래를 실행하고 새로고침하세요. 건너뛰면 스크린샷 10번 화면이 나옵니다.

```js
await fetch('http://localhost:8080/api/v1/auth/login', {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },
  credentials: 'include',
  body: JSON.stringify({ email: 'host@example.com', password: 'pulse1234' }),
});
```

시드(`mocks/data/seed.ts`)에 이벤트가 세 가지 상태로 준비돼 있습니다. 셋 다 `host@example.com` 소유입니다.

| 주소 | 시드 상태 | 보이는 것 |
| --- | --- | --- |
| `/events/ab3f9x/dashboard` | LIVE, 세션 3개, 소감 22건(독성·미분류·숨김 섞임) | 정상 화면 |
| `/events/zq1v8t/dashboard` | DRAFT, 세션 0개, 소감 0건 | 소감 0건 화면 |
| `/events/kd7m2p/dashboard` | ENDED, 소감 6건 | "요약 생성" 버튼이 활성 상태 |
| `/events/nope99/dashboard` | (없는 코드) | "이 이벤트를 볼 수 없어요" |

숨기기·삭제는 목 데이터를 바꾸지만 새로고침하면 시드로 돌아옵니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음. 다만 **`recharts`가 이 PR에서 처음 실제로 쓰입니다.** 지금까지 설치만 돼 있고 import하는 곳이 없었습니다. 기존 차트(`Donut`·`Thermometer`)는 직접 그린 SVG입니다.
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 1. 관리자 전용 화면인데 공개 엔드포인트를 쓰고 있었습니다

처음에는 이벤트 정보를 `GET /events/{eventCode}`(공개)로 받았습니다. 이 경로는 인증을 보지 않아서, 로그인하지 않은 사람이 주소를 직접 쳐도 제목과 세션 칩이 그려지고 소감만 401이 났습니다. 숫자가 전부 0인 멀쩡한 화면처럼 보입니다.

```
[MSW] GET /api/v1/events/ab3f9x           200 OK   ← 공개
[MSW] GET /api/v1/events/ab3f9x/sessions  200 OK   ← 공개
[MSW] GET /api/v1/admin/feedbacks         401 Unauthorized
```

남의 이벤트 코드도 같은 문제가 있었습니다. `/admin/feedbacks`는 내 소감만 거른 뒤 `eventCode`로 다시 거르기 때문에, 교집합이 비면 403이 아니라 **빈 배열을 200으로** 돌려줍니다. 남의 대시보드가 "소감 0건인 조용한 이벤트"로 보입니다.

그래서 `GET /events`(인증·내 이벤트 목록)를 받아 코드로 찾도록 바꿨습니다. 인증과 소유권을 서버가 한 번에 보고, 못 보는 이벤트는 목록에 아예 없어서 두 경우 다 화면이 뜨기 전에 걸립니다(스크린샷 09·10).

**세션 목록에는 대안이 없습니다.** API 명세서를 확인했는데, 세션은 쓰기(`POST`·`PATCH`·`DELETE`)만 소유자 전용이고 읽기는 게스트의 제출 대상 선택과 공용인 한 벌뿐입니다. `/admin/*`도 명세상 모더레이션 큐만 있습니다. 그래서 세션 조회는 공개인 채로 뒀고, 대신 판정 순서를 이벤트 뒤로 옮겼습니다. 세션 쪽이 없는 코드에 404를 내는데 먼저 보면 "볼 수 없는 이벤트"가 전부 "불러올 수 없어요"로 뭉개집니다.

### 2. 계산에서 판단한 것 둘

- **긍정 비율 분모에서 미분류를 뺐습니다.** `UNKNOWN`은 태깅 실패라 진짜 중립(`NEU`)과 다릅니다. 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다. 대신 "미분류 N건"을 `Stat`으로 따로 뒀습니다.
- **추이는 누적이 아니라 5분 칸별 건수입니다.** 누적이면 반응이 몰린 지점이 기울기로만 남아서 진행 중에 "지금 분위기가 꺾였다"를 읽기 어렵습니다. 첫 소감 시각을 칸 경계로 내림해서 시작하므로, 폴링으로 뒤에 붙는 소감이 앞 칸 경계를 밀지 않습니다.

### 3. 이 PR이 `showToast`의 첫 사용처입니다

`hooks/useToast.ts`는 #61에서 만들어졌는데 지금까지 어느 화면도 부르지 않았습니다. 숨기기·삭제가 첫 호출부입니다(스크린샷 04·05에서 실제로 뜨는 것을 확인했습니다).

### 4. 남은 사소한 어긋남

- 소감 0건 화면에서 모더레이션 큐의 "0건 대기" 배지가 `toxic` 톤(분홍)으로 뜹니다(스크린샷 06). 검토할 게 없는데 경고색이라 시안과 어긋납니다. 리뷰에서 정해지면 `neutral` 톤이나 배지 숨김으로 바꾸겠습니다.
- ~~**숨긴 소감을 화면에서 되돌릴 수 없습니다.**~~ → 6번 커밋(`79085aa`)에서 처리했습니다. 트러블슈팅 6번을 봐주세요.
- **대시보드 하단에 "모더레이션 큐 (준비 중)"이 그대로 노출됩니다.** `page.tsx`가 `ModerationQueueModal` 스텁을 렌더하는데, 그 스텁이 아직 문구만 돌려줍니다(첫 커밋부터 그랬고 이번 분리와는 무관합니다). **개발 단계라 그대로 두기로 했습니다.** 전체보기 모달 이슈에서 이 자리가 채워집니다.

### 5. 에러 상태에서도 폴링 타이머가 계속 돕니다

`refetchInterval: 5_000`처럼 숫자로 두면 쿼리가 실패해도 타이머가 멈추지 않습니다. `QueryObserver`가 간격을 다시 잴 때(`#updateRefetchInterval`) 보는 건 서버 환경 여부·`enabled`·간격값뿐이고 실패 여부는 아예 확인하지 않습니다. 그래서 로그인이 풀린 대시보드(스크린샷 10)가 성공할 수 없는 401을 5초마다 새로 받아냈습니다. 전역 `retry`는 4xx를 이미 거르고 있어서 재시도 경로로는 막히지 않습니다.

`refetchInterval`을 함수로 바꿔 해결했습니다. `onQueryUpdate`가 상태 변화마다 간격을 다시 계산하므로, 에러로 전이되는 시점에 `false`를 돌려주면 타이머가 실제로 해제됩니다.

**멈추는 범위를 "모든 에러"가 아니라 "다시 물어봐도 같은 답이 오는 실패"로 좁혔습니다.** 판정 기준은 `QueryProvider`의 `retry`와 같은 4xx + `INVALID_RESPONSE`입니다. 5xx·네트워크 끊김까지 같이 멈추면 순간 장애 한 번에 진행 중인 이벤트의 대시보드가 새로고침 전까지 복구되지 않습니다. `refetchOnWindowFocus`도 꺼져 있어서 탭을 다시 봐도 살아나지 않습니다.

폴링이 멈추면 `refreshIntervalMs`도 `null`을 돌려줍니다. 갱신이 끝난 화면이 "5초마다 갱신"을 계속 그리면 거짓말이 되기 때문입니다. 화면은 이 값이 `null`이면 라벨을 감추게 이미 돼 있었습니다.

같은 판정 기준이 `QueryProvider`와 `useDashboardFeed` 두 곳에 생겼습니다. 한쪽만 바뀌면 어긋나므로 `lib/`로 빼는 편이 나을 수 있는데, 이 PR 범위 밖이라 두었습니다.

### 6. 모더레이션 버튼의 `disabled`에 성격이 다른 두 조건이 섞여 있었습니다

원래 조건은 이랬습니다.

```tsx
disabled={feedback.status === 'HIDDEN' || hideMutation.isPending}
//        ↑ 영구 잠금                      ↑ 요청 왕복 동안만 잠금
```

**앞쪽은 틀린 조건이었습니다.** 되돌릴 수 없는 상태는 `DELETED`뿐이고(`/hide`·`/show` 모두 `FEEDBACK_ALREADY_DELETED` 409), 숨김은 되돌릴 수 있습니다(요구사항 소감 상태 전이 4번). 게다가 큐가 `includeHidden=true`로 받아서 숨긴 건이 목록에 그대로 남기 때문에, **화면에는 보이는데 되돌릴 방법만 없는** 상태였습니다. `showFeedback`·MSW `/show` 핸들러·"숨김 해제하면 다시 집계에 들어온다" 목 테스트가 이미 다 있어서 화면 배선만 붙였습니다. 버튼 라벨이 `HIDDEN`이면 "숨김 해제"로 바뀌고, 실패는 기존 배너가 받습니다.

**뒤쪽은 방향은 맞는데 범위가 넓었습니다.** `useMutation`을 컴포넌트에서 한 번 선언해 미리보기 세 건이 인스턴스 하나를 공유하므로, `isPending`은 "이 항목이 처리 중인가"가 아니라 "이 mutation이 요청 중인가"입니다. 1번 항목의 숨기기를 누르면 2·3번 항목의 숨기기까지 같이 잠겼습니다(삭제 버튼도 같은 문제였습니다). `mutate`에 넘긴 id가 요청이 도는 동안 `variables`에 남는 것을 이용해 대상 id 비교를 붙였습니다.

```tsx
disabled={hideMutation.isPending && hideMutation.variables === feedback.id}
```

중복 클릭 방지는 그대로 두면서 잠금이 누른 항목에만 걸립니다.

**그런데 항목 안에서 조치별로 나눈 게 또 문제였습니다(12번 커밋).** 숨기기 요청이 도는 동안 같은 소감의 삭제 버튼은 열려 있었습니다. 반대도 마찬가지입니다. 두 요청이 같은 소감의 상태 전이를 두고 겹치면 진 쪽이 실패로 떨어지고, 사용자가 잘못한 게 없는데 "소감 처리에 실패했어요" 배너만 뜹니다.

`isTogglePending`·`isRemovePending`을 `isItemPending` 하나로 합쳐 세 mutation을 모두 보게 했습니다. 큐의 두 버튼이 같은 판정을 씁니다. 잠기는 범위는 여전히 그 소감 하나뿐이라 다른 항목은 그대로 조작할 수 있습니다.

### 7. 화면 하나가 레포에서 가장 큰 파일이 됐습니다

`DashboardView.tsx`가 505줄이었습니다. 2위 화면인 `LiveResult.tsx`(203줄)의 2.5배입니다. 팀 컨벤션과 어긋나는 지점이 셋이라 파일을 나눴습니다.

| 새 파일 | 줄 | 왜 |
| --- | --- | --- |
| `components/dashboard/DashboardSkeleton.tsx` | 23 | 한 파일에 컴포넌트가 둘이면 "파일명 = 컴포넌트명" 규칙과 어긋납니다. 참가자 화면은 이미 `LiveSkeleton.tsx`로 떼어 놨습니다 |
| `components/dashboard/metrics.ts` | 133 | 숫자를 정하는 규칙(미분류를 분모에서 빼기, 칸 경계 내림)이 렌더 코드 사이에 흩어져 있었습니다. `components/feedback/sentiment.ts`와 같은 방식입니다 |
| `components/dashboard/metrics.test.ts` | 129 | 위가 순수 함수가 되면서 붙일 수 있게 된 테스트입니다 |
| `components/moderation/ModerationQueue.tsx` | 92 | `components/ui/README.md`가 정한 분류 기준대로면 도메인을 아는 코드는 `components/<도메인>/`입니다. 같은 폴더의 전체보기 모달 스텁이 같은 API 세 개를 씁니다 |
| `hooks/useModerationActions.ts` | 94 | 숨기기·숨김 해제·삭제 mutation과 항목별 잠금 판정입니다. 전체보기 모달이 같은 훅을 씁니다 |

`DashboardView.tsx`는 505 → 382줄이 됐습니다. **예상했던 250줄까지는 못 내려갔습니다.** 남은 부피는 추이 차트(recharts 설정 70줄)와 판정 근거를 적은 주석입니다. 차트까지 빼면 더 줄지만, 한 번만 쓰이는 조각을 파일로 만드는 값이 있는지는 따로 판단할 문제라 이번에는 두었습니다.

**잠금 판정을 훅 안에 가둔 이유**가 하나 더 있습니다. `variables === id` 비교를 화면마다 다시 쓰게 두면, 새 화면에서 한 번 빠뜨렸을 때 6번의 버그가 그대로 되살아납니다. 지금은 `isTogglePending(id)`를 부르는 것 말고는 방법이 없습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 12개라 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었고, 재현하지 못한 항목은 그렇게 표시했습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 이벤트 대시보드가 추가되어 세션별 피드백과 주요 통계를 확인할 수 있습니다.
  * 감정 분포·추이 차트, 실시간 피드, 상위 키워드 및 AI 요약 기능을 제공합니다.
  * 유해하거나 부적절한 소감을 검토하고 숨김 또는 삭제할 수 있습니다.
  * 대시보드 피드가 자동으로 갱신되어 최신 피드백을 확인할 수 있습니다.

* **개선 사항**
  * 숨겨진 소감은 일반 피드와 통계에서 제외되며, 모더레이션 목록에서는 확인할 수 있습니다.
  * 로딩, 오류 및 작업 처리 상태가 화면에 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
