### PR TITLE
chore(mocks): 이벤트 eventDate를 계약 스키마와 목에 반영

### DIFF
--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -74,6 +74,15 @@ const id = z.int().positive();
 const isoDateTime = z.iso.datetime();
 
 /**
+ * 타임존이 없는 달력 날짜(`YYYY-MM-DD`)입니다. `isoDateTime`과 달리 시각이 없습니다.
+ *
+ * 이 값을 `new Date(...)`에 넣지 마세요. 날짜만 있는 문자열은 UTC 자정으로 해석돼서,
+ * UTC보다 서쪽 지역에서는 하루 앞선 날짜로 보입니다(명세 2026-08-12 경고). 화면까지
+ * 문자열로 나르고, 포맷이 필요하면 그 자리에서 연·월·일을 직접 쪼개 씁니다.
+ */
+const calendarDate = z.iso.date();
+
+/**
  * 집계 개수. 0은 나오지만 음수는 나올 수 없습니다.
  *
  * 화면에서 clamp하지 않고 여기서 막습니다. 예를 들어 감정 분포에 음수가 들어오면
@@ -194,6 +203,8 @@ export const pulseEventSchema = z.object({
   code: z.string().min(1),
   title: z.string().min(2).max(60),
   description: z.string().max(500).nullable(),
+  /** 행사 당일 날짜. 이벤트를 만든 시각인 `createdAt`과 다릅니다(2026-08-12 명세). */
+  eventDate: calendarDate,
   ownerId: id,
   status: eventStatusSchema,
   createdAt: isoDateTime,
