### PR TITLE
refactor(auth): 로그인·회원가입 페이지 Server/Client 컴포넌트 경계 분리

### DIFF
--- a/app/(host)/login/page.tsx
+++ b/app/(host)/login/page.tsx
@@ -1,98 +1,14 @@
-'use client';
-
 import Link from 'next/link';
 
 import { Logo } from '@/components/brand/Logo';
-import { Field } from '@/components/ui/Field';
-import { Button } from '@/components/ui/Button';
-import { useState, type SubmitEvent, ChangeEvent } from 'react';
-import { useRouter } from 'next/navigation';
-import { useAuth } from '@/hooks/useAuth';
-import { ApiError } from '@/lib/apiClient';
+import LoginForm from '@/components/auth/LoginForm';
 
-type LoginInputs = {
-  email: string;
-  password: string;
-};
-
-const initialLoginInputs = {
-  email: '',
-  password: '',
-};
 const LoginPage = () => {
-  // API: POST /auth/login. useAuth() 훅 연결 완료. 라우트 가드는 별도 이슈에서 처리합니다.
-  // 로그인 실패는 별도 라우트가 아니라 이 페이지 내부에서 처리합니다.
-  // 401 응답(INVALID_CREDENTIALS)은 존재하지 않는 사용자와 비밀번호 불일치를 병합해서 내려주므로(API 명세서 확정),
-  // 어느 필드가 틀렸는지는 표시하지 않습니다. 이메일·비밀번호 입력 필드 모두 invalid 스타일로 표시하고, 공통 에러 문구 하나만 보여줍니다.
-  const [loginFailed, setLoginFailed] = useState(false);
-  const [loginFailedMessage, setLoginFailedMessage] = useState<string | null>(null);
-  const [loginInputs, setLoginInputs] = useState<LoginInputs>(initialLoginInputs);
-
-  const router = useRouter();
-  const { login } = useAuth();
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setLoginInputs((prev) => ({
-      ...prev,
-      [event.target.name]: event.target.value,
-    }));
-  };
-
-  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setLoginFailed(false);
-    setLoginFailedMessage(null);
-
-    try {
-      await login(loginInputs.email, loginInputs.password);
-      router.push('/events');
-    } catch (error) {
-      setLoginFailed(true);
-
-      if (error instanceof ApiError && error.code === 'INVALID_CREDENTIALS') {
-        setLoginFailedMessage('이메일 또는 비밀번호가 올바르지 않습니다.');
-      } else {
-        setLoginFailedMessage('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    }
-  };
-
   return (
     <div className="min-h-dvh flex justify-center items-center p-14 bg-background-default">
       <div className="w-100 p-8 flex flex-col items-center gap-4 border border-border-default rounded-xl bg-background-default">
         <Logo size="lg" />
-        <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit}>
-          <Field
-            className="w-full"
-            label="이메일"
-            type="email"
-            placeholder="host@example.com"
-            invalid={loginFailed}
-            onChange={handleChange}
-            name="email"
-            value={loginInputs.email}
-          />
-          <Field
-            className="w-full"
-            label="비밀번호"
-            type="password"
-            placeholder="••••••••"
-            invalid={loginFailed}
-            onChange={handleChange}
-            name="password"
-            value={loginInputs.password}
-          />
-          <p
-            role="alert"
-            aria-atomic="true"
-            className={loginFailed ? 'text-xs text-negative-darker' : 'sr-only'}
-          >
-            {loginFailed ? loginFailedMessage : null}
-          </p>
-          <Button type="submit" variant="primary" className="w-full">
-            로그인
-          </Button>
-        </form>
+        <LoginForm />
         <p className="text-xs text-text-secondary">
           계정이 없으신가요?{' '}
           <Link href="/signup" className="font-medium text-primary-darker">

--- a/app/(host)/signup/page.tsx
+++ b/app/(host)/signup/page.tsx
@@ -1,132 +1,14 @@
-'use client';
-
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
 import { Logo } from '@/components/brand/Logo';
-import { Field } from '@/components/ui/Field';
-import { Button } from '@/components/ui/Button';
-import { ChangeEvent, type SubmitEvent, useState } from 'react';
-import { passwordSchema, signupRequestSchema } from '@/lib/schemas/api';
-import { useAuth } from '@/hooks/useAuth';
-import { ApiError } from '@/lib/apiClient';
-
-type SignupInputs = {
-  email: string;
-  password: string;
-  passwordConfirm: string;
-};
-
-type SignupErrors = {
-  email?: string;
-  password?: string;
-  passwordConfirm?: string;
-};
-
-const initialSignupInputs: SignupInputs = {
-  email: '',
-  password: '',
-  passwordConfirm: '',
-};
+import SignupForm from '@/components/auth/SignupForm';
 
 const SignupPage = () => {
-  // API: POST /auth/signup. useAuth().signup으로 실제 요청을 보냅니다.
-  const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
-  const [signupErrors, setSignupErrors] = useState<SignupErrors>({});
-  // 필드별 에러(signupErrors)로 표현할 수 없는 서버 에러(400 폴백)만 여기 담습니다.
-  const [formError, setFormError] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const router = useRouter();
-  const { signup } = useAuth();
-
-  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setSignupInputs((prev) => ({
-      ...prev,
-      [event.target.name]: event.target.value,
-    }));
-  };
-
-  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (isSubmitting) return;
-    setFormError(null);
-
-    const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
-    const passwordValidation = passwordSchema.safeParse(signupInputs.password);
-    const passwordConfirmError =
-      signupInputs.password !== signupInputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
-
-    const nextErrors: SignupErrors = {
-      email: emailValidation.error?.issues[0].message,
-      password: passwordValidation.error?.issues[0].message,
-      passwordConfirm: passwordConfirmError,
-    };
-    setSignupErrors(nextErrors);
-
-    if (nextErrors.email || nextErrors.password || nextErrors.passwordConfirm) return;
-
-    setIsSubmitting(true);
-    try {
-      await signup(signupInputs.email, signupInputs.password);
-      router.push('/events');
-    } catch (error) {
-      if (error instanceof ApiError && error.code === 'EMAIL_ALREADY_EXISTS') {
-        setSignupErrors((prev) => ({ ...prev, email: '이미 가입된 이메일입니다.' }));
-      } else {
-        setFormError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
-      }
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
   return (
     <div className="min-h-dvh flex justify-center items-center p-14 bg-background-default">
       <div className="w-100 p-8 flex flex-col items-center gap-4 border border-border-default rounded-xl bg-background-default">
         <Logo size="lg" />
-        <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit} noValidate={true}>
-          <Field
-            onChange={handleChange}
-            className="w-full"
-            label="이메일"
-            name="email"
-            type="email"
-            placeholder="host@example.com"
-            value={signupInputs.email}
-            error={signupErrors.email}
-          />
-          <Field
-            onChange={handleChange}
-            className="w-full"
-            label="비밀번호"
-            name="password"
-            type="password"
-            placeholder="••••••••"
-            value={signupInputs.password}
-            error={signupErrors.password}
-          />
-          <Field
-            onChange={handleChange}
-            className="w-full"
-            label="비밀번호 확인"
-            name="passwordConfirm"
-            type="password"
-            placeholder="••••••••"
-            value={signupInputs.passwordConfirm}
-            error={signupErrors.passwordConfirm}
-          />
-          <p
-            role="alert"
-            aria-atomic="true"
-            className={formError ? 'text-xs text-negative-darker' : 'sr-only'}
-          >
-            {formError}
-          </p>
-          <Button type="submit" variant="primary" className="w-full" disabled={isSubmitting}>
-            {isSubmitting ? '가입 중...' : '회원가입'}
-          </Button>
-        </form>
+        <SignupForm />
         <p className="text-xs text-text-secondary">
           이미 계정이 있으신가요?{' '}
           <Link href="/login" className="font-medium text-primary-darker">

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -26,6 +26,7 @@ const LoginForm = () => {
   const [loginFailed, setLoginFailed] = useState(false);
   const [loginFailedMessage, setLoginFailedMessage] = useState<string | null>(null);
   const [loginInputs, setLoginInputs] = useState<LoginInputs>(initialLoginInputs);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const router = useRouter();
   const { login } = useAuth();
@@ -39,9 +40,11 @@ const LoginForm = () => {
 
   const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
+    if (isSubmitting) return;
     setLoginFailed(false);
     setLoginFailedMessage(null);
 
+    setIsSubmitting(true);
     try {
       await login(loginInputs.email, loginInputs.password);
       router.push('/events');
@@ -53,6 +56,8 @@ const LoginForm = () => {
       } else {
         setLoginFailedMessage('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -85,7 +90,7 @@ const LoginForm = () => {
       >
         {loginFailed ? loginFailedMessage : null}
       </p>
-      <Button type="submit" variant="primary" className="w-full">
+      <Button type="submit" variant="primary" className="w-full" disabled={isSubmitting}>
         로그인
       </Button>
     </form>

--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState, type SubmitEvent, ChangeEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
+import { Field } from '@/components/ui/Field';
+import { Button } from '@/components/ui/Button';
+import { useAuth } from '@/hooks/useAuth';
+import { ApiError } from '@/lib/apiClient';
+
+type LoginInputs = {
+  email: string;
+  password: string;
+};
+
+const initialLoginInputs = {
+  email: '',
+  password: '',
+};
+
+const LoginForm = () => {
+  // API: POST /auth/login. useAuth() 훅 연결 완료. 라우트 가드는 별도 이슈에서 처리합니다.
+  // 로그인 실패는 별도 라우트가 아니라 이 페이지 내부에서 처리합니다.
+  // 401 응답(INVALID_CREDENTIALS)은 존재하지 않는 사용자와 비밀번호 불일치를 병합해서 내려주므로(API 명세서 확정),
+  // 어느 필드가 틀렸는지는 표시하지 않습니다. 이메일·비밀번호 입력 필드 모두 invalid 스타일로 표시하고, 공통 에러 문구 하나만 보여줍니다.
+  const [loginFailed, setLoginFailed] = useState(false);
+  const [loginFailedMessage, setLoginFailedMessage] = useState<string | null>(null);
+  const [loginInputs, setLoginInputs] = useState<LoginInputs>(initialLoginInputs);
+
+  const router = useRouter();
+  const { login } = useAuth();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setLoginInputs((prev) => ({
+      ...prev,
+      [event.target.name]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLoginFailed(false);
+    setLoginFailedMessage(null);
+
+    try {
+      await login(loginInputs.email, loginInputs.password);
+      router.push('/events');
+    } catch (error) {
+      setLoginFailed(true);
+
+      if (error instanceof ApiError && error.code === 'INVALID_CREDENTIALS') {
+        setLoginFailedMessage('이메일 또는 비밀번호가 올바르지 않습니다.');
+      } else {
+        setLoginFailedMessage('로그인에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    }
+  };
+
+  return (
+    <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit}>
+      <Field
+        className="w-full"
+        label="이메일"
+        type="email"
+        placeholder="host@example.com"
+        invalid={loginFailed}
+        onChange={handleChange}
+        name="email"
+        value={loginInputs.email}
+      />
+      <Field
+        className="w-full"
+        label="비밀번호"
+        type="password"
+        placeholder="••••••••"
+        invalid={loginFailed}
+        onChange={handleChange}
+        name="password"
+        value={loginInputs.password}
+      />
+      <p
+        role="alert"
+        aria-atomic="true"
+        className={loginFailed ? 'text-xs text-negative-darker' : 'sr-only'}
+      >
+        {loginFailed ? loginFailedMessage : null}
+      </p>
+      <Button type="submit" variant="primary" className="w-full">
+        로그인
+      </Button>
+    </form>
+  );
+};
+
+export default LoginForm;

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -27,6 +27,19 @@ const initialSignupInputs: SignupInputs = {
   passwordConfirm: '',
 };
 
+const validateSignupInputs = (inputs: SignupInputs): SignupErrors => {
+  const emailValidation = signupRequestSchema.shape.email.safeParse(inputs.email);
+  const passwordValidation = passwordSchema.safeParse(inputs.password);
+  const passwordConfirmError =
+    inputs.password !== inputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
+
+  return {
+    email: emailValidation.error?.issues[0].message,
+    password: passwordValidation.error?.issues[0].message,
+    passwordConfirm: passwordConfirmError,
+  };
+};
+
 const SignupForm = () => {
   // API: POST /auth/signup. useAuth().signup으로 실제 요청을 보냅니다.
   const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
@@ -50,19 +63,11 @@ const SignupForm = () => {
     if (isSubmitting) return;
     setFormError(null);
 
-    const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
-    const passwordValidation = passwordSchema.safeParse(signupInputs.password);
-    const passwordConfirmError =
-      signupInputs.password !== signupInputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
+    const validationErrors = validateSignupInputs(signupInputs);
+    setSignupErrors(validationErrors);
 
-    const nextErrors: SignupErrors = {
-      email: emailValidation.error?.issues[0].message,
-      password: passwordValidation.error?.issues[0].message,
-      passwordConfirm: passwordConfirmError,
-    };
-    setSignupErrors(nextErrors);
-
-    if (nextErrors.email || nextErrors.password || nextErrors.passwordConfirm) return;
+    if (validationErrors.email || validationErrors.password || validationErrors.passwordConfirm)
+      return;
 
     setIsSubmitting(true);
     try {

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -40,6 +40,13 @@ const validateSignupInputs = (inputs: SignupInputs): SignupErrors => {
   };
 };
 
+const getSignupErrorFeedback = (error: unknown): { emailError?: string; formError?: string } => {
+  if (error instanceof ApiError && error.code === 'EMAIL_ALREADY_EXISTS') {
+    return { emailError: '이미 가입된 이메일입니다.' };
+  }
+  return { formError: '회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.' };
+};
+
 const SignupForm = () => {
   // API: POST /auth/signup. useAuth().signup으로 실제 요청을 보냅니다.
   const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
@@ -66,18 +73,18 @@ const SignupForm = () => {
     const validationErrors = validateSignupInputs(signupInputs);
     setSignupErrors(validationErrors);
 
-    if (validationErrors.email || validationErrors.password || validationErrors.passwordConfirm)
-      return;
+    if (Object.values(validationErrors).some(Boolean)) return;
 
     setIsSubmitting(true);
     try {
       await signup(signupInputs.email, signupInputs.password);
       router.push('/events');
     } catch (error) {
-      if (error instanceof ApiError && error.code === 'EMAIL_ALREADY_EXISTS') {
-        setSignupErrors((prev) => ({ ...prev, email: '이미 가입된 이메일입니다.' }));
+      const feedback = getSignupErrorFeedback(error);
+      if (feedback.emailError) {
+        setSignupErrors((prev) => ({ ...prev, email: feedback.emailError }));
       } else {
-        setFormError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
+        setFormError(feedback.formError ?? null);
       }
     } finally {
       setIsSubmitting(false);

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { ChangeEvent, type SubmitEvent, useState } from 'react';
+
+import { Field } from '@/components/ui/Field';
+import { Button } from '@/components/ui/Button';
+import { passwordSchema, signupRequestSchema } from '@/lib/schemas/api';
+import { useAuth } from '@/hooks/useAuth';
+import { ApiError } from '@/lib/apiClient';
+
+type SignupInputs = {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+};
+
+type SignupErrors = {
+  email?: string;
+  password?: string;
+  passwordConfirm?: string;
+};
+
+const initialSignupInputs: SignupInputs = {
+  email: '',
+  password: '',
+  passwordConfirm: '',
+};
+
+const SignupForm = () => {
+  // API: POST /auth/signup. useAuth().signup으로 실제 요청을 보냅니다.
+  const [signupInputs, setSignupInputs] = useState<SignupInputs>(initialSignupInputs);
+  const [signupErrors, setSignupErrors] = useState<SignupErrors>({});
+  // 필드별 에러(signupErrors)로 표현할 수 없는 서버 에러(400 폴백)만 여기 담습니다.
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const router = useRouter();
+  const { signup } = useAuth();
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setSignupInputs((prev) => ({
+      ...prev,
+      [event.target.name]: event.target.value,
+    }));
+  };
+
+  const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) return;
+    setFormError(null);
+
+    const emailValidation = signupRequestSchema.shape.email.safeParse(signupInputs.email);
+    const passwordValidation = passwordSchema.safeParse(signupInputs.password);
+    const passwordConfirmError =
+      signupInputs.password !== signupInputs.passwordConfirm ? '비밀번호가 일치하지 않습니다.' : '';
+
+    const nextErrors: SignupErrors = {
+      email: emailValidation.error?.issues[0].message,
+      password: passwordValidation.error?.issues[0].message,
+      passwordConfirm: passwordConfirmError,
+    };
+    setSignupErrors(nextErrors);
+
+    if (nextErrors.email || nextErrors.password || nextErrors.passwordConfirm) return;
+
+    setIsSubmitting(true);
+    try {
+      await signup(signupInputs.email, signupInputs.password);
+      router.push('/events');
+    } catch (error) {
+      if (error instanceof ApiError && error.code === 'EMAIL_ALREADY_EXISTS') {
+        setSignupErrors((prev) => ({ ...prev, email: '이미 가입된 이메일입니다.' }));
+      } else {
+        setFormError('회원가입에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit} noValidate={true}>
+      <Field
+        onChange={handleChange}
+        className="w-full"
+        label="이메일"
+        name="email"
+        type="email"
+        placeholder="host@example.com"
+        value={signupInputs.email}
+        error={signupErrors.email}
+      />
+      <Field
+        onChange={handleChange}
+        className="w-full"
+        label="비밀번호"
+        name="password"
+        type="password"
+        placeholder="••••••••"
+        value={signupInputs.password}
+        error={signupErrors.password}
+      />
+      <Field
+        onChange={handleChange}
+        className="w-full"
+        label="비밀번호 확인"
+        name="passwordConfirm"
+        type="password"
+        placeholder="••••••••"
+        value={signupInputs.passwordConfirm}
+        error={signupErrors.passwordConfirm}
+      />
+      <p
+        role="alert"
+        aria-atomic="true"
+        className={formError ? 'text-xs text-negative-darker' : 'sr-only'}
+      >
+        {formError}
+      </p>
+      <Button type="submit" variant="primary" className="w-full" disabled={isSubmitting}>
+        {isSubmitting ? '가입 중...' : '회원가입'}
+      </Button>
+    </form>
+  );
+};
+
+export default SignupForm;


### PR DESCRIPTION
## 변경 사항

- 로그인·회원가입 페이지(`app/(host)/login/page.tsx`, `app/(host)/signup/page.tsx`)를 Server Component로 유지하고, 
입력 상태·`useAuth`·`useRouter`·제출 처리만 `components/auth/LoginForm.tsx`·`components/auth/SignupForm.tsx`라는 별도 Client Component로 분리했습니다.
- `CLAUDE.md`의 SSR/CSR 경계 규칙("공개 페이지는 SSR/SSG, 대시보드는 CSR로 구성합니다")에 맞추기 위한 리팩터링이며, PR #112 코드래빗 리뷰에서 처음 지적됐습니다.
- UI·문구·동작 로직은 바꾸지 않았습니다.  
  기존 코드를 그대로 옮기기만 했습니다.

## 개발 과정 로그 (커밋 순서, 오래된 순)

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| 26b63b6 | refactor(auth): 로그인·회원가입 페이지 Server/Client 컴포넌트 경계 분리 | 이슈 #114(로그인·회원가입 Server/Client 경계 분리)가 원래 목표로 한 작업입니다. 로그인·회원가입 페이지를 Server Component로 유지하고, 입력 상태·`useAuth`·`useRouter`·제출 처리만 별도 Client Component로 분리했습니다. |
| 61b7fa6 | fix(auth): 로그인 폼 중복 제출 방지 | PR #129 코드래빗 리뷰(`components/auth/LoginForm.tsx:31`)에서 로그인 폼에 중복 제출 방지 로직이 없다는 지적을 받아 반영했습니다. |
| db5c9a3 | refactor(auth): SignupForm 유효성 검사 로직을 컴포넌트 밖으로 분리 | WebStorm 복잡도 경고(SignupForm 153%)를 계기로, 유효성 검사 로직을 컴포넌트 밖 순수 함수(`validateSignupInputs`)로 분리했습니다. |
| ae4c7c9 | refactor(auth): SignupForm handleSubmit 분기 추가 정리 | 같은 복잡도 실험을 이어가면서 에러 판단 분기를 추가로 정리했습니다(153%에서 127%로 낮아짐). 이 지점에서 리팩터링을 마무리하기로 결정했습니다. |

## 관련 이슈

- Closes #114

## 검증 방법

- `npm run lint`: 경고 없이 통과했습니다.
- `npm run build`: TypeScript 체크·정적 페이지 생성 모두 통과했습니다. `/login`, `/signup`이 여전히 정적(○) 라우트로 표시됩니다.
- `npm run dev`로 서버를 띄운 뒤 `curl`로 RSC(React Server Components) 페이로드를 확인해, `LoginForm`·`SignupForm`이 별도 클라이언트 청크로 정확히 분리된 것을 확인했습니다.
- 브라우저(Chrome)로 두 화면을 직접 조작해서 아래 시나리오를 확인했습니다.
  - 로그인 실패(비밀번호 오류): 이메일·비밀번호 필드가 모두 invalid 스타일로 바뀌고 "이메일 또는 비밀번호가 올바르지 않습니다." 문구가 뜹니다.
  - 회원가입 실패(중복 이메일): 이메일 필드에만 "이미 가입된 이메일입니다." 문구가 뜹니다.
  - 로그인·회원가입 성공(폼 제출 자체): `POST /auth/login`·`POST /auth/signup` 요청이 200으로 응답하고, 이어지는 `GET /auth/me`도 정상적으로 로그인된 사용자 정보를 돌려줍니다.

### 스크린샷

이 PR은 UI를 바꾸지 않아서, 아래 스크린샷은 리팩터링 후에도 화면이 그대로인지 보여주는 용도입니다.  
각 항목마다 스크린샷을 첨부했습니다.

- **로그인 화면 (정상 상태, 빈 폼)**
> <img width="502" height="460" alt="shot-msqziatj" src="https://github.com/user-attachments/assets/77900606-5f67-46ef-b4fa-e1f44a327389" />


- **로그인 실패 상태 (비밀번호 오류 문구가 뜬 화면)**
> <img width="459" height="488" alt="shot-msqzirn9" src="https://github.com/user-attachments/assets/ac1ba199-3061-4847-b597-3f2cec85b1f6" />


- **회원가입 화면 (정상 상태, 빈 폼)**
> <img width="483" height="547" alt="shot-msqzhqnz" src="https://github.com/user-attachments/assets/b5eaf92e-25f2-4b0c-8efa-e25faa58a639" />


- **회원가입 실패 상태 (이메일 중복 오류 문구가 뜬 화면)**
> <img width="499" height="552" alt="shot-msqzgqv1" src="https://github.com/user-attachments/assets/4c3a38a9-71f3-4fa0-bbbf-d49f6500ffc8" />


## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

이 PR의 코드는 페어 모드가 아니라 Claude가 직접 작성했습니다.  
코드 자체는 기존 파일 내용을 그대로 옮긴 것이라 로직 변경은 없지만, 리뷰 시 이 점을 참고해주세요.

로그인·회원가입 성공 후 `router.push('/events')`가 실행돼도 `/events`로 이동하지 않는 문제를 브라우저 검증 중 발견했습니다.  
이 PR이 옮긴 코드(`handleSubmit`·`router.push`)나 `proxy.ts`는 전혀 건드리지 않았고, 
원인은 `proxy.ts`의 `accessToken` 쿠키 체크와 MSW 목 서버의 교차 오리진(cross-origin) 쿠키 문제로 추정됩니다.  
이슈 본문에 명시된 "라우트 가드 등 다른 인증 관련 작업은 이번 작업에서 제외" 범위에 해당해 이 PR에서는 고치지 않았고, 
별도 이슈(#128)로 등록했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새 기능

- 로그인 및 회원가입 화면에 전용 폼을 제공합니다.
- 로그인 시 잘못된 인증 정보와 기타 오류를 구분해 안내합니다.
- 회원가입 시 이메일, 비밀번호, 비밀번호 확인을 검증합니다.
- 이메일 중복 및 가입 실패 오류를 구분해 표시합니다.
- 제출 중 중복 요청을 방지하고 진행 상태를 표시합니다.
- 로그인과 회원가입이 완료되면 이벤트 목록으로 이동합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


