### PR TITLE
feat(auth): 회원가입 페이지에 useAuth.signup 연동

### DIFF
--- a/app/(host)/signup/page.tsx
+++ b/app/(host)/signup/page.tsx
@@ -35,6 +35,7 @@ const SignupPage = () => {
   const [signupErrors, setSignupErrors] = useState<SignupErrors>({});
   // 필드별 에러(signupErrors)로 표현할 수 없는 서버 에러(400 폴백)만 여기 담습니다.
   const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const router = useRouter();
   const { signup } = useAuth();
@@ -48,6 +49,7 @@ const SignupPage = () => {
 
   const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (isSubmitting) return;
     setFormError(null);
 
     const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
@@ -64,6 +66,7 @@ const SignupPage = () => {
 
     if (nextErrors.email || nextErrors.password || nextErrors.passwordConfirm) return;
 
+    setIsSubmitting(true);
     try {
       await signup(signupInputs.email, signupInputs.password);
       router.push('/events');
@@ -73,6 +76,8 @@ const SignupPage = () => {
       } else {
         setFormError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -118,8 +123,8 @@ const SignupPage = () => {
           >
             {formError}
           </p>
-          <Button type="submit" variant="primary" className="w-full">
-            회원가입
+          <Button type="submit" variant="primary" className="w-full" disabled={isSubmitting}>
+            {isSubmitting ? '가입 중...' : '회원가입'}
           </Button>
         </form>
         <p className="text-xs text-text-secondary">

--- a/app/(host)/signup/page.tsx
+++ b/app/(host)/signup/page.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { Logo } from '@/components/brand/Logo';
 import { Field } from '@/components/ui/Field';
 import { Button } from '@/components/ui/Button';
 import { ChangeEvent, type SubmitEvent, useState } from 'react';
 import { passwordSchema, signupRequestSchema } from '@/lib/schemas/api';
+import { useAuth } from '@/hooks/useAuth';
+import { ApiError } from '@/lib/apiClient';
 
 type SignupInputs = {
   email: string;
@@ -27,11 +30,14 @@ const initialSignupInputs: SignupInputs = {
 };
 
 const SignupPage = () => {
-  // API: POST /auth/signup
-  // useAuth()의 signup 함수는 아직 없기 때문에(PR #79 미머지)
-  // 클라이언트 사전 검증까지만 하고 실제 서버 제출은 하지 않습니다.
+  // API: POST /auth/signup. useAuth().signup으로 실제 요청을 보냅니다.
   const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
   const [signupErrors, setSignupErrors] = useState<SignupErrors>({});
+  // 필드별 에러(signupErrors)로 표현할 수 없는 서버 에러(400 폴백)만 여기 담습니다.
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const router = useRouter();
+  const { signup } = useAuth();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setSignupInputs((prev) => ({
@@ -40,20 +46,34 @@ const SignupPage = () => {
     }));
   };
 
-  const handleSubmit = (event: SubmitEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setFormError(null);
 
     const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
     const passwordValidation = passwordSchema.safeParse(signupInputs.password);
     const passwordConfirmError =
       signupInputs.password !== signupInputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
 
-    setSignupErrors((prev) => ({
-      ...prev,
+    const nextErrors: SignupErrors = {
       email: emailValidation.error?.issues[0].message,
       password: passwordValidation.error?.issues[0].message,
       passwordConfirm: passwordConfirmError,
-    }));
+    };
+    setSignupErrors(nextErrors);
+
+    if (nextErrors.email || nextErrors.password || nextErrors.passwordConfirm) return;
+
+    try {
+      await signup(signupInputs.email, signupInputs.password);
+      router.push('/events');
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'EMAIL_ALREADY_EXISTS') {
+        setSignupErrors((prev) => ({ ...prev, email: '이미 가입된 이메일입니다.' }));
+      } else {
+        setFormError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
   };
 
   return (
@@ -91,6 +111,13 @@ const SignupPage = () => {
             value={signupInputs.passwordConfirm}
             error={signupErrors.passwordConfirm}
           />
+          <p
+            role="alert"
+            aria-atomic="true"
+            className={formError ? 'text-xs text-negative-darker' : 'sr-only'}
+          >
+            {formError}
+          </p>
           <Button type="submit" variant="primary" className="w-full">
             회원가입
           </Button>

--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { fetchMe, login, logout } from '@/lib/api/endpoints';
+import { fetchMe, login, logout, signup } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import { AuthUser } from '@/lib/schemas/api';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -11,6 +11,7 @@ export interface UseAuthReturn {
   /** UNAUTHORIZED(비로그인)는 여기 담기지 않습니다. 서버·네트워크 오류가 있을 때만 채워지며, 이 경우에도 user는 이전 값을 유지할 수 있으므로 로그인 여부는 error가 아니라 user로 판단해야 합니다. */
   error: Error | null;
   login: (email: string, password: string) => Promise<void>;
+  signup: (email: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
 }
 
@@ -45,6 +46,19 @@ export function useAuth(): UseAuthReturn {
     },
   });
 
+  const signupMutation = useMutation({
+    mutationFn: signup,
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: ['auth', 'me'] });
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(['auth', 'me'], data);
+    },
+    onSettled: () => {
+      return queryClient.invalidateQueries({ queryKey: ['auth', 'me'] });
+    },
+  });
+
   const logoutMutation = useMutation({
     mutationFn: logout,
     onMutate: async () => {
@@ -67,6 +81,9 @@ export function useAuth(): UseAuthReturn {
     error: meQuery.error,
     login: async (email, password) => {
       await loginMutation.mutateAsync({ email, password });
+    },
+    signup: async (email, password) => {
+      await signupMutation.mutateAsync({ email, password });
     },
     logout: async () => {
       await logoutMutation.mutateAsync();


### PR DESCRIPTION
## 변경 사항

`useAuth`에 `login`과 동일한 패턴으로 `signup` 함수를 추가하고, 회원가입 페이지 `handleSubmit`을 이 함수로 실제 서버 요청을 보내도록 교체했습니다.

- `hooks/useAuth.ts`: `signupMutation`을 `loginMutation`과 동일한 캐시 갱신 패턴(`onMutate`에서 `cancelQueries`, `onSuccess`에서 `setQueryData`, `onSettled`에서 `invalidateQueries`)으로 추가하고, `UseAuthReturn`에 `signup`을 노출했습니다.
- `app/(host)/signup/page.tsx`: 클라이언트 검증을 통과하면 `signup(email, password)`을 호출합니다. 성공하면 `/events`로 이동합니다. 409(`EMAIL_ALREADY_EXISTS`)는 이메일 필드 에러로, 그 외 서버 에러는 폼 하단 공통 에러 문구(`formError`)로 분기합니다. 제출 시작 지점에서 `formError`를 초기화해 재시도 시 이전 서버 에러가 남지 않도록 했습니다.

## 관련 이슈

- Closes #122

## 검증 방법

```
$ npx tsc --noEmit
(출력 없음)

$ npm run lint
(출력 없음 — 위반 없음)
```

브라우저에서 아래 세 가지를 직접 확인했습니다.

- 새 이메일로 회원가입하면 계정이 생성되고 `/events`로 이동합니다.
- 이미 가입된 이메일(`host@example.com`)로 제출하면 이메일 필드 아래에 "이미 가입된 이메일입니다." 에러가 표시됩니다.
- 위 상태에서 이메일만 다른 값으로 고쳐 재시도하면 이전 에러 없이 정상적으로 가입됩니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

400(`VALIDATION_ERROR`) 폴백 에러 처리 코드는 작성했지만, 브라우저에서 실제로 트리거하지는 못했습니다.
클라이언트 쪽 zod 검증(`signupRequestSchema`·`passwordSchema`)이 서버 검증 규칙을 그대로 미러링하고 있어서, 클라이언트 검증을 통과한 요청이 서버에서 400을 받는 경로 자체가 사실상 도달하기 어렵습니다.

이 PR은 마감(2026-08-14 오전 MSW 기준 축1 완성) 때문에 페어 모드가 아니라 Claude가 직접 구현했습니다. 리뷰 시 평소보다 꼼꼼한 확인을 부탁드립니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 회원가입 페이지에서 실제 회원가입 요청을 지원합니다.
  * 회원가입이 완료되면 이벤트 목록으로 자동 이동합니다.
  * 제출 중 중복 요청을 방지하고 진행 상태를 표시합니다.

* **버그 수정**
  * 이메일 중복 오류를 이메일 입력란에 표시합니다.
  * 기타 서버 오류를 폼 오류로 안내합니다.
  * 입력값 검증에 실패하면 요청을 보내지 않습니다.
  * 서버 오류 안내를 접근성 알림으로 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->