### PR TITLE
feat(dashboard): 리포트 공개 버튼 문구 정리

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -398,7 +398,7 @@ const DashboardView = () => {
                 disabled={setReportPublicMutation.isPending}
                 onClick={() => setReportPublicMutation.mutate(!isReportPublic)}
               >
-                {isReportPublic ? '비공개로 전환' : '공개로 전환'}
+                {isReportPublic ? '리포트 비공개' : '리포트 공개'}
               </Button>
             )}
             {event.status === 'LIVE' && (


### PR DESCRIPTION
## 변경 사항

- 대시보드 헤더의 리포트 공개 버튼 문구를 "공개로 전환" / "비공개로 전환"에서 **"리포트 공개" / "리포트 비공개"**로 바꿨습니다.

"전환"이 붙어 불친절했고, 무엇을 공개한다는 건지도 문구에 드러나지 않았습니다.

| 현재 리포트 상태 | 이전 | 변경 후 |
| --- | --- | --- |
| 비공개 (`isPublic: false`) | 공개로 전환 | 리포트 공개 |
| 공개 (`isPublic: true`) | 비공개로 전환 | 리포트 비공개 |

"누르면 일어날 일"을 적는 기준은 그대로 두고 표현만 줄였습니다. 버튼 위치(헤더 우측), 노출 조건(`isReportGenerated`), 동작, 성공 토스트 문구는 건드리지 않았습니다.

## 관련 이슈

- Closes #148

## 검증 방법

- `npm run lint` → exit 0, 오류·경고 없음
- `npm run test` → Test Files 4 passed (4), Tests 88 passed (88), 7.45s

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.