### PR TITLE
feat(dashboard): 헤더에 요약 생성 버튼 추가

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -376,6 +376,24 @@ const DashboardView = () => {
          */}
         <div className="flex flex-col items-end gap-2">
           <div className="flex items-center gap-2">
+            {event.status === 'ENDED' && (
+              <div className="flex shrink-0 items-center gap-2">
+                {isReportGenerating && <Badge tone="neutral">생성 중</Badge>}
+                {isReportGenerated && <Badge tone="positive">생성 완료</Badge>}
+
+                {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
+                {!isReportGenerated && (
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    disabled={event.status !== 'ENDED' || isReportUnknown || isReportGenerating}
+                    onClick={() => generateReportMutation.mutate()}
+                  >
+                    요약 생성
+                  </Button>
+                )}
+              </div>
+            )}
             {event.status === 'LIVE' && (
               <>
                 <Button variant="secondary" size="sm" onClick={() => setIsQrOpen(true)}>


### PR DESCRIPTION
## 변경 사항

- 대시보드 헤더 우측에 "요약 생성" 버튼과 리포트 상태 배지("생성 중" / "생성 완료")를 추가했습니다.

요약 생성 버튼이 화면 최하단 리포트 카드에만 있어서, 이벤트가 끝난 뒤 누르려면 대시보드를 끝까지 내려야 했습니다. 이슈 방침대로 **기존 버튼은 그대로 두고** 위쪽에 하나 더 두는 방식입니다.

`event.status === "ENDED"`에서만 내놓습니다. 생성 자체가 `ENDED`에서만 가능해서, 그 전에는 눌러봐야 `EVENT_NOT_ENDED`만 받습니다. 비활성 조건(`isReportUnknown`, `isReportGenerating`)과 `isReportGenerated`일 때 버튼이 빠지는 동작은 아래 카드의 버튼과 같습니다.

헤더 버튼은 `variant="secondary"`, `size="sm"`입니다. 옆에 선 QR·링크 복사·이벤트 종료와 같은 급으로 보이게 맞췄습니다(카드 쪽은 그 화면의 주 조치라 `primary` 그대로).
<img width="946" height="212" alt="스크린샷 2026-08-14 112801" src="https://github.com/user-attachments/assets/88c43b3c-094a-4257-b2dd-1d049391d1e1" />
<img width="952" height="262" alt="스크린샷 2026-08-14 112807" src="https://github.com/user-attachments/assets/fba7f1dc-0d42-45da-a8d0-77c5ef60f01e" />
<img width="939" height="220" alt="스크린샷 2026-08-14 112813" src="https://github.com/user-attachments/assets/e90e835f-83cd-435e-9ec1-aaa61ee0744a" />
<img width="940" height="301" alt="스크린샷 2026-08-14 112817" src="https://github.com/user-attachments/assets/dc5d0c80-4d6f-4fa5-a967-bd5ea433cd8e" />


## 관련 이슈

- Closes #153

## 검증 방법

- `npm run lint` → exit 0, 오류·경고 없음
- `npm run test` → Test Files 4 passed (4), Tests 88 passed (88), 2.41s

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

같은 조치를 두 자리에 두는 만큼 상태 표시도 두 곳에서 같이 움직입니다. 배지·비활성 조건이 한쪽만 바뀌면 화면이 서로 다른 말을 하게 되므로, 이후 생성 흐름을 손댈 때는 두 자리를 함께 봐야 합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.