@@ -211,6 +222,8 @@ export const eventViewSchema = pulseEventSchema.omit({ id: true, ownerId: true }
 export const eventCreateRequestSchema = z.object({
   title: z.string().min(2).max(60),
   description: z.string().max(500).optional(),
+  /** 생성 시 필수입니다. 나머지 선택 필드와 달리 빠지면 VALIDATION_ERROR입니다. */
+  eventDate: calendarDate,
 });
 
 /** 전 필드 optional(부분 수정). code/ownerId/createdAt은 수정 대상이 아닙니다. */
@@ -218,6 +231,7 @@ export const eventUpdateRequestSchema = z.object({
   title: z.string().min(2).max(60).optional(),
   description: z.string().max(500).optional(),
   status: z.enum(['LIVE', 'ENDED']).optional(),
+  eventDate: calendarDate.optional(),
 });
 
 export const sessionSchema = z.object({

--- a/mocks/data/seed.ts
+++ b/mocks/data/seed.ts
@@ -24,6 +24,8 @@ export const seedEvents: PulseEvent[] = [
     code: 'ab3f9x',
     title: '2026 프론트엔드 세미나',
     description: '리액트 서버 컴포넌트와 실시간 UI를 주제로 한 사내 세미나입니다.',
+    // 소감 시드가 2026-08-05 기준으로 깔려 있어서 행사 날짜도 같은 날에 맞췄습니다.
+    eventDate: '2026-08-05',
     ownerId: HOST_USER.id,
     status: 'LIVE',
     createdAt: '2026-08-01T09:00:00.000Z',
@@ -33,6 +35,8 @@ export const seedEvents: PulseEvent[] = [
     code: 'kd7m2p',
     title: '한컴 신입 온보딩 데이',
     description: '신입 개발자 대상 온보딩 세션입니다.',
+    // 이미 끝난 행사. 목록에서 "지난 행사"를 확인하는 용도입니다.
+    eventDate: '2026-07-20',
     ownerId: HOST_USER.id,
     status: 'ENDED',
     createdAt: '2026-07-20T01:00:00.000Z',
@@ -42,6 +46,8 @@ export const seedEvents: PulseEvent[] = [
     code: 'zq1v8t',
     title: '사내 해커톤 리허설',
     description: null,
+    // 아직 열지 않은 행사. createdAt보다 미래라 두 필드가 다른 값임이 드러납니다.
+    eventDate: '2026-09-01',
     ownerId: HOST_USER.id,
     status: 'DRAFT',
     createdAt: '2026-08-04T05:00:00.000Z',

--- a/mocks/data/store.ts
+++ b/mocks/data/store.ts
@@ -163,10 +163,18 @@ export const findReportByEventId = (eventId: number): Report | undefined =>
  * 핸들러가 행을 그대로 반환하면 내부 `id`·`ownerId`가 딸려 나갑니다. 명세가 공개뷰에서
  * 이들을 뺐으므로(2026-08-06) 공개 경로는 반드시 이 변환을 거쳐야 합니다.
  */
+/*
+ * `eventViewSchema`는 `pulseEventSchema`에서 파생되지만 이 매퍼는 필드를 손으로 나열합니다.
+ * `Event`에 필드가 붙으면 스키마는 저절로 따라오는데 여기는 안 따라와서, 새 필드를 빠뜨리면
+ * 목이 자기 계약을 어기고 `INVALID_RESPONSE`가 납니다(2026-08-12 `eventDate` 추가 때 실제로
+ * 걸렸습니다). 필드를 지우는 쪽(`id`·`ownerId`)이 목적이라 나열을 유지하되, `Event`에 필드를
+ * 추가할 때는 여기도 같이 봐야 합니다.
+ */
 export const toEventView = (event: PulseEvent): EventView => ({
   code: event.code,
   title: event.title,
   description: event.description,
+  eventDate: event.eventDate,
   status: event.status,
   createdAt: event.createdAt,
 });

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -256,6 +256,60 @@ describe('이벤트 조회', () => {
     await expect(response.json()).resolves.toMatchObject({ code: 'EVENT_NOT_FOUND' });
   });
 
+  /*
+   * 2026-08-12 명세로 들어온 필드입니다. 행사 당일(`eventDate`)과 이벤트를 만든 시각
+   * (`createdAt`)이 다른 값이라는 게 요점이라, 존재만 보지 않고 시드의 실제 값을 확인합니다.
+   */
+  it('공개 상세에 행사 날짜가 실리고 생성 시각과 구분된다', async () => {
+    const response = await call(`/events/${DRAFT_EVENT_CODE}`);
+    const event = eventViewSchema.parse(await response.json());
+
+    expect(event.eventDate).toBe('2026-09-01');
+    expect(event.createdAt.slice(0, 10)).toBe('2026-08-04');
+  });
+
+  it('행사 날짜 없이 이벤트를 만들면 VALIDATION_ERROR를 준다', async () => {
+    const response = await call('/events', {
+      method: 'POST',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '날짜 빠진 이벤트' }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('시각이 붙은 문자열은 행사 날짜로 받지 않는다', async () => {
+    const response = await call('/events', {
+      method: 'POST',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: '형식 틀린 이벤트', eventDate: '2026-09-01T00:00:00.000Z' }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toMatchObject({ code: 'VALIDATION_ERROR' });
+  });
+
+  it('행사 날짜만 보내면 그 값만 바뀐다', async () => {
+    const before = pulseEventSchema.parse(
+      (await (await call('/events', { headers: AUTH_HEADERS })).json()).items.find(
+        (item: { code: string }) => item.code === DRAFT_EVENT_CODE,
+      ),
+    );
+
+    const response = await call(`/events/${DRAFT_EVENT_CODE}`, {
+      method: 'PATCH',
+      headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ eventDate: '2026-09-15' }),
+    });
+
+    expect(response.status).toBe(200);
+    const after = pulseEventSchema.parse(await response.json());
+    expect(after.eventDate).toBe('2026-09-15');
+    expect(after.title).toBe(before.title);
+    expect(after.status).toBe(before.status);
+  });
+
   it('세션이 0개인 이벤트는 LIVE로 못 넘어간다', async () => {
     const response = await call(`/events/${DRAFT_EVENT_CODE}`, {
       method: 'PATCH',
@@ -432,6 +486,7 @@ describe('세션 수정', () => {
       code: 'other1',
       title: '다른 사람 이벤트',
       description: null,
+      eventDate: '2026-08-05',
       ownerId: 999,
       status: 'LIVE',
       createdAt: '2026-08-01T09:00:00.000Z',

--- a/mocks/handlers/event.ts
+++ b/mocks/handlers/event.ts
@@ -59,6 +59,7 @@ export const eventHandlers = [
       code: generateEventCode(),
       title: body.data.title,
       description: body.data.description ?? null,
+      eventDate: body.data.eventDate,
       ownerId: account.id,
       status: 'DRAFT',
       createdAt: new Date().toISOString(),
@@ -100,6 +101,7 @@ export const eventHandlers = [
 
     if (body.data.title !== undefined) event.title = body.data.title;
     if (body.data.description !== undefined) event.description = body.data.description;
+    if (body.data.eventDate !== undefined) event.eventDate = body.data.eventDate;
 
     return HttpResponse.json(event);
   }),


### PR DESCRIPTION
## 변경 사항

노션 API 명세서(SSOT) 2026-08-12자 변경을 계약 스키마와 MSW 목에 반영했습니다.

> **2026-08-12 (김효인·BE)** 이벤트에 `eventDate`(행사 당일 날짜, `YYYY-MM-DD`) 필드 추가 — 생성 시각 `createdAt`과 별개. `POST /events` 요청 **필수**, `PATCH`는 optional, 응답(`Event`)·공개뷰(`EventView`) 모두 노출. openapi 0.3.0.

- `lib/schemas/api.ts` — 달력 날짜 헬퍼 `calendarDate`(`z.iso.date()`)를 `isoDateTime` 옆에 두고, `pulseEventSchema`·`eventCreateRequestSchema`(필수)·`eventUpdateRequestSchema`(optional)에 `eventDate`를 추가했습니다. `eventViewSchema`는 `pulseEventSchema`에서 파생이라 자동으로 따라옵니다.
- `mocks/data/store.ts` — `toEventView`에 필드를 추가했습니다(아래 트러블슈팅 참고).
- `mocks/data/seed.ts` — 시드 이벤트 3건에 값을 넣었습니다.
- `mocks/handlers/event.ts` — `POST`가 요청값을 저장하고 `PATCH`가 부분 수정을 반영합니다.
- `mocks/handlers.test.ts` — 계약 회귀 테스트 4개를 추가하고, 이벤트를 직접 심는 픽스처에 필드를 채웠습니다.

MSW 목 스키마가 백엔드 연동의 단일 소스라(CLAUDE.md) 어긋난 채로 두면 실제 Spring 응답이 들어오는 순간 `INVALID_RESPONSE`가 납니다.

## 관련 이슈

- Closes #118

## 검증 방법

```
$ npm run test
Test Files  3 passed (3)
     Tests  75 passed (75)      ← 기존 71 + 신규 4

$ npm run lint
(출력 없음 — 위반 없음)

$ npx tsc --noEmit
(출력 없음)

$ npm run build
▲ Next.js 16.2.12 (Turbopack)
✓ Compiled successfully in 10.0s
  Finished TypeScript in 9.5s
✓ Generating static pages using 7 workers (9/9)
```

추가한 테스트 4개입니다. 전부 명세 문장을 그대로 옮긴 것입니다.

| 테스트 | 검증하는 명세 문장 |
| --- | --- |
| 공개 상세에 행사 날짜가 실리고 생성 시각과 구분된다 | "응답(`Event`)·공개뷰(`EventView`) 모두 노출", "`createdAt`과 별개" |
| 행사 날짜 없이 이벤트를 만들면 VALIDATION_ERROR를 준다 | "`POST /events` 요청 **필수**" |
| 시각이 붙은 문자열은 행사 날짜로 받지 않는다 | "`YYYY-MM-DD`" |
| 행사 날짜만 보내면 그 값만 바뀐다 | "`PATCH`는 optional", 부분 수정 |

세 번째는 `2026-09-01T00:00:00.000Z`를 넣어 봅니다. `z.iso.datetime()`과 `z.iso.date()`를 헷갈려 쓰면 통과해버리는 자리라 따로 뒀습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- **Breaking Change: 있습니다.** `PulseEvent`·`EventView` 타입에 필수 필드가 생겼습니다. 이벤트 객체를 만드는 코드는 전부 `eventDate`를 채워야 하고, 빠뜨리면 `tsc`가 `TS2741`로 막습니다.

레포에서 이벤트 객체를 만드는 곳은 네 군데이고 이 PR에서 전부 고쳤습니다.

| 위치 | |
| --- | --- |
| `mocks/data/seed.ts` | 시드 이벤트 3건 |
| `mocks/handlers/event.ts` | `POST /events`가 만드는 새 이벤트 |
| `mocks/handlers.test.ts` | 소유자 불일치 재현용 픽스처 |

**작업 중인 브랜치에서 이벤트 객체를 만들고 있다면 `eventDate`를 채워야 합니다.** 지금 열려 있는 PR이 여섯 개라 rebase 시 충돌 대신 타입 에러로 나타날 수 있습니다.

## 트러블슈팅 및 참고 사항

### 파생 스키마와 손으로 쓴 매퍼가 따로 놉니다

`eventViewSchema`는 `pulseEventSchema.omit({ id, ownerId })`로 파생돼 있고, 주석에도 "나중에 `Event`에 필드가 붙어도 공개뷰가 자동으로 따라오면서 두 스키마가 어긋날 수 없다"고 적혀 있습니다. 스키마는 실제로 그렇습니다.

그런데 목의 매퍼(`mocks/data/store.ts`)는 필드를 손으로 나열합니다. **수정 전**입니다.

```ts
export const toEventView = (event: PulseEvent): EventView => ({
  code: event.code,
  title: event.title,
  description: event.description,
  // eventDate가 없습니다 — 스키마는 따라왔는데 매퍼는 안 따라온 지점
  status: event.status,
  createdAt: event.createdAt,
});
```

**수정 후**입니다. `eventDate`는 공개뷰에도 실리는 값이라(명세의 `EventView`) 그대로 내보냅니다. 참가자 진입 화면이 "이 행사가 언제인지"를 알아야 하기 때문입니다. 이 함수가 떨어내는 건 내부 식별자 `id`·`ownerId`뿐입니다.

```ts
export const toEventView = (event: PulseEvent): EventView => ({
  code: event.code,
  title: event.title,
  description: event.description,
  eventDate: event.eventDate,
  status: event.status,
  createdAt: event.createdAt,
});
```

**타입이 막아주기는 합니다.** 반환 타입이 `EventView`로 붙어 있어서 필드를 빠뜨리면 `tsc`가 잡습니다. 확인해봤습니다.

```
mocks/data/store.ts(173,63): error TS2741: Property 'eventDate' is missing in type
'{ code: string; title: string; description: string | null; status: ...; createdAt: string; }'
but required in type '{ eventDate: string; status: ...; createdAt: string; ... }'
```

저는 `npm run test`를 `tsc`보다 먼저 돌려서 이 에러 대신 목의 계약 위반이 먼저 보였습니다.

```
ZodError: [{ "path": ["eventDate"], "message": "Invalid input: expected string, received undefined" }]
```

어느 쪽이든 조용히 넘어가지는 않습니다. 다만 파생 스키마 주석만 읽으면 "공개뷰는 알아서 따라온다"고 생각하기 쉬운데 매퍼는 아니라는 점은 남습니다. 필드를 지우는 게(`id`·`ownerId`) 이 함수의 목적이라 나열 자체는 유지하고, "`Event`에 필드를 추가할 때는 여기도 같이 봐야 한다"는 주석을 달았습니다. 스프레드(`...event`)로 바꾸면 자동으로 따라오지만 새 내부 필드가 실수로 공개될 수 있어서 그쪽은 고르지 않았습니다.

### 날짜를 `Date`로 바꾸지 않았습니다

명세가 경고한 대로 `YYYY-MM-DD`는 타임존이 없어서 `new Date('2026-09-01')`이 UTC 자정으로 해석됩니다. KST에서는 그대로지만 UTC보다 서쪽 지역에서는 하루 앞선 날짜가 됩니다. 그래서 `calendarDate` 헬퍼에 경고 주석을 달고 값은 문자열로만 다룹니다. 포맷이 필요해지는 화면에서 date-only 파서를 쓰기로 남겨뒀습니다.

### 시드 날짜 값

세 이벤트에 서로 다른 날짜를 넣었습니다. `eventDate`와 `createdAt`이 별개 값이라는 게 목 데이터에서 바로 보이게 하려는 것입니다.

| 이벤트 | 상태 | `eventDate` | `createdAt` |
| --- | --- | --- | --- |
| 한컴 신입 온보딩 데이 | ENDED | 2026-07-20 | 2026-07-20 |
| 2026 프론트엔드 세미나 | LIVE | 2026-08-05 | 2026-08-01 |
| 사내 해커톤 리허설 | DRAFT | 2026-09-01 | 2026-08-04 |

`LIVE` 이벤트를 2026-08-05로 맞춘 건 소감 시드가 그날 기준으로 깔려 있기 때문입니다(`seed.ts`의 `EVENT_START_MS`). `DRAFT`만 `createdAt`보다 미래이고 나머지 둘은 같거나 과거라, 두 필드가 독립적으로 움직인다는 게 드러납니다.

다만 **오늘 날짜를 기준으로 보면 ENDED와 LIVE가 둘 다 과거입니다.** 이벤트 목록(#94)에서 "오늘 열리는 행사"를 눈으로 확인해야 한다면 `LIVE` 이벤트의 날짜를 옮겨야 할 수 있습니다. 그 화면 작업 때 정하면 될 것 같아 여기서는 소감 시드와의 정합을 우선했습니다.

### 범위에서 뺀 것

- **화면 표시.** 이벤트 목록(#94)·이벤트 생성(#116)·대시보드가 이 값을 어디에 어떻게 보여줄지는 각 화면 이슈에서 정합니다. 이 PR은 계약만 맞춥니다.
- **`lib/api/endpoints.ts`의 생성·수정 바인딩.** `createEvent`·`updateEvent`가 아직 없습니다. 만드는 건 #116 몫이라 여기서 미리 만들지 않았습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
