### PR TITLE
chore(config): 삭제된 EventsLayout을 가리키는 주석을 proxy.ts로 정정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,8 +20,8 @@ const nextConfig: NextConfig = {
    * 브라우저가 백엔드로 직접 요청을 보내는 대신 이 Next.js 서버를 거치게 하는 리버스 프록시입니다.
    *
    * 백엔드(Render)와 프론트(Vercel)가 서로 다른 도메인이라, 브라우저가 백엔드에 직접 요청을 보내면
-   * accessToken·XSRF-TOKEN 쿠키가 백엔드 도메인에 묶여서 프론트 서버(`app/(host)/events/layout.tsx`
-   * 등)나 `document.cookie`(CSRF 토큰을 헤더에 실을 때 씀)로 읽을 수 없습니다(이슈 #139·#140).
+   * accessToken·XSRF-TOKEN 쿠키가 백엔드 도메인에 묶여서 프론트 서버(`proxy.ts` 등)나
+   * `document.cookie`(CSRF 토큰을 헤더에 실을 때 씀)로 읽을 수 없습니다(이슈 #139·#140).
    * 이 프록시를 거치면 브라우저는 항상 프론트 자신에게만 요청을 보내고, 백엔드가 내려주는 쿠키도
    * 프론트 자신의 도메인 것으로 저장됩니다.
    *


### PR DESCRIPTION
## 변경 사항

- `next.config.ts`의 리버스 프록시 설명 주석에서 이미 삭제된 `app/(host)/events/layout.tsx`(EventsLayout) 언급을 실제로 쿠키를 못 읽던 대상인 `proxy.ts`로 정정했습니다.

## 관련 이슈

- Closes #156

## 검증 방법

- `npm run lint` 통과 확인
- 기능 변경이 없는 주석 정정이라 별도 화면 검증은 필요 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- `app/(host)/events/layout.tsx`(EventsLayout)는 PR #141에서 라우트 가드를 `proxy.ts` 서버 미들웨어 방식으로 되돌리며 삭제됐고, 그때 이 주석은 정정하지 않고 이슈 #156으로 남겨뒀습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
