### PR TITLE
feat(dashboard): 세션 첫 시작과 재개의 버튼 문구 분리

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -83,6 +83,15 @@ const DashboardView = () => {
   const [isQrOpen, setIsQrOpen] = useState(false);
   const [isEndConfirmOpen, setIsEndConfirmOpen] = useState(false);
 
+  /*
+   * 이 화면에서 멈춘 세션입니다. 세션은 생성 시 `CLOSED`라(2026-08-07 명세) 상태만으로는 "아직
+   * 열지 않았다"와 "열었다가 멈췄다"를 가를 수 없는데, 버튼이 권하는 다음 행동은 그 둘이 다릅니다.
+   *
+   * `SessionView`에는 열린 적이 있는지 알려주는 필드가 없어서 화면이 직접 기억합니다. 새로고침하면
+   * 잊고 다른 기기에서 멈춘 것도 모릅니다 — 정확히 하려면 서버에 흔적이 필요합니다(#143).
+   */
+  const [pausedSessionIds, setPausedSessionIds] = useState<ReadonlySet<number>>(new Set());
+
   const { copy: copyLink, isFailed: isCopyFailed } = useCopyLink();
 
   /*
@@ -214,6 +223,13 @@ const DashboardView = () => {
       updateSession(eventCode, id, { status }),
     onSuccess: (session) => {
       queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      /* 다시 열면 지웁니다. 남겨두면 멈췄다 연 세션을 또 멈출 때가 아니라 처음 열 때부터 "다시"가 됩니다. */
+      setPausedSessionIds((previous) => {
+        const next = new Set(previous);
+        if (session.status === 'ACTIVE') next.delete(session.id);
+        else next.add(session.id);
+        return next;
+      });
       showToast(session.status === 'ACTIVE' ? '이제 소감을 받아요' : '소감 받기를 멈췄어요');
     },
   });
@@ -327,6 +343,10 @@ const DashboardView = () => {
   const selectedSession =
     sessionId === null ? null : (sessions.find((session) => session.id === sessionId) ?? null);
 
+  /* 같은 `CLOSED`라도 이 화면에서 멈춘 세션은 "다시", 아직 안 연 세션은 "처음"입니다. */
+  const isSelectedSessionPaused =
+    selectedSession !== null && pausedSessionIds.has(selectedSession.id);
+
   return (
     <div className="flex flex-col gap-4">
       <div className="flex flex-wrap items-start justify-between gap-3">
@@ -399,7 +419,11 @@ const DashboardView = () => {
           {event.status === 'LIVE' && selectedSession !== null && (
             <div className="flex items-center gap-2">
               <Badge tone={selectedSession.status === 'ACTIVE' ? 'positive' : 'neutral'}>
-                {selectedSession.status === 'ACTIVE' ? '소감 받는 중' : '소감 멈춤'}
+                {selectedSession.status === 'ACTIVE'
+                  ? '소감 받는 중'
+                  : isSelectedSessionPaused
+                    ? '소감 멈춤'
+                    : '시작 전'}
               </Badge>
               <Button
                 variant="secondary"
@@ -412,7 +436,11 @@ const DashboardView = () => {
                   })
                 }
               >
-                {selectedSession.status === 'ACTIVE' ? '멈추기' : '다시 받기'}
+                {selectedSession.status === 'ACTIVE'
+                  ? '멈추기'
+                  : isSelectedSessionPaused
+                    ? '다시 받기'
+                    : '소감 받기'}
               </Button>
             </div>
           )}


### PR DESCRIPTION
## 변경 사항

- 세션 토글의 배지·버튼 문구를 세 갈래로 나눴습니다. 한 번도 연 적 없는 세션에는 "시작 전 / 소감 받기", 이 화면에서 멈춘 세션에는 "소감 멈춤 / 다시 받기"가 나갑니다.

세션은 생성 시 `CLOSED`라(2026-08-07 명세, 발표가 시작될 때 주최자가 열어야 소감이 들어옴), 지금까지는 처음 여는 세션에도 "다시 받기"가 붙었습니다. 처음 시작하는 사람에게 "다시"는 틀린 안내입니다.

| 상태 | 배지 | 버튼 |
| --- | --- | --- |
| `CLOSED` + 기억 없음(첫 시작) | 시작 전 | 소감 받기 |
| `ACTIVE` | 소감 받는 중 | 멈추기 |
| `CLOSED` + 이 화면에서 멈춤 | 소감 멈춤 | 다시 받기 |

배지를 같이 고친 이유는, 버튼만 바꾸면 "소감 멈춤" 옆에 "소감 받기"가 서기 때문입니다.

## 관련 이슈

- Closes #143

## 검증 방법

- `npm run lint` → exit 0, 오류·경고 없음
- `npm run test` → Test Files 4 passed (4), Tests 88 passed (88), 2.83s

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**서버가 두 `CLOSED`를 구분해주지 않습니다.** `Session`/`SessionView`에 있는 필드는 `id`, `eventId`, `title`, `order`, `status`가 전부라(`lib/schemas/api.ts`), "아직 안 열림"과 "열었다 멈춤"이 같은 `CLOSED`로 옵니다. 그래서 이 화면에서 멈춘 세션 id를 컴포넌트가 `useState`로 기억합니다.

**한계:** 새로고침하면 기억이 사라져, 이전에 열었다 닫은 세션도 "소감 받기"로 보입니다. 다른 기기에서 멈춘 것도 모릅니다.

대안으로 "그 세션에 소감이 있는지"로 추론하는 방법을 검토했지만, 열어놨는데 아무도 쓰지 않은 세션을 멈추면 곧바로 "소감 받기"로 되돌아가서 원하는 동작이 그 자리에서 깨집니다. 정확히 하려면 서버에 `openedAt`(또는 `hasOpened`)이 필요한데 API 계약 변경이라 백엔드 담당자 확인이 먼저입니다. 필요하다고 판단되면 별도 이슈로 올리겠습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.