### PR TITLE
docs(ui): 결정 기록을 날짜순으로 정렬

### DIFF
--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -825,7 +825,6 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 ## 결정 기록
 
 - 2026.08.11 (#106) — `Button`·`Chip`에 `cursor-pointer` 추가. 비활성 커서만 정하고 기본 커서를 안 정해서, `<button>`의 브라우저 기본값인 `default`가 그대로 나왔음. #54가 화면에서 `className="cursor-pointer"`로 덧대고 있었는데 `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없어 컴포넌트로 올림. 칩 아이콘은 새 prop 없이 `children`으로 넣기로 함 — `gap-2.5`가 이미 있어 간격이 붙고, Figma의 `icon` Boolean과 대응됨
-  \=======
 - 2026.08.11 (#88) — 버튼 모양의 링크를 위해 `buttonStyle(variant, size)`를 export. `<a>` 안에 `<button>`을 넣을 수 없어(HTML 콘텐츠 모델) 요소는 `next/link`로 두고 모양만 가져옴. `as` prop으로 폴리모픽하게 만드는 방법도 있었지만 제네릭 타입이 복잡해지고 `type="button"` 기본값이 `<a>`로 새는 것도 막아야 해서 미룸. 사용처가 서넛 넘어가면 `LinkButton` 래퍼를 두기로 함
 - 2026.08.11 (#96) — `Text/tertiary` 토큰 값을 `#888780`에서 `#77766f`로 교체. 흰 배경 3.61:1 → 4.56:1로 12px 텍스트 AA를 넘김. 위 항목들의 3.13:1·3.61:1은 변경 전 값 기준임
 - 2026.08.10 (#75) — Banner 테두리를 점선으로 수정. #70에서 실선으로 만든 건 Figma JSON 추출 결과에 선 종류가 담기지 않아 확인 없이 가정한 실수였음. 기능적 이유는 없고 시안 그대로임 — 다른 컴포넌트는 실선이라 Banner만 예외이고, 실수가 아니니 통일하지 말 것


### PR DESCRIPTION
## 변경 사항

`components/ui/README.md`의 결정 기록 항목 여섯 줄을 날짜순으로 옮겼습니다. **내용 변경은 없습니다.**

## 문제

새 항목을 항상 맨 위에 넣기로 해서 순서가 어긋나 있었습니다.

```text
08.11  #88 #96
08.10  ×4
08.05  모더레이션 버튼 높이     ← 08.10과 08.07 사이에 끼어 있었음
08.07  #66 #61×5 #59×3
08.06  #14×2 #16 #15×2 #21×3 #43×2 #34×3 … #23
08.07  ConfirmDialog ×4        ← 08.06 블록 아래로 내려가 있었음
08.06  Banner 닫기 버튼         ← 같음
```

`## ConfirmDialog` 섹션을 만들 때 파일 끝에 이어 붙인 흔적으로 보입니다. 나머지는 전부 내림차순으로 맞습니다.

## 왜 지금인지

#96 PR 본문에 이렇게 적고 미뤄뒀습니다.

> 결정 기록 정렬 — 날짜 순서가 엉켜 있지만 정렬하면 40줄이 diff에 잡혀 이 PR의 목적이 흐려집니다. 별도로 처리하겠습니다

**40줄이 아니라 여섯 줄이었습니다.** 확인 안 하고 어림으로 적었던 값입니다.

## 관련 이슈

없습니다. #96에서 넘어온 후속 작업이라 별도 이슈를 파지 않았습니다.

## 검증 방법

```powershell
sls components\ui\README.md -Pattern "^- 2026" | % { $_.Line.Substring(2,10) }
```

날짜만 뽑아 보면 내림차순입니다.

```text
2026.08.11
2026.08.11
2026.08.10
2026.08.10
2026.08.10
2026.08.10
2026.08.07
...
2026.08.06
2026.08.05
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- 신규 토큰: 없음
- Breaking Change: 없음
- **문서만 변경** — 코드 변경 없음. 항목의 문구도 그대로입니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 이벤트 상태에 따라 제출 화면, 종료 안내, 세션 대기 화면이 구분되어 표시됩니다.
  - 종료된 이벤트에 공개 리포트가 있으면 결과 페이지로 이동할 수 있습니다.
  - 리포트가 없는 경우 적절한 빈 상태 안내가 제공됩니다.

- **개선**
  - 존재하지 않는 이벤트 페이지의 안내 화면이 카드형 레이아웃으로 개선되었습니다.
  - 빈 상태 화면의 정렬과 가독성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->