### PR TITLE
fix(dashboard): 본문 없는 GENERATED 리포트의 안내문 분리

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -315,7 +315,11 @@ const DashboardView = () => {
   const isReportGenerating = generateReportMutation.isPending || report?.status === 'GENERATING';
   const isReportGenerated = report?.status === 'GENERATED';
 
-  /* 본문은 `GENERATED`에서만 채워집니다(스키마상 그 전에는 전부 null입니다). */
+  /*
+   * 본문은 `GENERATED`에서만 채워집니다. 다만 `reportSchema`가 `status`와 `summaryText`를 묶지
+   * 않아서 `GENERATED`인데 본문이 비어 오는 응답도 검증을 통과합니다. 그 경우까지 아래 안내문이
+   * 갈라 받습니다.
+   */
   const summaryText = report?.status === 'GENERATED' ? report.summaryText : null;
 
   /* 상태를 모르는 동안은 잠급니다. 이미 리포트가 있는 이벤트에서 눌리면 REPORT_ALREADY_EXISTS만 받습니다. */
@@ -608,6 +612,11 @@ const DashboardView = () => {
            * 카드 아래 한 줄이 상태에 따라 다른 일을 합니다. 생성 전에는 왜 눌러야 하는지 알리는
            * 안내문이고, 끝나면 요약 본문이 그 자리에 들어옵니다. 자리를 나누지 않는 이유는
            * 안내문이 요약이 없을 때만 필요한 문장이라서입니다.
+           *
+           * 생성이 끝났는데 본문이 비어 있는 경우를 따로 받습니다. 여기서 "생성하시면…"으로
+           * 되돌리면 오른쪽 버튼은 이미 빠진 뒤라(`isReportGenerated`) 시키는 대로 할 수단이
+           * 없습니다. `GENERATING` 문구로 묶지 않는 것도 같은 이유입니다 — 폴링이 `GENERATED`에서
+           * 멈춰서(위 `refetchInterval`) 기다려도 아무것도 다시 오지 않습니다.
            */}
           <section
             className={`${CARD} flex-row items-start justify-between gap-4 bg-background-muted`}
@@ -623,7 +632,9 @@ const DashboardView = () => {
                 <p className="text-xs font-normal leading-4 text-text-tertiary">
                   {isReportGenerating
                     ? '요약을 만들고 있어요. 끝나면 여기에 올라와요'
-                    : '생성하시면 읽어보고 공개할 수 있어요'}
+                    : isReportGenerated
+                      ? '요약 본문을 받지 못했어요. 잠시 후 다시 열어봐 주세요'
+                      : '생성하시면 읽어보고 공개할 수 있어요'}
                 </p>
               )}
             </div>


### PR DESCRIPTION
## 변경 사항

- 리포트 카드의 빈 상태 문구를 `isReportGenerated`로 한 갈래 더 나눴습니다. `GENERATED`인데 `summaryText`가 `null`인 경우 "생성하시면 읽어보고 공개할 수 있어요" 대신 "요약 본문을 받지 못했어요. 잠시 후 다시 열어봐 주세요"가 나갑니다.

이 조합이 나오면 "생성 완료" 배지가 붙은 채로 생성을 권하는 안내문이 뜨는데, 생성 버튼은 `isReportGenerated` 조건으로 이미 숨겨진 뒤라 시키는 대로 할 수단이 없었습니다.

`GENERATING` 문구로 묶지 않은 이유는 폴링이 `GENERATED`에서 멈추기 때문입니다(`DashboardView.tsx`의 `refetchInterval`). "곧 올라와요"라고 적으면 아무것도 다시 받아오지 않는 채로 그 문구가 남습니다.

상태별로 이렇게 갈립니다.

| 상태 | 문구 | 생성 버튼 |
| --- | --- | --- |
| 리포트 없음(404) | 생성하시면 읽어보고 공개할 수 있어요 | 노출 |
| `FAILED` | 생성하시면 읽어보고 공개할 수 있어요 | 노출(재생성 가능) |
| `GENERATING` | 요약을 만들고 있어요. 끝나면 여기에 올라와요 | 숨김 |
| `GENERATED` + 본문 | 요약 본문 | 숨김 |
| `GENERATED` + `null` | **요약 본문을 받지 못했어요** | 숨김 |

`FAILED`가 기존대로 첫 번째 문구 + 버튼 노출을 유지해야 해서(목 기준 `FAILED`에서만 재생성 가능), `report === null`로 묶지 않고 `isReportGenerated`로 갈랐습니다.

## 관련 이슈

- Closes #142

## 검증 방법

- `npm run lint` → exit 0, 오류·경고 없음
- `npm run test` → Test Files 4 passed (4), Tests 88 passed (88), 8.51s

화면 확인은 하지 않았습니다. MSW 목이 `GENERATED`로 넘길 때 항상 본문을 채워서(`mocks/handlers/report.ts`) 이 분기를 목 모드에서 띄우려면 핸들러를 일부러 고장 내야 합니다. 나머지 네 갈래는 기존 동작 그대로입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

근본 원인은 `lib/schemas/api.ts`의 `reportSchema`가 `status`와 `summaryText`를 묶지 않는 데 있습니다. `{ status: "GENERATED", summaryText: null }`이 검증을 통과합니다. 스키마를 상태별 유니온으로 쪼개거나 `refine`으로 막는 방법을 검토했지만, 유니온은 `Report` 타입이 바뀌면서 목 핸들러의 변이 코드를 다시 써야 하고, `refine`은 응답 전체를 `INVALID_RESPONSE`로 죽여도 화면은 결국 "생성 전"으로 보입니다. 지금 문제는 막다른 화면이라, 화면에서 막는 쪽을 택했습니다.

실제 백엔드를 붙일 때 이 조합이 실제로 오는지 확인해보고, 온다면 스키마를 조이는 건 별도로 다루면 되겠습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * AI 리포트가 생성 완료 상태여도 본문이 비어 있는 경우, 생성 전 안내 대신 본문 누락 안내를 표시합니다.
  * 해당 상황에서는 재생성 버튼을 제공하지 않고 다시 접속하도록 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->