### PR TITLE
feat(event): 이벤트 관리 화면 구현

### DIFF
--- a/app/(host)/events/[eventCode]/page.tsx
+++ b/app/(host)/events/[eventCode]/page.tsx
@@ -1,16 +1,17 @@
 import EventForm from '@/components/events/EventForm';
-import ReportPanel from '@/components/report/ReportPanel';
 
-const EventEditPage = () => {
+interface EventEditPageProps {
+  params: Promise<{ eventCode: string }>;
+}
+
+const EventEditPage = async ({ params }: EventEditPageProps) => {
   // URL은 eventCode. openapi v0.3부터 수정·삭제(PATCH/DELETE /events/{eventCode})도
   // eventCode를 그대로 사용합니다. eventId를 먼저 조회할 필요가 없습니다.
-  // 진행 중(LIVE/DRAFT) 상태면 EventForm(수정 모드)을, ENDED 상태면 ReportPanel을
-  // 보여줍니다.
+  const { eventCode } = await params;
+
   return (
-    <div>
-      <p>이벤트 수정 (준비 중)</p>
-      <EventForm />
-      <ReportPanel />
+    <div className="min-h-dvh w-full flex flex-col justify-center items-center gap-6 p-14 bg-background-default">
+      <EventForm eventCode={eventCode} />
     </div>
   );
 };

--- a/app/(host)/events/new/page.tsx
+++ b/app/(host)/events/new/page.tsx
@@ -3,8 +3,7 @@ import EventForm from '@/components/events/EventForm';
 const NewEventPage = () => {
   // API: POST /events. events/page.tsx의 "새 이벤트 만들기" 버튼이 이 페이지로 이동합니다.
   return (
-    <div>
-      <p>이벤트 등록 (준비 중)</p>
+    <div className="min-h-dvh w-full flex flex-col justify-center items-center gap-6 p-14 bg-background-default">
       <EventForm />
     </div>
   );

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -1,14 +1,33 @@
 'use client';
 
 import { type ChangeEvent, type SubmitEvent, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Field } from '@/components/ui/Field';
 import { Textarea } from '@/components/ui/Textarea';
-import { eventCreateRequestSchema } from '@/lib/schemas/api';
 import { Button } from '@/components/ui/Button';
-import { useRouter } from 'next/navigation';
-import { useMutation } from '@tanstack/react-query';
-import { createEvent } from '@/lib/api/endpoints';
 import { Banner } from '@/components/ui/Banner';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import ReportPanel from '@/components/report/ReportPanel';
+import { showToast } from '@/hooks/useToast';
+import { eventCreateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
+import type { SessionView } from '@/lib/schemas/api';
+import {
+  createEvent,
+  createSession,
+  deleteEvent,
+  deleteSession,
+  fetchEventByCode,
+  fetchSessionsByEventCode,
+  updateEvent,
+  updateSession,
+} from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+
+interface EventFormProps {
+  /** 있으면 수정 모드(기존 값 로드 + PATCH), 없으면 생성 모드(POST)입니다. */
+  eventCode?: string;
+}
 
 type EventFormInputs = {
   title: string;
@@ -28,22 +47,113 @@ const initialEventFormInputs: EventFormInputs = {
   eventDate: '',
 };
 
-const EventForm = () => {
-  // 이벤트 등록/수정 공용 폼. 제목·이벤트코드·시작일·세션 목록으로 구성됩니다.
-  // 세션 추가·수정·삭제는 페이지 이동 없이 이 컴포넌트 내부 상태(인라인 편집)로
-  // 처리하고, 이벤트 삭제는 이 폼 위에 뜨는 확인 모달로 처리합니다.
-  // API(openapi v0.3): POST /events(등록), PATCH /events/{eventCode}(수정),
-  // DELETE /events/{eventCode}(삭제), POST /events/{eventCode}/sessions(세션 추가),
-  // PATCH /events/{eventCode}/sessions/{sessionId}(세션 수정),
-  // DELETE /events/{eventCode}/sessions/{sessionId}(세션 삭제).
+// 이벤트 등록/수정 공용 폼. 세션 추가·수정·삭제는 페이지 이동 없이 이 컴포넌트
+// 내부 상태(인라인 편집)로 처리하고, 이벤트 삭제는 이 폼 위에 뜨는 확인 모달로 처리합니다.
+// API(openapi v0.3): POST /events(등록), PATCH /events/{eventCode}(수정),
+// DELETE /events/{eventCode}(삭제), POST /events/{eventCode}/sessions(세션 추가),
+// PATCH /events/{eventCode}/sessions/{sessionId}(세션 수정),
+// DELETE /events/{eventCode}/sessions/{sessionId}(세션 삭제).
+const EventForm = ({ eventCode }: EventFormProps) => {
+  const isEditMode = Boolean(eventCode);
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
   const [eventFormInputs, setEventFormInputs] = useState<EventFormInputs>(initialEventFormInputs);
   const [eventFormErrors, setEventFormErrors] = useState<EventFormErrors>({});
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
 
-  const router = useRouter();
+  const [isAddingSession, setIsAddingSession] = useState(false);
+  const [newSessionTitle, setNewSessionTitle] = useState('');
+  const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
+  const [editingSessionTitle, setEditingSessionTitle] = useState('');
+  const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null);
 
-  const { mutate, isPending, error } = useMutation({
-    mutationFn: createEvent,
+  const eventQuery = useQuery({
+    queryKey: ['event', eventCode],
+    queryFn: () => fetchEventByCode(eventCode as string),
+    enabled: isEditMode,
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions', eventCode],
+    queryFn: () => fetchSessionsByEventCode(eventCode as string),
+    enabled: isEditMode,
+  });
+  const sessions: SessionView[] = sessionsQuery.data ?? [];
+
+  // 쿼리 데이터가 새로 도착했을 때만 폼 입력값을 덮어씁니다(렌더링 중 상태 조정 —
+  // useEffect로 하면 렌더가 한 번 더 겹치고 react-hooks/set-state-in-effect에 걸립니다).
+  const [loadedEventData, setLoadedEventData] = useState(eventQuery.data);
+  if (eventQuery.data && eventQuery.data !== loadedEventData) {
+    setLoadedEventData(eventQuery.data);
+    setEventFormInputs({
+      title: eventQuery.data.title,
+      description: eventQuery.data.description ?? '',
+      eventDate: eventQuery.data.eventDate,
+    });
+  }
+
+  const {
+    mutate: saveEvent,
+    isPending: isSaving,
+    error: saveError,
+  } = useMutation({
+    mutationFn: (body: EventFormInputs) =>
+      isEditMode ? updateEvent(eventCode as string, body) : createEvent(body),
+    onSuccess: () => {
+      if (isEditMode) {
+        queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
+        showToast('저장했어요');
+      } else {
+        router.push('/events');
+      }
+    },
+  });
+
+  const { mutate: startEvent, isPending: isStarting } = useMutation({
+    mutationFn: () => updateEvent(eventCode as string, { status: 'LIVE' }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
+      showToast('이벤트를 시작했어요');
+    },
+    onError: (error) => {
+      if (error instanceof ApiError && error.code === 'INVALID_EVENT_STATE_TRANSITION') {
+        showToast('세션이 1개 이상 있어야 이벤트를 시작할 수 있어요');
+      }
+    },
+  });
+
+  const { mutate: removeEvent, isPending: isDeleting } = useMutation({
+    mutationFn: () => deleteEvent(eventCode as string),
     onSuccess: () => router.push('/events'),
+  });
+
+  const { mutate: addSession, isPending: isAddingSessionPending } = useMutation({
+    mutationFn: (title: string) =>
+      createSession(eventCode as string, { title, order: sessions.length + 1 }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setIsAddingSession(false);
+      setNewSessionTitle('');
+    },
+  });
+
+  const { mutate: editSession, isPending: isEditingSessionPending } = useMutation({
+    mutationFn: ({ sessionId, title }: { sessionId: number; title: string }) =>
+      updateSession(eventCode as string, sessionId, { title }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setEditingSessionId(null);
+    },
+  });
+
+  const { mutate: removeSession, isPending: isRemovingSession } = useMutation({
+    mutationFn: (sessionId: number) => deleteSession(eventCode as string, sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setDeletingSessionId(null);
+      showToast('세션이 삭제되었어요');
+    },
   });
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -70,9 +180,34 @@ const EventForm = () => {
     }));
 
     if (titleValidation.success && descriptionValidation.success && eventDateValidation.success) {
-      mutate(eventFormInputs);
+      saveEvent(eventFormInputs);
     }
   };
+
+  const handleAddSessionConfirm = () => {
+    const validation = sessionCreateRequestSchema.shape.title.safeParse(newSessionTitle);
+    if (!validation.success) return;
+    addSession(newSessionTitle);
+  };
+
+  const handleEditSessionStart = (session: SessionView) => {
+    setEditingSessionId(session.id);
+    setEditingSessionTitle(session.title);
+  };
+
+  const handleEditSessionConfirm = (sessionId: number) => {
+    const validation = sessionCreateRequestSchema.shape.title.safeParse(editingSessionTitle);
+    if (!validation.success) return;
+    editSession({ sessionId, title: editingSessionTitle });
+  };
+
+  if (isEditMode && eventQuery.isPending) {
+    return <p>불러오는 중...</p>;
+  }
+
+  if (isEditMode && eventQuery.data?.status === 'ENDED') {
+    return <ReportPanel />;
+  }
 
   return (
     <>
@@ -94,6 +229,14 @@ const EventForm = () => {
           onChange={handleInputChange}
           error={eventFormErrors.eventDate}
         />
+        {isEditMode && eventQuery.data ? (
+          <Field
+            label="참가자 링크"
+            name="code"
+            value={`pulse.app/e/${eventQuery.data.code}`}
+            readOnly
+          />
+        ) : null}
         <section className="flex flex-col gap-1">
           <p className="text-xs font-normal leading-4 text-text-secondary">설명 (선택)</p>
           <Textarea
@@ -115,17 +258,150 @@ const EventForm = () => {
             {eventFormErrors.description}
           </p>
         </section>
-        {error ? (
+
+        {isEditMode ? (
+          <section className="flex flex-col gap-2">
+            <p className="text-xs font-normal leading-4 text-text-secondary">세션 목록</p>
+            {sessions.map((session) => (
+              <div
+                key={session.id}
+                className="flex items-center justify-between gap-2 rounded-lg border border-border-default px-4 py-3"
+              >
+                {editingSessionId === session.id ? (
+                  <>
+                    <input
+                      className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
+                      value={editingSessionTitle}
+                      onChange={(event) => setEditingSessionTitle(event.target.value)}
+                    />
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={isEditingSessionPending}
+                      onClick={() => handleEditSessionConfirm(session.id)}
+                    >
+                      확인
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    <span className="text-sm text-text-primary">{session.title}</span>
+                    <div className="flex gap-2 text-xs text-text-secondary">
+                      <button type="button" onClick={() => handleEditSessionStart(session)}>
+                        수정
+                      </button>
+                      <button type="button" onClick={() => setDeletingSessionId(session.id)}>
+                        삭제
+                      </button>
+                    </div>
+                  </>
+                )}
+              </div>
+            ))}
+            {isAddingSession ? (
+              <div className="flex items-center gap-2 rounded-lg border border-border-default px-4 py-3">
+                <input
+                  className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
+                  placeholder="세션 제목을 입력하세요."
+                  value={newSessionTitle}
+                  onChange={(event) => setNewSessionTitle(event.target.value)}
+                  autoFocus
+                />
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={isAddingSessionPending}
+                  onClick={handleAddSessionConfirm}
+                >
+                  확인
+                </Button>
+              </div>
+            ) : (
+              <Button type="button" variant="secondary" onClick={() => setIsAddingSession(true)}>
+                + 세션추가
+              </Button>
+            )}
+          </section>
+        ) : null}
+
+        {saveError ? (
           <Banner type="negative" className="w-full">
-            이벤트를 등록하지 못했습니다. 잠시 후 다시 시도해주세요.
+            {isEditMode
+              ? '이벤트를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'
+              : '이벤트를 등록하지 못했습니다. 잠시 후 다시 시도해주세요.'}
           </Banner>
         ) : null}
-        <div className="flex justify-end">
-          <Button type="submit" variant="secondary" disabled={isPending}>
-            {isPending ? '등록 중...' : '등록'}
+
+        <div className="flex justify-end gap-2">
+          {isEditMode ? (
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={isDeleting}
+              onClick={() => setIsDeleteDialogOpen(true)}
+            >
+              삭제
+            </Button>
+          ) : null}
+          <Button type="submit" variant="secondary" disabled={isSaving}>
+            {isSaving ? '저장 중...' : isEditMode ? '저장' : '등록'}
           </Button>
+          {isEditMode && eventQuery.data?.status === 'DRAFT' ? (
+            <Button
+              type="button"
+              variant="primary"
+              disabled={isStarting}
+              onClick={() => startEvent()}
+            >
+              {isStarting ? '시작 중...' : '이벤트 시작'}
+            </Button>
+          ) : null}
         </div>
       </form>
+
+      <ConfirmDialog
+        open={isDeleteDialogOpen}
+        title="이벤트를 삭제할까요?"
+        description="삭제하면 되돌릴 수 없어요"
+        onClose={() => setIsDeleteDialogOpen(false)}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setIsDeleteDialogOpen(false)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              disabled={isDeleting}
+              onClick={() => removeEvent()}
+            >
+              삭제
+            </Button>
+          </>
+        }
+      />
+
+      <ConfirmDialog
+        open={deletingSessionId !== null}
+        title="세션을 삭제할까요?"
+        description="삭제하면 되돌릴 수 없어요"
+        onClose={() => setDeletingSessionId(null)}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setDeletingSessionId(null)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="primary"
+              disabled={isRemovingSession}
+              onClick={() => deletingSessionId !== null && removeSession(deletingSessionId)}
+            >
+              삭제
+            </Button>
+          </>
+        }
+      />
     </>
   );
 };

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -13,16 +13,19 @@ import { Banner } from '@/components/ui/Banner';
 type EventFormInputs = {
   title: string;
   description: string;
+  eventDate: string;
 };
 
 type EventFormErrors = {
   title?: string;
   description?: string;
+  eventDate?: string;
 };
 
 const initialEventFormInputs: EventFormInputs = {
   title: '',
   description: '',
+  eventDate: '',
 };
 
 const EventForm = () => {
@@ -55,14 +58,18 @@ const EventForm = () => {
     const descriptionValidation = eventCreateRequestSchema.shape.description.safeParse(
       eventFormInputs.description,
     );
+    const eventDateValidation = eventCreateRequestSchema.shape.eventDate.safeParse(
+      eventFormInputs.eventDate,
+    );
 
     setEventFormErrors((prev) => ({
       ...prev,
       title: titleValidation.error?.issues[0]?.message,
       description: descriptionValidation.error?.issues[0]?.message,
+      eventDate: eventDateValidation.error?.issues[0]?.message,
     }));
 
-    if (titleValidation.success && descriptionValidation.success) {
+    if (titleValidation.success && descriptionValidation.success && eventDateValidation.success) {
       mutate(eventFormInputs);
     }
   };
@@ -78,6 +85,14 @@ const EventForm = () => {
           value={eventFormInputs.title}
           onChange={handleInputChange}
           error={eventFormErrors.title}
+        />
+        <Field
+          label="행사 날짜"
+          name="eventDate"
+          type="date"
+          value={eventFormInputs.eventDate}
+          onChange={handleInputChange}
+          error={eventFormErrors.eventDate}
         />
         <section className="flex flex-col gap-1">
           <p className="text-xs font-normal leading-4 text-text-secondary">설명 (선택)</p>

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -1,3 +1,30 @@
+'use client';
+
+import { type ChangeEvent, type SubmitEvent, useState } from 'react';
+import { Field } from '@/components/ui/Field';
+import { Textarea } from '@/components/ui/Textarea';
+import { eventCreateRequestSchema } from '@/lib/schemas/api';
+import { Button } from '@/components/ui/Button';
+import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { createEvent } from '@/lib/api/endpoints';
+import { Banner } from '@/components/ui/Banner';
+
+type EventFormInputs = {
+  title: string;
+  description: string;
+};
+
+type EventFormErrors = {
+  title?: string;
+  description?: string;
+};
+
+const initialEventFormInputs: EventFormInputs = {
+  title: '',
+  description: '',
+};
+
 const EventForm = () => {
   // 이벤트 등록/수정 공용 폼. 제목·이벤트코드·시작일·세션 목록으로 구성됩니다.
   // 세션 추가·수정·삭제는 페이지 이동 없이 이 컴포넌트 내부 상태(인라인 편집)로
@@ -6,7 +33,86 @@ const EventForm = () => {
   // DELETE /events/{eventCode}(삭제), POST /events/{eventCode}/sessions(세션 추가),
   // PATCH /events/{eventCode}/sessions/{sessionId}(세션 수정),
   // DELETE /events/{eventCode}/sessions/{sessionId}(세션 삭제).
-  return <div>이벤트 정보 입력 폼 (준비 중)</div>;
+  const [eventFormInputs, setEventFormInputs] = useState<EventFormInputs>(initialEventFormInputs);
+  const [eventFormErrors, setEventFormErrors] = useState<EventFormErrors>({});
+
+  const router = useRouter();
+
+  const { mutate, isPending, error } = useMutation({
+    mutationFn: createEvent,
+    onSuccess: () => router.push('/events'),
+  });
+
+  const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+    const { name, value } = event.target;
+    setEventFormInputs((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleFormSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const titleValidation = eventCreateRequestSchema.shape.title.safeParse(eventFormInputs.title);
+    const descriptionValidation = eventCreateRequestSchema.shape.description.safeParse(
+      eventFormInputs.description,
+    );
+
+    setEventFormErrors((prev) => ({
+      ...prev,
+      title: titleValidation.error?.issues[0]?.message,
+      description: descriptionValidation.error?.issues[0]?.message,
+    }));
+
+    if (titleValidation.success && descriptionValidation.success) {
+      mutate(eventFormInputs);
+    }
+  };
+
+  return (
+    <>
+      <h1 className="w-full max-w-190 text-xl font-semibold text-text-primary">이벤트 설정</h1>
+      <form onSubmit={handleFormSubmit} className="w-full max-w-190 flex flex-col gap-6">
+        <Field
+          label="제목"
+          name="title"
+          placeholder="이벤트 제목을 입력하세요."
+          value={eventFormInputs.title}
+          onChange={handleInputChange}
+          error={eventFormErrors.title}
+        />
+        <section className="flex flex-col gap-1">
+          <p className="text-xs font-normal leading-4 text-text-secondary">설명 (선택)</p>
+          <Textarea
+            invalid={Boolean(eventFormErrors.description)}
+            maxLength={500}
+            placeholder="이벤트에 대한 간단한 설명을 남겨주세요."
+            value={eventFormInputs.description}
+            onChange={handleInputChange}
+          />
+          <p
+            className={
+              eventFormErrors.description
+                ? 'text-xs font-normal leading-4 text-negative-darker'
+                : 'sr-only'
+            }
+            role="alert"
+            aria-atomic="true"
+          >
+            {eventFormErrors.description}
+          </p>
+        </section>
+        {error ? (
+          <Banner type="negative" className="w-full">
+            이벤트를 등록하지 못했습니다. 잠시 후 다시 시도해주세요.
+          </Banner>
+        ) : null}
+        <div className="flex justify-end">
+          <Button type="submit" variant="secondary" disabled={isPending}>
+            {isPending ? '등록 중...' : '등록'}
+          </Button>
+        </div>
+      </form>
+    </>
+  );
 };
 
 export default EventForm;

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -240,6 +240,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
         <section className="flex flex-col gap-1">
           <p className="text-xs font-normal leading-4 text-text-secondary">설명 (선택)</p>
           <Textarea
+            name="description"
             invalid={Boolean(eventFormErrors.description)}
             maxLength={500}
             placeholder="이벤트에 대한 간단한 설명을 남겨주세요."

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -2,6 +2,7 @@ import apiClient, { ApiError } from '@/lib/apiClient';
 import { getClientId } from '@/lib/clientId';
 import type {
   AuthUser,
+  EventCreateRequest,
   EventView,
   Feedback,
   FeedbackSnapshot,
@@ -119,6 +120,14 @@ export const fetchMe = async (signal?: AbortSignal): Promise<AuthUser> => {
 export const fetchMyEvents = async (): Promise<PulseEvent[]> => {
   const data = await apiClient<unknown>('/events');
   return parseResponse(listResponseSchema(pulseEventSchema), data, 'GET /events').items;
+};
+
+export const createEvent = async (body: EventCreateRequest): Promise<PulseEvent> => {
+  const data = await apiClient<unknown>('/events', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(pulseEventSchema, data, 'POST /events');
 };
 
 /**

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -3,6 +3,7 @@ import { getClientId } from '@/lib/clientId';
 import type {
   AuthUser,
   EventCreateRequest,
+  EventUpdateRequest,
   EventView,
   Feedback,
   FeedbackSnapshot,
@@ -13,6 +14,7 @@ import type {
   PulseEvent,
   Report,
   Session,
+  SessionCreateRequest,
   SessionUpdateRequest,
   SessionView,
   SignupRequest,
@@ -139,6 +141,22 @@ export const fetchEventByCode = async (eventCode: string): Promise<EventView> =>
   return parseResponse(eventViewSchema, data, 'GET /events/{eventCode}');
 };
 
+export const updateEvent = async (
+  eventCode: string,
+  body: EventUpdateRequest,
+): Promise<PulseEvent> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(pulseEventSchema, data, 'PATCH /events/{eventCode}');
+};
+
+/** 소프트 삭제. 응답 204라 반환값이 없습니다. */
+export const deleteEvent = async (eventCode: string): Promise<void> => {
+  await apiClient<null>(`/events/${eventCode}`, { method: 'DELETE' });
+};
+
 /** 세션 목록. 게스트 제출 대상 선택과 소유자 세션 탭이 같이 씁니다. `DELETED`는 빠집니다. */
 export const fetchSessionsByEventCode = async (eventCode: string): Promise<SessionView[]> => {
   const data = await apiClient<unknown>(`/events/${eventCode}/sessions`, { skipAuth: true });
@@ -147,6 +165,17 @@ export const fetchSessionsByEventCode = async (eventCode: string): Promise<Sessi
     data,
     'GET /events/{eventCode}/sessions',
   ).items;
+};
+
+export const createSession = async (
+  eventCode: string,
+  body: SessionCreateRequest,
+): Promise<Session> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/sessions`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(sessionSchema, data, 'POST /events/{eventCode}/sessions');
 };
 
 export const updateSession = async (
@@ -159,6 +188,11 @@ export const updateSession = async (
     body: JSON.stringify(body),
   });
   return parseResponse(sessionSchema, data, 'PATCH /events/{eventCode}/sessions/{sessionId}');
+};
+
+/** 소프트 삭제. 응답 204라 반환값이 없습니다. */
+export const deleteSession = async (eventCode: string, sessionId: number): Promise<void> => {
+  await apiClient<null>(`/events/${eventCode}/sessions/${sessionId}`, { method: 'DELETE' });
 };
 
 // ─────────────────────────────────────────────────────────────

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -209,8 +209,8 @@ export const pulseEventSchema = z.object({
 export const eventViewSchema = pulseEventSchema.omit({ id: true, ownerId: true });
 
 export const eventCreateRequestSchema = z.object({
-  title: z.string().min(2).max(60),
-  description: z.string().max(500).optional(),
+  title: z.string().min(2, '제목은 2자 이상이어야 합니다.').max(60, '제목은 60자 이하여야 합니다.'),
+  description: z.string().max(500, '설명은 500자 이하여야 합니다.').optional(),
 });
 
 /** 전 필드 optional(부분 수정). code/ownerId/createdAt은 수정 대상이 아닙니다. */


### PR DESCRIPTION
## 변경 사항

원래 이벤트 생성(제목·설명 입력)만 다루던 PR이었는데, `dev`에 머지된 PR #119(`eventDate` 계약 반영)와 충돌이 나면서 이 브랜치에 이어서 이벤트 관리 화면 전체(생성·수정·삭제·상태전환·세션관리)를 완성했습니다.

- **`eventCreateRequestSchema`에 `eventDate` 반영**: PR #119 머지로 생긴 `dev` 충돌(`lib/schemas/api.ts`)을 해소하고, `EventForm`에 날짜 입력 필드(`<input type="date">`)를 추가했습니다. Figma 시안(이벤트 등록 화면)에는 이 필드가 없었지만, API 명세서가 생성 시 필수로 요구해서 최소 형태로 넣었습니다.
- **`EventForm`을 등록/수정 공용으로 확장**: `eventCode` prop이 있으면 수정 모드로 동작합니다. 기존 값을 프리필하고, 참가자 링크(`pulse.app/e/{code}`, 서버가 준 `code`를 그대로 표시하는 읽기 전용 필드)를 보여줍니다.
- **세션 인라인 추가·수정·삭제**: 페이지 이동 없이 목록 안에서 바로 처리합니다.
- **이벤트 삭제**: 이미 있던 `ConfirmDialog`를 재사용해 확인 모달로 처리합니다.
- **이벤트 상태 전환**: `EventForm`에 "이벤트 시작"(`DRAFT → LIVE`) 버튼을 뒀습니다. `ENDED → 종료`는 대시보드 헤더 쪽(축 3 담당) 몫이라 이 폼에 없습니다.
- **`ENDED` 상태면 폼 대신 `ReportPanel`을 보여줍니다.** `ReportPanel` 내부 로직은 축 3 담당이라 자리만 가져다 놨습니다.
- `lib/api/endpoints.ts`에 `updateEvent`·`deleteEvent`·`createSession`·`deleteSession`을 추가했습니다.

## 개발 과정 로그 (커밋 순서, 오래된 순)

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| `115d2b1` | feat(event): 이벤트 생성 UI 구현 | 제목·설명 입력으로 이벤트를 생성하는 최초 구현입니다. |
| `83cc561` | fix(schema): eventCreateRequestSchema 검증 메시지 한국어로 지정 | zod 기본 영문 에러 메시지를 한국어로 바꿨습니다. |
| `38c8141` | fix(event): EventForm에 행사 날짜 입력 필드 추가 | PR #119 머지로 `eventDate`가 필수가 되면서 생긴 타입 에러를 해소했습니다. |
| `2269c29` | feat(event): 이벤트 관리 화면 완성 | 수정·삭제·상태전환·세션관리를 한 번에 채웠습니다. |

## 관련 이슈

- Closes #116
- Closes #126

## 검증 방법

```
$ npx tsc --noEmit
(출력 없음)

$ npm run lint
(출력 없음 — 위반 없음)
```

브라우저에서 아래를 직접 확인했습니다.

- 제목·행사 날짜·설명을 입력해 이벤트를 생성하면 DRAFT 카드로 목록에 나타납니다.
- 기존 이벤트를 열면 제목·날짜·참가자 링크가 프리필됩니다.
- 세션을 추가하면 목록에 즉시 나타나고, 수정·삭제도 페이지 이동 없이 인라인으로 동작합니다. 세션 삭제는 확인 모달("세션을 삭제할까요? 삭제하면 되돌릴 수 없어요")을 거칩니다.
- 세션이 1개 이상인 상태에서 "이벤트 시작"을 누르면 "이벤트를 시작했어요" 토스트가 뜨고 `LIVE`로 전환됩니다.
- `ENDED` 상태 이벤트를 열면 폼 대신 리포트 패널(현재 "준비 중" 스켈레톤)이 뜹니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음(이미 `dev`에 반영된 `eventDate` 계약을 따라간 것뿐입니다)

## 트러블슈팅 및 참고 사항

### `dev`에 머지된 PR #119(계약 스키마 반영)와의 스키마 충돌이 났습니다

`lib/schemas/api.ts`의 `eventCreateRequestSchema`에서, 이 브랜치는 `eventDate` 없는 옛 버전을, `dev`는 `eventDate`(필수)가 추가된 버전을 갖고 있어 병합 충돌이 났습니다.
`git merge origin/dev`로 병합하면서 두 브랜치의 변경사항(한국어 에러 메시지 + `eventDate` 필드)을 합쳐 해소했습니다.

### `useEffect`로 폼 초기값을 채우면 린트 에러가 났습니다

`react-hooks/set-state-in-effect` 규칙에 걸려서, React 공식 문서가 권장하는 "렌더링 중 상태 조정" 패턴으로 바꿨습니다. 쿼리 데이터가 이전과 달라졌을 때만 렌더 함수 본문에서 직접 `setState`를 호출합니다.

이 PR은 마감(2026-08-14 오전 MSW 기준 완성) 때문에 페어 모드가 아니라 Claude가 직접 구현했습니다. 리뷰 시 평소보다 꼼꼼한 확인을 부탁드립니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경(이벤트 관리 화면 완성)만 담았습니다.
- [x] 커밋이 여러 개라 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 이벤트 생성 및 수정 화면을 추가했습니다.
  * 이벤트 제목, 설명, 날짜를 입력하고 유효성 검증 결과를 확인할 수 있습니다.
  * 이벤트 세션을 추가·수정·삭제할 수 있습니다.
  * 이벤트 삭제 및 시작 기능을 지원합니다.
  * 이벤트 진행 상태에 따라 로딩 화면, 안내 메시지와 종료 보고서를 제공합니다.
  * 작업 결과에 따른 성공·실패 알림과 화면 이동을 제공합니다.
* **개선**
  * 이벤트 생성 및 수정 페이지의 레이아웃과 화면 구성을 개선했습니다.
  * 입력 오류 메시지를 한국어로 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->