### PR TITLE
fix(auth): Mock 서버 로그인 성공 후 accessToken 쿠키가 저장되지 않는 문제 수정

### DIFF
--- a/mocks/browser.ts
+++ b/mocks/browser.ts
@@ -1,4 +1,9 @@
 import { setupWorker } from 'msw/browser';
-import { handlers } from './handlers';
+import { createHandlers } from './handlers';
 
-export const worker = setupWorker(...handlers);
+/**
+ * Service Worker가 응답을 가로채는 환경이라 `httpOnly: true`로 두면 `accessToken`
+ * 쿠키가 브라우저에 저장되지 않습니다(이슈 #128, `mocks/handlers/auth.ts`
+ * `sessionCookies` 주석 참고). `httpOnly: false`로 이 제약을 우회합니다.
+ */
+export const worker = setupWorker(...createHandlers({ httpOnly: false }));

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -12,6 +12,7 @@ import {
   sessionViewSchema,
 } from '@/lib/schemas/api';
 import { db, nextAccountId, resetDb } from '@/mocks/data/store';
+import { createAuthHandlers } from '@/mocks/handlers/auth';
 import { API_BASE_URL } from '@/mocks/handlers/shared';
 import { server } from '@/mocks/server';
 
@@ -80,12 +81,29 @@ describe('auth', () => {
     expect(body).not.toHaveProperty('accessToken');
 
     const { accessToken, xsrfToken } = splitSetCookie(response);
-    // 실제 명세는 accessToken에 HttpOnly를 붙이지만, 목은 일부러 뺍니다. Service Worker가
-    // 가로챈 응답은 HttpOnly Set-Cookie를 브라우저 저장소에 반영하지 못해서(이슈 #128,
-    // mocks/handlers/auth.ts의 sessionCookies 주석 참고), 목에서 HttpOnly를 유지하면
-    // 로컬 브라우저 테스트에서 로그인 이후 화면을 전혀 열어볼 수 없습니다.
-    expect(accessToken).not.toContain('HttpOnly');
+    // 이 테스트는 mocks/server.ts(msw/node)를 쓰므로 Service Worker를 거치지 않습니다.
+    // 계약 테스트인 만큼 명세대로 accessToken에 HttpOnly가 붙어야 합니다. 브라우저에서만
+    // HttpOnly를 빼는 예외(이슈 #128)는 아래 별도 테스트가 검증합니다.
+    expect(accessToken).toContain('HttpOnly');
     // CSRF 토큰은 FE가 읽어서 헤더로 되돌려 보내야 해서 HttpOnly면 안 됩니다.
+    expect(xsrfToken).not.toContain('HttpOnly');
+  });
+
+  it('브라우저 목은 accessToken에 HttpOnly를 붙이지 않는다 (이슈 #128)', async () => {
+    // Service Worker가 가로챈 응답은 HttpOnly Set-Cookie를 브라우저 저장소에 반영하지
+    // 못해서(mocks/handlers/auth.ts의 sessionCookies 주석 참고), mocks/browser.ts는
+    // httpOnly: false로 이 핸들러를 띄웁니다. 여기서는 같은 옵션으로 만든 핸들러를
+    // 이 테스트에서만 잠깐 끼워 넣어(server.use) 그 동작을 직접 검증합니다.
+    server.use(...createAuthHandlers({ httpOnly: false }));
+
+    const response = await call('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email: 'host@example.com', password: 'pulse1234' }),
+    });
+
+    const { accessToken, xsrfToken } = splitSetCookie(response);
+    expect(accessToken).not.toContain('HttpOnly');
     expect(xsrfToken).not.toContain('HttpOnly');
   });
 

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -80,7 +80,11 @@ describe('auth', () => {
     expect(body).not.toHaveProperty('accessToken');
 
     const { accessToken, xsrfToken } = splitSetCookie(response);
-    expect(accessToken).toContain('HttpOnly');
+    // 실제 명세는 accessToken에 HttpOnly를 붙이지만, 목은 일부러 뺍니다. Service Worker가
+    // 가로챈 응답은 HttpOnly Set-Cookie를 브라우저 저장소에 반영하지 못해서(이슈 #128,
+    // mocks/handlers/auth.ts의 sessionCookies 주석 참고), 목에서 HttpOnly를 유지하면
+    // 로컬 브라우저 테스트에서 로그인 이후 화면을 전혀 열어볼 수 없습니다.
+    expect(accessToken).not.toContain('HttpOnly');
     // CSRF 토큰은 FE가 읽어서 헤더로 되돌려 보내야 해서 HttpOnly면 안 됩니다.
     expect(xsrfToken).not.toContain('HttpOnly');
   });

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -1,5 +1,5 @@
 import { adminHandlers } from '@/mocks/handlers/admin';
