### PR TITLE
fix(live): 제출 완료 배너 신호를 붙이고 도착 즉시 지움

### DIFF
--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -63,7 +63,9 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
       // 전부 차단으로 떨어집니다 — 소감을 내고 넘어가도 못 봅니다.
       markSubmitted(eventCode, sessionId);
 
-      router.push(`/e/${eventCode}/live?sessionId=${sessionId}`);
+      // `submitted=1`은 결과 화면이 "소감이 등록되었어요" 배너를 띄우는 신호입니다.
+      // 도착한 화면이 한 번 읽고 주소에서 지웁니다(#111).
+      router.push(`/e/${eventCode}/live?sessionId=${sessionId}&submitted=1`);
     },
   });
 

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -83,8 +83,32 @@ const LiveResult = () => {
    *
    * 제출 기록(`submitted`)으로 판정하지 않는 이유는 그 값이 "언젠가 냈다"만 알려주기
    * 때문입니다. 며칠 뒤 같은 링크를 다시 열었을 때도 안내가 뜨면 방금 낸 것처럼 읽힙니다.
+   *
+   * 플래그는 도착하자마자 주소에서 지웁니다. 남겨두면 새로고침할 때마다 다시 뜨는데,
+   * 지운 뒤에도 안내는 화면에 머물러야 해서 값을 state로 옮깁니다(#111).
    */
-  const justSubmitted = searchParams.get('submitted') === '1';
+  const [justSubmitted, setJustSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get('submitted') !== '1') return;
+
+    const remaining = new URLSearchParams(searchParams.toString());
+    remaining.delete('submitted');
+
+    // 이 화면이 플래그를 소비했다는 표시라 effect 말고 둘 곳이 없습니다.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setJustSubmitted(true);
+    /*
+     * `router.replace`가 아니라 `window.history.replaceState`입니다. 둘 다 Next 라우터와
+     * 동기화되지만(`next/dist/docs/01-app/02-guides/single-page-applications.md`),
+     * `router.replace`는 라우터를 거치면서 리렌더를 한 번 더 일으킵니다. 이 화면은 5초마다
+     * 폴링으로 다시 그려지는 중이라 주소창만 고치면 충분합니다.
+     *
+     * 지운 결과가 `searchParams`에 반영되면서 이 effect가 한 번 더 도는데, 그때는 위에서
+     * 바로 빠져나갑니다.
+     */
+    window.history.replaceState(null, '', `/e/${code}/live?${remaining.toString()}`);
+  }, [code, searchParams]);
 
   /*
    * 기록에 없는 세션은 집계를 아예 부르지 않습니다. 화면만 가리고 요청은 그대로 내보내면

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -86,8 +86,16 @@ const LiveResult = () => {
    *
    * 플래그는 도착하자마자 주소에서 지웁니다. 남겨두면 새로고침할 때마다 다시 뜨는데,
    * 지운 뒤에도 안내는 화면에 머물러야 해서 값을 state로 옮깁니다(#111).
+   *
+   * 담는 값은 "띄웠다"가 아니라 "누구에게 띄웠는지"입니다. 소비 사실만 남기면, 이 화면을
+   * 유지한 채 `?sessionId=`만 바뀌었을 때 effect가 플래그 없이 빠져나가면서 이전 세션의
+   * 안내가 그대로 남습니다. 지금은 그렇게 옮겨 다니는 길이 없지만(나가는 문은 `/e/{code}`
+   * 하나뿐입니다), 이 화면에 세션 전환이 붙는 순간 조용히 어긋납니다.
    */
