### PR TITLE
feat(feedback): 독성 소감을 제출 시점부터 비공개로 저장

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -305,13 +305,20 @@ const DashboardView = () => {
   /*
    * 숨긴 건은 집계와 피드에서 뺍니다. 목록을 `includeHidden=true`로 받는 건 모더레이션
    * 큐가 이미 숨긴 건도 보여줘야 해서지, 숫자에 넣으려는 게 아닙니다.
+   * 독성 건수만 예외입니다(아래 참고).
    */
   const visible = items.filter((feedback) => feedback.status === 'VISIBLE');
 
   const { positive, neutral, negative, unclassified, positiveRate } = summarizeSentiments(visible);
 
+  /*
+   * 독성 건수만 `visible`이 아니라 전체를 셉니다. 독성 소감은 제출 시점에
+   * 이미 HIDDEN으로 저장되므로 `visible`에는 한 건도 남지 않습니다.
+   * 이건 감정 집계가 아니라 모더레이션 지표라서, 숨겼어도 몇 건 들어왔는지는
+   * 주최자에게 보여야 합니다. `visible` 기준으로 되돌리지 마세요.
+   */
   const toxicItems = items.filter((feedback) => feedback.toxic);
-  const toxicCount = visible.filter((feedback) => feedback.toxic).length;
+  const toxicCount = toxicItems.length;
 
   const trend = buildTrend(visible);
   const keywords = countKeywords(visible);

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -744,6 +744,46 @@ describe('소감 제출', () => {
     expect(body).not.toHaveProperty('toxic');
   });
 
+  /*
+   * 독성 건수만 `visible`이 아니라 전체를 셉니다. 독성 소감은 제출 시점에
+   * 이미 HIDDEN으로 저장되므로 `visible`에는 한 건도 남지 않습니다.
+   * 이건 감정 집계가 아니라 모더레이션 지표라서, 숨겼어도 몇 건 들어왔는지는
+   * 주최자에게 보여야 합니다. `visible` 기준으로 되돌리지 마세요.
+   */
+  it('독성으로 태깅된 소감은 HIDDEN으로 저장되어 공개 스냅샷에 안 나온다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/feedbacks`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-Client-Id': 'client-toxic' },
+      body: JSON.stringify({
+        sessionId: 101,
+        text: '시발 뭐라는 건지 하나도 모르겠네',
+        sentiment: 'NEG',
+        toxic: true,
+        keywords: [],
+        taggerVersion: 'koelectra-small-v3-nsmc-q8+tau-1.2',
+      }),
+    });
+
+    expect(response.status).toBe(201);
+    const { id } = (await response.json()) as { id: number };
+
+    // 저장 상태는 관리자 큐로만 확인합니다. 공개 응답에는 status가 없습니다.
+    const queue = (await (
+      await call(`/admin/feedbacks?eventCode=${LIVE_EVENT_CODE}&includeHidden=true`, {
+        headers: AUTH_HEADERS,
+      })
+    ).json()) as { items: { id: number; status: string }[] };
+
+    expect(queue.items.find((item) => item.id === id)?.status).toBe('HIDDEN');
+
+    // 집계와 최근 피드에서 빠져야 실시간 지표에 욕설이 안 뜹니다.
+    const snapshot = (await (
+      await call(`/events/${LIVE_EVENT_CODE}/feedbacks?sessionId=101`)
+    ).json()) as { recentFeedbacks: { id: number }[] };
+
+    expect(snapshot.recentFeedbacks.some((item) => item.id === id)).toBe(false);
+  });
+
   it('같은 클라이언트가 분당 4번째로 제출하면 RATE_LIMIT_EXCEEDED를 준다', async () => {
     for (let attempt = 0; attempt < 3; attempt += 1) {
       expect((await submit('client-b')).status).toBe(201);

--- a/mocks/handlers/feedback.ts
+++ b/mocks/handlers/feedback.ts
@@ -50,7 +50,7 @@ export const feedbackHandlers = [
       toxic: body.data.toxic,
       keywords: body.data.keywords,
       taggerVersion: body.data.taggerVersion,
-      status: 'VISIBLE',
+      status: body.data.toxic ? 'HIDDEN' : 'VISIBLE',
       createdAt: new Date().toISOString(),
     };
     db.feedbacks.push(feedback);


### PR DESCRIPTION
## 변경 사항

- 독성으로 태깅된 소감을 **제출 시점부터 `HIDDEN`으로 저장**합니다. 지금까지는 `toxic` 여부와 무관하게 `VISIBLE`로 들어가서, 주최자가 모더레이션 큐에서 수동으로 숨기기 전까지 **욕설이 워드클라우드와 최근 피드에 그대로 노출**됐습니다.
- `HIDDEN`은 이미 집계와 피드에서 빠지므로(`mocks/data/store.ts`) 새 상태를 추가하지 않고 기존 값을 그대로 썼습니다.
- **독성 건수는 계속 셉니다.** 가리는 것은 소감 텍스트와 감정 집계이지 독성 발생 건수가 아닙니다. 주최자는 몇 건이 들어왔는지 알아야 대응할 수 있습니다.
- 참가자에게는 숨김 사실을 알리지 않습니다. 제출 응답은 공개 뷰라 `status`가 없어서 현재 동작 그대로입니다. 알려주면 우회를 유도합니다.

```ts
// mocks/handlers/feedback.ts
- status: 'VISIBLE',
+ status: body.data.toxic ? 'HIDDEN' : 'VISIBLE',
```

## ⚠️ 축 3 담당 파일을 한 줄 건드렸습니다

`components/dashboard/DashboardView.tsx`는 대시보드(축 3) 담당 파일인데, **이 PR 없이는 고칠 수 없고 이 PR과 함께 고치지 않으면 화면이 거짓말을 합니다.**

```tsx
- const toxicCount = visible.filter((feedback) => feedback.toxic).length;
+ const toxicCount = toxicItems.length;
```

기존 계산은 `VISIBLE` 목록에서 `toxic`을 셌습니다. 독성이 제출 즉시 `HIDDEN`이 되면 **`visible` 안에 `toxic`인 건이 한 건도 남지 않습니다.**

```tsx
<Stat label="독성 플래그" value={`${toxicCount}`} tone="toxic" />   // → 0으로 고정
<ModerationQueue items={toxicItems} waitingCount={toxicCount} />     // → 목록엔 N건, 배지엔 "0건 대기"
```

기존 계산이 맞았던 건 `toxic=true`도 `VISIBLE`로 들어왔기 때문입니다. 전제가 바뀌어서 같이 고쳤습니다.

**변경은 이 한 줄과 주석 2곳이 전부입니다.** 렌더링·레이아웃·다른 지표는 건드리지 않았습니다. 대시보드 담당자분께서 이 부분만 확인해주시면 좋겠습니다.

`visible` 바로 아래에서 혼자 `items`를 쓰는 모양이라, 왜 예외인지 주석을 남겼습니다. 이유가 없으면 나중에 실수로 보고 되돌릴 자리라서요.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| `334a622` | feat(feedback): 독성 소감을 제출 시점부터 비공개로 저장 | 저장 시 `status` 결정 + 그로 인해 깨지는 대시보드 지표 동시 수정 |
| `be4703f` | test(mocks): 독성 소감 자동 숨김 계약 테스트 추가 | 규칙이 삼항 연산자 한 줄뿐이라 되돌려도 빌드·린트가 통과함 |

## 관련 이슈

- Closes #150

## 검증 방법

### 자동

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 6.1s / ✓ Finished TypeScript in 6.1s
npm run test    ✓ 4 files, 89 tests passed (805ms)   ← 88 → 89
```

추가한 테스트가 확인하는 것:

1. `toxic: true`로 제출하면 `201`로 저장된다
2. 관리자 큐(`includeHidden=true`)에서 해당 건의 `status`가 `HIDDEN`이다
3. 공개 스냅샷(`/events/:code/feedbacks?sessionId=101`)의 `recentFeedbacks`에 안 나온다

저장 상태를 공개 응답으로는 검증할 수 없어 큐를 거쳤습니다. 공개 뷰에는 `status`가 의도적으로 빠져 있습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **MSW 핸들러 동작이 바뀝니다.** 서버 컴포넌트는 `instrumentation.ts`의 `msw/node`를 타므로, pull 후 **dev 서버 재시작**이 필요합니다.

## 트러블슈팅 및 참고 사항

### seed 데이터는 건드리지 않았습니다

처음에는 `mocks/data/seed.ts`의 `toxic: true` 4건도 `HIDDEN`으로 맞추려 했는데, 텍스트를 확인하고 그만뒀습니다.

```
'준비를 하나도 안 한 게 티가 나네 시간 아깝다'
'이딴 걸 토론이라고 앉아서 듣고 있는 내가 한심하다'
'앞에 나온 사람 얼굴부터가 마음에 안 드는데'
'개나 소나 발표하는구나 진짜'
```

**네 건 모두 우리 욕설 사전에 안 걸립니다.** `개새`는 사전에 있지만 `개나`는 다릅니다.

즉 `toxic`이 두 가지 뜻으로 쓰이고 있습니다 — seed는 **모더레이션 대상 전반**(인신공격·비하 포함), 클라이언트 태거는 **욕설 사전 매칭**입니다. seed를 손대는 건 이 정의를 확정한 뒤에 하는 게 맞다고 판단했습니다.

별도 이슈로 논의 중입니다. 이 PR의 동작 규칙(`toxic → HIDDEN`) 자체는 어느 쪽으로 정해지든 유효합니다.

### 서버 재검증은 이 PR 범위 밖입니다

`toxic`은 브라우저 Web Worker가 판정해서 요청 body에 담아 보내는 값입니다. **워커를 우회해 `toxic: false`로 보내면 그대로 통과합니다.** 이번 변경으로 막히지 않습니다.

### 백엔드 담당자께

API 스키마 변경은 아닙니다. **저장 시 `status` 기본값을 결정하는 로직**만 바뀝니다. MSW 목이 계약의 단일 소스이므로 실제 Spring 구현도 같은 규칙을 따라야 합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