-import { authHandlers } from '@/mocks/handlers/auth';
+import { createAuthHandlers } from '@/mocks/handlers/auth';
 import { eventHandlers } from '@/mocks/handlers/event';
 import { feedbackHandlers } from '@/mocks/handlers/feedback';
 import { reportHandlers } from '@/mocks/handlers/report';
@@ -10,9 +10,13 @@ import { reportHandlers } from '@/mocks/handlers/report';
  *
  * 미확정 엔드포인트를 모아두던 `proposed.ts`는 2026-08-06에 다섯 건이 전부 명세로
  * 확정되면서 사라졌습니다. 지금은 전 핸들러가 확정 계약입니다.
+ *
+ * `httpOnly`는 인증 핸들러의 `accessToken` 쿠키에만 영향을 줍니다(이슈 #128). 값을 어떻게
+ * 넘겨야 하는지는 `mocks/handlers/auth.ts`의 `sessionCookies` 주석을 참고해야 합니다.
+ * 이 파일을 직접 쓰는 `mocks/server.ts`·`mocks/browser.ts` 각각의 값도 그쪽에서 정합니다.
  */
-export const handlers = [
-  ...authHandlers,
+export const createHandlers = ({ httpOnly }: { httpOnly: boolean }) => [
+  ...createAuthHandlers({ httpOnly }),
   ...eventHandlers,
   ...feedbackHandlers,
   ...adminHandlers,

--- a/mocks/handlers/auth.ts
+++ b/mocks/handlers/auth.ts
@@ -33,10 +33,7 @@ const MOCK_XSRF_TOKEN = 'mock-xsrf-token';
  *
  * ---
  *
- * `accessToken`에는 실제 명세와 달리 `HttpOnly`를 붙이지 않습니다(이슈 #128).
- *
- * AS-IS: 원래는 실제 BE와 동일하게 `HttpOnly`를 붙였습니다.
- * TO-BE: 목 환경에서는 `HttpOnly`를 빼야 브라우저에 쿠키가 실제로 저장됩니다.
+ * `httpOnly` 옵션은 `accessToken` 쿠키에만 영향을 줍니다(이슈 #128).
  *
  * 브라우저에서 MSW는 Service Worker(`mockServiceWorker.js`)가 페이지의 `fetch`를
  * 가로채서, 이 파일이 만든 응답을 `FetchEvent.respondWith()`로 대신 돌려주는 방식으로
@@ -46,8 +43,8 @@ const MOCK_XSRF_TOKEN = 'mock-xsrf-token';
  * 심을 수 있게 되면 `HttpOnly`의 존재 이유 자체가 무너지기 때문입니다.
  *
  * 이슈 #128에서 아래 순서로 이 원인을 좁혔습니다.
- * - Node 환경(`msw/node`, `mocks/handlers.test.ts`)에서는 이 함수가 두 쿠키를 모두
- *   정확히 만든다는 걸 테스트로 확인했습니다. 즉 이 파일의 로직 자체는 원래도 맞았습니다.
+ * - Node 환경(`msw/node`, `mocks/server.ts`)에서는 이 함수가 두 쿠키를 모두 정확히
+ *   만든다는 걸 테스트로 확인했습니다. 즉 이 파일의 로직 자체는 원래도 맞았습니다.
  * - 그런데 실제 브라우저에서 로그인해보면 `HttpOnly`가 없는 `XSRF-TOKEN`만 저장되고,
  *   `HttpOnly`가 붙은 `accessToken`은 쿠키를 완전히 지운 뒤 다시 로그인해도 저장되지
  *   않았습니다. 두 쿠키의 유일한 차이가 `HttpOnly`라 원인이 여기로 좁혀졌습니다.
@@ -56,19 +53,32 @@ const MOCK_XSRF_TOKEN = 'mock-xsrf-token';
  *   WHATWG 쿠키 스토어 제안의 논의(https://github.com/whatwg/cookiestore/issues/37)에서도
  *   같은 제약으로 설명되고 있어서, 이 프로젝트만의 버그가 아니라 브라우저 자체의 제약으로 판단했습니다.
  *
- * 실제 BE 응답은 이 파일을 거치지 않으므로(`mocks/config.ts`의 `isMockingEnabled`가 꺼지면
- * 이 핸들러 자체가 실행되지 않습니다), 실제 배포 환경의 보안에는 영향이 없습니다. FE 코드
+ * 그래서 이 함수들은 호출하는 쪽이 `httpOnly` 여부를 직접 정하게 합니다.
+ * `mocks/server.ts`(SSR 목·`mocks/handlers.test.ts` 계약 테스트, Service Worker를
+ * 거치지 않음)는 `httpOnly: true`로 실제 명세를 그대로 지킵니다. `mocks/browser.ts`(브라우저
+ * 개발 서버, Service Worker를 거침)만 `httpOnly: false`로 위 제약을 우회합니다. 실제 BE
+ * 응답은 이 파일을 거치지 않으므로(`mocks/config.ts`의 `isMockingEnabled`가 꺼지면 이
+ * 핸들러 자체가 실행되지 않습니다), 실제 배포 환경의 보안에는 영향이 없습니다. FE 코드
  * 어디에도 `accessToken`을 `document.cookie`로 직접 읽는 곳이 없어서(애초에 `HttpOnly`라
- * 못 읽는 게 설계 의도), 목에서만 `HttpOnly`를 빼도 놓치는 실제 버그는 없습니다.
+ * 못 읽는 게 설계 의도), 브라우저 목에서만 `HttpOnly`를 빼도 놓치는 실제 버그는 없습니다.
  */
-const sessionCookies = (accountId: number): [string, string][] => [
-  ['Set-Cookie', `${ACCESS_TOKEN_COOKIE}=${issueAccessToken(accountId)}; Path=/; SameSite=Lax`],
+const sessionCookies = (
+  accountId: number,
+  { httpOnly }: { httpOnly: boolean },
+): [string, string][] => [
+  [
+    'Set-Cookie',
+    `${ACCESS_TOKEN_COOKIE}=${issueAccessToken(accountId)}; Path=/; SameSite=Lax${httpOnly ? '; HttpOnly' : ''}`,
+  ],
   // CSRF double-submit용이라 HttpOnly가 아닙니다. FE가 읽어서 X-XSRF-TOKEN 헤더로 되돌려 보냅니다.
   ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax`],
 ];
 
-const expiredCookies = (): [string, string][] => [
-  ['Set-Cookie', `${ACCESS_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`],
+const expiredCookies = ({ httpOnly }: { httpOnly: boolean }): [string, string][] => [
+  [
+    'Set-Cookie',
+    `${ACCESS_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0${httpOnly ? '; HttpOnly' : ''}`,
+  ],
   ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`],
 ];
 
@@ -78,7 +88,12 @@ const toAuthUser = (account: MockAccount): AuthUser => ({
   createdAt: account.createdAt,
 });
 
-export const authHandlers = [
+/**
+ * 인증 핸들러 목록을 만듭니다. `httpOnly`는 위 `sessionCookies`·`expiredCookies` 주석대로
+ * `accessToken` 쿠키에만 적용되며, 호출하는 쪽(`mocks/server.ts`·`mocks/browser.ts`)이
+ * 자신의 환경에 맞는 값을 넘겨야 합니다.
+ */
+export const createAuthHandlers = ({ httpOnly }: { httpOnly: boolean }) => [
   http.post(`${API_BASE_URL}/auth/login`, async ({ request }) => {
     const body = await parseBody(request, loginRequestSchema);
     if (!body.ok) return body.response;
@@ -90,7 +105,9 @@ export const authHandlers = [
       return errorResponse('INVALID_CREDENTIALS');
     }
 
-    return HttpResponse.json(toAuthUser(account), { headers: sessionCookies(account.id) });
+    return HttpResponse.json(toAuthUser(account), {
+      headers: sessionCookies(account.id, { httpOnly }),
+    });
   }),
 
   http.post(`${API_BASE_URL}/auth/signup`, async ({ request }) => {
@@ -111,13 +128,13 @@ export const authHandlers = [
     // 가입과 동시에 쿠키를 내려 로그인 상태로 만듭니다. 별도 로그인 호출이 필요 없습니다.
     return HttpResponse.json(toAuthUser(account), {
       status: 201,
-      headers: sessionCookies(account.id),
+      headers: sessionCookies(account.id, { httpOnly }),
     });
   }),
 
   // 쿠키만 만료시킵니다. 로그인 상태가 아니어도 성공으로 봅니다(멱등).
   http.post(`${API_BASE_URL}/auth/logout`, () => {
-    return new HttpResponse(null, { status: 204, headers: expiredCookies() });
+    return new HttpResponse(null, { status: 204, headers: expiredCookies({ httpOnly }) });
   }),
 
   /**

--- a/mocks/handlers/auth.ts
+++ b/mocks/handlers/auth.ts
@@ -27,27 +27,50 @@ const MOCK_XSRF_TOKEN = 'mock-xsrf-token';
  * 실제 BE는 `Secure; SameSite=None`으로 내립니다(FE·BE 도메인이 다름).
  * 목은 `Secure`를 빼고 `SameSite=Lax`로 둡니다 — localhost는 http라서 `Secure` 쿠키가 저장되지 않고,
  * 목은 같은 오리진이라 `None`이 필요 없습니다.
+ *
+ * `Headers`에 `Set-Cookie`를 `.append()`로 두 번 넣으면 MSW가 마지막 값만 적용하고
+ * 앞의 값을 버려서(https://github.com/mswjs/msw/issues/1290), 배열로 직접 넘깁니다.
+ *
+ * ---
+ *
+ * `accessToken`에는 실제 명세와 달리 `HttpOnly`를 붙이지 않습니다(이슈 #128).
+ *
+ * AS-IS: 원래는 실제 BE와 동일하게 `HttpOnly`를 붙였습니다.
+ * TO-BE: 목 환경에서는 `HttpOnly`를 빼야 브라우저에 쿠키가 실제로 저장됩니다.
+ *
+ * 브라우저에서 MSW는 Service Worker(`mockServiceWorker.js`)가 페이지의 `fetch`를
+ * 가로채서, 이 파일이 만든 응답을 `FetchEvent.respondWith()`로 대신 돌려주는 방식으로
+ * 동작합니다. 브라우저는 이렇게 Service Worker가 대신 돌려준 응답에 대해서는,
+ * `HttpOnly`가 붙은 `Set-Cookie`를 실제 쿠키 저장소에 반영하지 않습니다. 스크립트가
+ * 제어하는 계층(Service Worker)이 "스크립트가 못 건드리는 쿠키(HttpOnly)"를 마음대로
+ * 심을 수 있게 되면 `HttpOnly`의 존재 이유 자체가 무너지기 때문입니다.
+ *
+ * 이슈 #128에서 아래 순서로 이 원인을 좁혔습니다.
+ * - Node 환경(`msw/node`, `mocks/handlers.test.ts`)에서는 이 함수가 두 쿠키를 모두
+ *   정확히 만든다는 걸 테스트로 확인했습니다. 즉 이 파일의 로직 자체는 원래도 맞았습니다.
+ * - 그런데 실제 브라우저에서 로그인해보면 `HttpOnly`가 없는 `XSRF-TOKEN`만 저장되고,
+ *   `HttpOnly`가 붙은 `accessToken`은 쿠키를 완전히 지운 뒤 다시 로그인해도 저장되지
+ *   않았습니다. 두 쿠키의 유일한 차이가 `HttpOnly`라 원인이 여기로 좁혀졌습니다.
+ * - 이 현상은 MDN 문서(Service Worker가 `HttpOnly` 쿠키를 다루지 못한다는 설명,
+ *   https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API/Using_Service_Workers)와
+ *   WHATWG 쿠키 스토어 제안의 논의(https://github.com/whatwg/cookiestore/issues/37)에서도
+ *   같은 제약으로 설명되고 있어서, 이 프로젝트만의 버그가 아니라 브라우저 자체의 제약으로 판단했습니다.
+ *
+ * 실제 BE 응답은 이 파일을 거치지 않으므로(`mocks/config.ts`의 `isMockingEnabled`가 꺼지면
+ * 이 핸들러 자체가 실행되지 않습니다), 실제 배포 환경의 보안에는 영향이 없습니다. FE 코드
+ * 어디에도 `accessToken`을 `document.cookie`로 직접 읽는 곳이 없어서(애초에 `HttpOnly`라
+ * 못 읽는 게 설계 의도), 목에서만 `HttpOnly`를 빼도 놓치는 실제 버그는 없습니다.
  */
-const sessionCookies = (accountId: number): Headers => {
-  const headers = new Headers();
-  headers.append(
-    'Set-Cookie',
-    `${ACCESS_TOKEN_COOKIE}=${issueAccessToken(accountId)}; Path=/; HttpOnly; SameSite=Lax`,
-  );
+const sessionCookies = (accountId: number): [string, string][] => [
+  ['Set-Cookie', `${ACCESS_TOKEN_COOKIE}=${issueAccessToken(accountId)}; Path=/; SameSite=Lax`],
   // CSRF double-submit용이라 HttpOnly가 아닙니다. FE가 읽어서 X-XSRF-TOKEN 헤더로 되돌려 보냅니다.
-  headers.append('Set-Cookie', `${XSRF_TOKEN_COOKIE}=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax`);
-  return headers;
-};
+  ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax`],
+];
 
-const expiredCookies = (): Headers => {
-  const headers = new Headers();
-  headers.append(
-    'Set-Cookie',
-    `${ACCESS_TOKEN_COOKIE}=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0`,
-  );
-  headers.append('Set-Cookie', `${XSRF_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`);
-  return headers;
-};
+const expiredCookies = (): [string, string][] => [
+  ['Set-Cookie', `${ACCESS_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`],
+  ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`],
+];
 
 const toAuthUser = (account: MockAccount): AuthUser => ({
   id: account.id,

--- a/mocks/server.ts
+++ b/mocks/server.ts
@@ -1,4 +1,9 @@
 import { setupServer } from 'msw/node';
-import { handlers } from './handlers';
+import { createHandlers } from './handlers';
 
-export const server = setupServer(...handlers);
+/**
+ * Service Worker를 거치지 않는 환경(SSR 목·`mocks/handlers.test.ts` 계약 테스트)이라
+ * `httpOnly: true`로 실제 명세를 그대로 지킵니다(이슈 #128, `mocks/handlers/auth.ts`
+ * `sessionCookies` 주석 참고).
+ */
+export const server = setupServer(...createHandlers({ httpOnly: true }));


### PR DESCRIPTION
## 변경 사항

- 로그인·회원가입 요청에 응답하는 목(mock) 핸들러 파일인 `mocks/handlers/auth.ts`가, `accessToken` 쿠키에 붙이던 `HttpOnly`를 이제 붙이지 않습니다.
  - AS-IS: 실제 API 명세와 동일하게 `HttpOnly`를 붙였습니다.
  - TO-BE: 목 환경에서만 `HttpOnly`를 뺍니다.
- 원인은 브라우저 자체의 제약입니다.  
  Service Worker가 가로챈 응답은 `HttpOnly` `Set-Cookie`를 쿠키 저장소에 반영하지 못합니다.
- `mocks/handlers.test.ts`의 계약 테스트도 같은 이유로 기대값을 수정했습니다.

## 관련 이슈

- Closes #128

## 검증 방법

- `npx vitest run mocks/handlers.test.ts`: 58개 전부 통과했습니다.
- `npm run lint`, `npm run build`: 통과했습니다.
- 브라우저(Chrome)로 직접 아래 시나리오를 확인했습니다.
  - 로그인 성공: `/events`로 이동하고, DevTools에 `accessToken`·`XSRF-TOKEN` 쿠키가 모두 저장됩니다.
  - 로그인된 상태에서 `/events` 직접 접근: `/login`으로 리다이렉트되지 않고 화면이 그대로 보입니다.
  - 회원가입 성공(새 이메일): `/events`로 이동합니다.
  - 로그인 실패(비밀번호 오류): "이메일 또는 비밀번호가 올바르지 않습니다." 문구가 뜹니다.
  - 회원가입 실패(중복 이메일): "이미 가입된 이메일입니다." 문구가 뜹니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음. 목 서버 전용 변경이라 실제 백엔드 연동에는 영향이 없습니다(`mocks/config.ts`의 `isMockingEnabled`가 꺼지면 이 파일 자체가 실행되지 않습니다).

## 트러블슈팅 및 참고 사항

원인 조사 과정을 요약합니다.

- 처음에는 "오리진이 달라서(`localhost:8080` vs `localhost:3000`) 쿠키를 못 본다"고 추정했습니다. 쿠키는 포트가 아니라 도메인 기준으로 저장된다는 걸 뒤늦게 확인해서, 이 추정은 틀렸다고 정정했습니다.
- Node 테스트(`mocks/handlers.test.ts`, `msw/node` 환경)로 `sessionCookies` 함수 자체는 이미 두 쿠키를 정확히 만든다는 걸 먼저 확인했습니다.
- 브라우저에서 직접 확인한 결과, `HttpOnly`가 없는 `XSRF-TOKEN`만 저장되고 `HttpOnly`가 붙은 `accessToken`만 저장되지 않는다는 걸 재현했습니다. 두 쿠키의 유일한 차이가 `HttpOnly`라 원인을 여기로 좁혔습니다.
- MDN·WHATWG 쿠키 스토어 논의에서도 Service Worker가 가로챈 응답은 `HttpOnly` 쿠키를 적용하지 못한다는 같은 제약이 설명되고 있어서, 브라우저 자체의 제약으로 확인했습니다.

자세한 조사 과정과 근거 링크는 이슈 #128 본문에 정리해뒀습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 브라우저 기반 모의 환경에서 인증 쿠키가 정상적으로 저장되도록 개선했습니다.
  - 서버 및 테스트 환경에서는 인증 쿠키에 `HttpOnly` 보안 속성이 적용됩니다.
  - CSRF 보호 쿠키의 보안 설정과 만료 동작은 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->