-  const [justSubmitted, setJustSubmitted] = useState(false);
+  const [bannerTarget, setBannerTarget] = useState<string | null>(null);
+
+  const currentTarget = `${code}:${requestedId}`;
+  const justSubmitted = bannerTarget === currentTarget;
 
   useEffect(() => {
     if (searchParams.get('submitted') !== '1') return;
@@ -97,7 +105,7 @@ const LiveResult = () => {
 
     // 이 화면이 플래그를 소비했다는 표시라 effect 말고 둘 곳이 없습니다.
     // eslint-disable-next-line react-hooks/set-state-in-effect
-    setJustSubmitted(true);
+    setBannerTarget(currentTarget);
     /*
      * `router.replace`가 아니라 `window.history.replaceState`입니다. 둘 다 Next 라우터와
      * 동기화되지만(`next/dist/docs/01-app/02-guides/single-page-applications.md`),
@@ -108,7 +116,7 @@ const LiveResult = () => {
      * 바로 빠져나갑니다.
      */
     window.history.replaceState(null, '', `/e/${code}/live?${remaining.toString()}`);
-  }, [code, searchParams]);
+  }, [code, currentTarget, searchParams]);
 
   /*
    * 기록에 없는 세션은 집계를 아예 부르지 않습니다. 화면만 가리고 요청은 그대로 내보내면


### PR DESCRIPTION
## 변경 사항

- `FeedbackForm`이 제출 성공 후 이동 URL에 `&submitted=1`을 붙입니다. 이 절반이 비어 있어서 `justSubmitted`가 항상 `false`였고, `소감이 등록되었어요` 배너가 어떤 경로로도 뜨지 않았습니다. #101이 읽는 쪽(`LiveResult`)만 들어간 채 닫혀서 짝이 빠져 있었습니다.
- `LiveResult`는 플래그를 한 번 읽어 state로 옮기고 `window.history.replaceState`로 주소에서 지웁니다. PR #54 리뷰에서 정해진 세 규칙 중 마지막(새로고침하면 안 뜬다)이 이걸로 채워집니다.
- 그 state는 "띄웠다"가 아니라 **"누구에게 띄웠는지"**(`{code}:{sessionId}`)를 담습니다. 소비 사실만 남기면 이 화면을 유지한 채 `?sessionId=`만 바뀔 때 이전 세션의 배너가 그대로 남습니다.
- 구현 방식은 #111에서 확정된 A안(쿼리) 그대로입니다. B안(sessionStorage)은 `pulse:submitted:{eventCode}`(localStorage)와 저장소 계층이 갈리는 점 때문에 접었습니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| `5c4d3eb` | fix(live): 제출 완료 배너 신호를 붙이고 도착 즉시 지움 | 두 화면이 같이 들어가야 배너가 동작해서 한 커밋으로 묶음 |
| `75b2914` | fix(live): 등록 안내 배너를 대상 세션에 묶음 | 배너 상태가 대상 세션을 안 들고 있어, 화면 유지한 채 세션만 바뀌면 이전 배너가 남음 |

## 관련 이슈

- Closes #111
- Refs #54, #101

## 검증 방법

`npm run dev`(MSW 목 자동 활성화) + Chrome으로 실제 흐름을 확인했습니다. 이벤트는 시드의 LIVE 이벤트 `ab3f9x`, 세션은 `1부: 키노트`(101)·`2부: 패널 토론`(102)입니다. 아래는 모두 최종 커밋(`75b2914`) 기준입니다.

1. **제출 → 배너**: `/e/ab3f9x`에서 소감 제출 → `/e/ab3f9x/live?sessionId=101`로 이동하고 `소감이 등록되었어요` 배너가 떴습니다. dev 서버 로그에 `GET /e/ab3f9x/live?sessionId=101&submitted=1 200`이 찍혔고, 도착 시점 `location.href`는 이미 `?sessionId=101`이었습니다 — 플래그가 붙어서 왔고 지워졌다는 뜻입니다.
2. **머무는 동안 유지(규칙 2)**: 배너가 뜬 채 폴링 2회(약 11초) 뒤에도 배너가 그대로 있었습니다.
3. **새로고침(규칙 3)**: `location.reload()` → 배너 없음, URL은 `?sessionId=101`.
4. **손으로 플래그를 붙인 진입**: `?sessionId=101&submitted=1`로 직접 들어가면 배너가 뜨고 주소는 즉시 `?sessionId=101`로 정리됩니다. `history.length`가 늘지 않아 `pushState`가 아니라 `replaceState`로 동작하는 것도 확인했습니다.
5. **같은 화면에서 세션만 전환(`75b2914` 대상)**: 101에 배너가 뜬 상태에서 `history.pushState`로 `?sessionId=102`로 바꿨습니다. Next가 `useSearchParams`와 동기화하므로 컴포넌트는 언마운트되지 않고 제목만 `2부: 패널 토론`으로 바뀝니다.
   - 수정 전(`5c4d3eb`): 제목은 102인데 **배너가 그대로 남았습니다**.
   - 수정 후(`75b2914`): 배너가 사라집니다.

커밋 훅(lint-staged)의 `eslint --fix` + `prettier --write`가 변경된 파일에 통과했습니다. `npm run lint`·`npm run test` 전체는 돌리지 않았습니다 — 이 변경을 덮는 컴포넌트 테스트가 아직 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- `router.replace`가 아니라 `window.history.replaceState`입니다. 둘 다 Next 라우터와 동기화되지만(`node_modules/next/dist/docs/01-app/02-guides/single-page-applications.md`), `router.replace`는 라우터를 거치면서 리렌더를 한 번 더 일으킵니다. 이 화면은 5초마다 폴링으로 다시 그려지는 중이라 주소창만 고치면 충분합니다. #111 코멘트에서 짚어주신 그대로입니다.
- 플래그를 지우면 `useSearchParams`가 갱신되면서 effect가 한 번 더 도는데, 그때는 첫 줄에서 바로 빠져나갑니다. 그래서 early return 자리에서 상태를 비우는 방식은 쓸 수 없습니다 — 방금 띄운 배너를 스스로 꺼버립니다. 키로 비교하는 이유가 이것입니다.
- `75b2914`가 막는 경로는 **현재 앱에 없습니다.** 이 화면에 들어오는 길은 `FeedbackForm`의 push와 직접 진입뿐이고 둘 다 새로 마운트되며, 나가는 문은 `/e/{code}` 하나라 라우트가 바뀝니다. 하단 버튼 주석에 적힌 "이미 남긴 세션 칩 → 그 세션 결과" 가 이 화면 안의 세션 전환으로 구현되는 순간 어긋나므로 미리 막아둔 것입니다.
- 알면서 남겨둔 틈: 세션을 옮긴 뒤 뒤로가기로 원래 세션에 돌아오면 키가 다시 맞아 배너가 재등장합니다. 그 경로 자체가 아직 없어서 분기를 더 붙이지 않았습니다.
- 검증 중 dev 서버가 `/`를 포함한 모든 라우트를 404로 응답하는 일이 있었는데, `.next` 캐시가 깨진 것이었습니다(서버 두 개가 잠깐 같은 디렉터리를 잡았습니다). `.next`를 지우고 다시 띄우니 정상이었고, 이 PR의 코드와는 무관합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
