### PR TITLE
fix(dashboard): 모더레이션 큐 토글 문구 길이를 맞춰 버튼 밀림 제거

### DIFF
--- a/components/moderation/ModerationQueue.tsx
+++ b/components/moderation/ModerationQueue.tsx
@@ -68,13 +68,18 @@ const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: Moderatio
                 content={feedback.text}
                 actions={
                   <>
+                    {/*
+                     * 두 문구의 글자 수를 맞춰뒀습니다. 「숨김 해제」처럼 길이가 다르면 숨긴 줄만
+                     * 버튼이 넓어져서 옆의 `삭제`가 줄마다 다른 자리에 놓입니다. 눌러야 할 버튼이
+                     * 행마다 움직이면 연달아 처리할 때 잘못 누릅니다.
+                     */}
                     <Button
                       variant="secondary"
                       size="sm"
                       disabled={isPending}
                       onClick={() => actions.toggleHidden(feedback)}
                     >
-                      {isHidden ? '숨김 해제' : '숨기기'}
+                      {isHidden ? '보이기' : '숨기기'}
                     </Button>
                     <Button
                       variant="danger"


### PR DESCRIPTION
## 변경 사항

모더레이션 큐에서 소감을 숨기면 그 줄의 `삭제` 버튼만 오른쪽으로 밀리던 문제를 고쳤습니다.

```
▣ 독성 의심                      ▣ 독성 의심
  [숨기기] [삭제]                  [숨기기] [삭제]

▣ 독성 의심 · 숨김        →      ▣ 독성 의심 · 숨김
  [숨김 해제] [삭제]  ← 밀림       [보이기]  [삭제]  ← 정렬됨
```

토글 버튼 문구가 `숨기기`(3자) ↔ `숨김 해제`(공백 포함 5자)로 길이가 달랐고, `Button`은 너비가 Hug(내용 크기)라 같은 flex 행의 `삭제`가 그만큼 밀렸습니다. `숨김 해제`를 `보이기`로 바꿔 양쪽을 3자로 맞췄습니다.

**왜 고쳐야 하는지** — 독성 소감을 연달아 처리하는 화면입니다. 한 건을 숨긴 직후 다음 건을 누르려는데 방금 처리한 줄의 배치가 바뀌어 있으면 마우스가 향하던 자리에 다른 버튼이 옵니다. 옆이 되돌릴 수 없는 `삭제`라 잘못 누르면 피해가 큽니다.

**`min-w-`를 쓰지 않은 이유** — 너비를 박으면 한글 문구 길이에 맞춘 숫자가 코드에 남고, `components/ui/README.md`가 `Button`의 너비를 Hug로 규정합니다. API도 `hide`/`show` 한 쌍이라 `숨기기`/`보이기`가 그대로 대응됩니다.

**건드리지 않은 것** — `useModerationActions`의 토스트 문구(`숨김을 해제했어요`)는 버튼 이름이 아니라 동작 설명이라 그대로 뒀습니다. `app/dev/msw/page.tsx`의 같은 문구는 개발용 하네스라 범위 밖입니다.

## 관련 이슈

- Closes #133
- Refs #115

## 검증 방법

`npm run dev`(MSW 목 모드)로 `/events/ab3f9x/dashboard`에서 확인했습니다. 시드에 이미 숨긴 건이 하나 섞여 있어 두 상태가 한 화면에 같이 보입니다. lint·prettier는 커밋 훅(lint-staged)이 통과시켰습니다.

| 확인한 것 | 결과 |
| --- | --- |
| 큐에 보통/숨김 상태가 섞인 화면 | 세 줄 모두 `삭제` 버튼이 같은 x좌표에 놓임 |
| `숨기기` 클릭 | 문구가 `보이기`로 바뀌고 메타에 `· 숨김`이 붙음. `삭제` 위치 그대로 |
| 토글 동작 | 숨기기 ↔ 보이기가 기존과 동일하게 동작 |

> ℹ️ **PR #132가 머지되면 그냥 로그인하면 됩니다.** 그 전까지는 목 모드에서 로그인해도 `/events/*`에 못 들어갑니다(#128과 같은 원인으로 보임). 검증하려면 DevTools 콘솔에서 아래를 실행한 뒤 이동하세요. 자세한 배경은 #131에 적어뒀습니다.
>
> ```js
> document.cookie = 'accessToken=mock-access-token-1; Path=/; SameSite=Lax';
> document.cookie = 'XSRF-TOKEN=mock-xsrf-token; Path=/; SameSite=Lax';
> ```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음 (버튼 문구만 바뀝니다)

## 트러블슈팅 및 참고 사항

원래 #131(QR·링크 복사·이벤트 종료)에서 같은 종류의 문제를 `링크 복사`/`복사 완료` 문구 길이를 맞춰 해결했는데, 그 과정에서 여기도 같은 문제가 있는 걸 발견했습니다. #131은 새 기능이고 이건 이미 머지된 #117 코드의 버그 수정이라 PR을 나눴습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 수동 확인 절차와 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 숨김 상태의 피드백 버튼 문구를 ‘숨김 해제’에서 ‘보이기’로 변경했습니다.
  * 일반 상태의 ‘숨기기’ 문구와 일관된 표현을 사용합니다.
  * 기존 동작과 비활성화 조건은 그대로 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
