### PR TITLE
feat(auth): 백오피스 라우트 가드 추가

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -1,9 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 /**
- * HttpOnly 쿠키라 값을 읽고 검증할 수 없습니다(2026-08-07 명세). 존재 여부만 보는
- * 낙관적 체크입니다. 실제 유효성(위조·만료 여부)은 각 요청에서 서버가 검증합니다 —
- * 이 Proxy는 비로그인 사용자를 화면 진입 전에 걸러내는 1차 방어선일 뿐입니다.
+ * HttpOnly는 브라우저 JS(`document.cookie`)의 접근만 막습니다(2026-08-07 명세). Proxy는
+ * 서버에서 도는 코드라 `request.cookies.get()`/`has()`로 값 자체는 읽을 수 있습니다.
+ *
+ * 다만 이 토큰이 진짜 유효한지(위조·만료 여부)는 여기서 검증할 수단이 없어서, 존재
+ * 여부만 보는 낙관적 체크로 그칩니다. 실제 유효성 검증은 데이터에 가까운 서버 로직
+ * (각 API 요청)이 맡습니다 — 이 Proxy는 비로그인 사용자를 화면 진입 전에 걸러내는
+ * 1차 방어선일 뿐입니다.
  */
 const ACCESS_TOKEN_COOKIE = 'accessToken';
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+/**
+ * HttpOnly 쿠키라 값을 읽고 검증할 수 없습니다(2026-08-07 명세). 존재 여부만 보는
+ * 낙관적 체크입니다. 실제 유효성(위조·만료 여부)은 각 요청에서 서버가 검증합니다 —
+ * 이 Proxy는 비로그인 사용자를 화면 진입 전에 걸러내는 1차 방어선일 뿐입니다.
+ */
+const ACCESS_TOKEN_COOKIE = 'accessToken';
+
+export default function proxy(request: NextRequest) {
+  const hasAccessToken = request.cookies.has(ACCESS_TOKEN_COOKIE);
+
+  if (!hasAccessToken) {
+    return NextResponse.redirect(new URL('/login', request.url));
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ['/events/:path*'],
+};


### PR DESCRIPTION
## 변경 사항

로그인하지 않은 사용자가 `/events` 이하 백오피스 화면에 URL로 직접 들어갈 수 있던 문제를 막았습니다.

- 프로젝트 루트에 `proxy.ts`를 추가했습니다. Next.js 16부터 이 기능의 파일 이름이 `middleware.ts`에서 `proxy.ts`로 바뀌었고 export 함수 이름도 `proxy`(기본 export)로 바뀌어서, 이 버전 기준으로 작성했습니다.
- 인증 쿠키(`accessToken`)는 HttpOnly라 값을 읽고 검증할 수 없어서, 쿠키의 존재 여부만 보는 낙관적 체크로 구현했습니다. 실제 유효성(위조·만료 여부)은 각 API 요청에서 서버가 검증합니다.
- `matcher`를 `/events/:path*`로 좁혀 이 경로에서만 실행되도록 했습니다.

## 관련 이슈

- Closes #123

## 검증 방법

```
$ npx tsc --noEmit
(출력 없음)

$ npm run lint
(출력 없음 — 위반 없음)
```

브라우저에서 로그인하지 않은 상태로 `/events`에 접근하면 `/login`으로 리다이렉트되는 것을 3회 재현해 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

로그인한 상태에서 `/events`가 정상 통과되는 분기는 직접 검증하지 못했습니다.
이 브랜치는 `dev` 기준이라 로그인 페이지의 실제 `useAuth` 연동(PR #112)이 아직 없어서, 인증 쿠키를 발급받으려면 콘솔에서 로그인 API를 직접 호출하는 우회가 필요했습니다.
credentials를 포함한 cross-origin 요청을 시도했지만 쿠키가 저장되지 않았고, 이어서 `document.cookie` 조회도 브라우저 자동화 도구의 쿠키 관련 스크립트 차단에 막혀 원인을 더 파고들지 못했습니다.
다만 이 분기는 `if (!hasAccessToken) { 리다이렉트 }` 조건문의 else 경로일 뿐이라 별도 로직이 없습니다.
PR #112 머지 후 실제 로그인 흐름으로 통합 검증하는 걸 권장합니다.

이 PR은 마감(2026-08-14 오전 MSW 기준 축1 완성) 때문에 페어 모드가 아니라 Claude가 직접 구현했습니다. 리뷰 시 평소보다 꼼꼼한 확인을 부탁드립니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 로그인하지 않은 사용자가 이벤트 페이지에 접근하면 로그인 화면으로 자동 이동합니다.
  * 로그인 쿠키가 있으면 이벤트 페이지에 계속 접근할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->