### PR TITLE
refactor(layout): Header를 app/(host)/layout.tsx 공통 레이아웃으로 이동

### DIFF
--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -4,12 +4,10 @@ import { useQuery } from '@tanstack/react-query';
 
 import { fetchMyEvents } from '@/lib/api/endpoints';
 import EventCard from '@/components/events/EventCard';
-import useAuth from '@/hooks/useAuth';
 import { useMemo, useState } from 'react';
 import EventStatusFilterTabs, {
   EventStatusFilter,
 } from '@/components/events/EventStatusFilterTabs';
-import { Header } from '@/components/layout/Header';
 import Link from 'next/link';
 import { Banner } from '@/components/ui/Banner';
 import EventListEmptyState from '@/components/events/EventListEmptyState';
@@ -19,8 +17,6 @@ const EventsListPage = () => {
   const [selectedTab, setSelectedTab] = useState<EventStatusFilter>('ALL');
 
   // API: GET/POST /events. "새 이벤트 만들기" 버튼은 /events/new로 이동합니다.
-  const { user, logout, isLoading: isAuthLoading } = useAuth();
-
   const myEvents = useQuery({
     queryKey: ['events', 'my'],
     queryFn: fetchMyEvents,
@@ -45,41 +41,38 @@ const EventsListPage = () => {
   }
 
   return (
-    <>
-      <Header email={user?.email ?? ''} onLogout={logout} isEmailLoading={isAuthLoading} />
-      <div className="flex flex-col gap-6 px-20 py-8">
-        <div className="flex items-center justify-between gap-6">
-          <p className="text-xl font-semibold text-text-primary">내 이벤트</p>
-          <Link href="/events/new" className={buttonStyle('primary', 'md')}>
-            + 새 이벤트
-          </Link>
-        </div>
-        {myEvents.isPending && <p>불러오는 중...</p>}
-        {myEvents.isError && <Banner type="negative">이벤트 목록을 불러오지 못했습니다.</Banner>}
-        {isEventsEmpty && (
-          <EventListEmptyState
-            title="아직 만든 이벤트가 없어요"
-            description="첫 이벤트를 만들고 참가자에게 링크를 공유해보세요"
-          />
-        )}
-        {myEvents.isSuccess && !isEventsEmpty && (
-          <EventStatusFilterTabs selectedStatus={selectedTab} onChange={setSelectedTab} />
-        )}
-        {isFilterEmpty && (
-          <EventListEmptyState
-            title="이 상태의 이벤트가 없어요"
-            description="다른 탭을 선택해보세요"
-          />
-        )}
-        {hasEvents && (
-          <div className="flex flex-col gap-3">
-            {filteredEvents.map((event) => (
-              <EventCard key={event.id} event={event} />
-            ))}
-          </div>
-        )}
+    <div className="flex flex-col gap-6 px-20 py-8">
+      <div className="flex items-center justify-between gap-6">
+        <p className="text-xl font-semibold text-text-primary">내 이벤트</p>
+        <Link href="/events/new" className={buttonStyle('primary', 'md')}>
+          + 새 이벤트
+        </Link>
       </div>
-    </>
+      {myEvents.isPending && <p>불러오는 중...</p>}
+      {myEvents.isError && <Banner type="negative">이벤트 목록을 불러오지 못했습니다.</Banner>}
+      {isEventsEmpty && (
+        <EventListEmptyState
+          title="아직 만든 이벤트가 없어요"
+          description="첫 이벤트를 만들고 참가자에게 링크를 공유해보세요"
+        />
+      )}
+      {myEvents.isSuccess && !isEventsEmpty && (
+        <EventStatusFilterTabs selectedStatus={selectedTab} onChange={setSelectedTab} />
+      )}
+      {isFilterEmpty && (
+        <EventListEmptyState
+          title="이 상태의 이벤트가 없어요"
+          description="다른 탭을 선택해보세요"
+        />
+      )}
+      {hasEvents && (
+        <div className="flex flex-col gap-3">
+          {filteredEvents.map((event) => (
+            <EventCard key={event.id} event={event} />
+          ))}
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/app/(host)/layout.tsx
+++ b/app/(host)/layout.tsx
@@ -1,0 +1,16 @@
+import { HostHeader } from '@/components/layout/HostHeader';
+
+interface HostLayoutProps {
+  children: React.ReactNode;
+}
+
+const HostLayout = ({ children }: HostLayoutProps) => {
+  return (
+    <>
+      <HostHeader />
+      {children}
+    </>
+  );
+};
+
+export default HostLayout;

--- a/components/layout/HostHeader.tsx
+++ b/components/layout/HostHeader.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { Header } from '@/components/layout/Header';
+import useAuth from '@/hooks/useAuth';
+
+/** 로그인 전 화면입니다. 세션이 없어 email·onLogout을 보여줄 수 없으므로 Header를 숨깁니다. */
+const HEADER_HIDDEN_PATHS = ['/login', '/signup'];
+
+/**
+ * `SessionHeader`를 pathname에 따라 마운트할지 결정합니다.
+ *
+ * `/login`·`/signup`에서는 `SessionHeader`를 아예 마운트하지 않습니다. `useAuth()` 호출을
+ * `SessionHeader` 안에 둔 것도 이 때문입니다 — 여기서 `useAuth()`를 직접 부르면 훅은 조건 없이
+ * 항상 실행되므로, `/login`에서도 세션 확인 요청이 나가버립니다.
+ */
+const HostHeader = () => {
+  const pathname = usePathname();
+
+  if (HEADER_HIDDEN_PATHS.includes(pathname)) {
+    return null;
+  }
+
+  return <SessionHeader />;
+};
+
+const SessionHeader = () => {
+  const { user, logout, isLoading: isEmailLoading } = useAuth();
+
+  return <Header email={user?.email ?? ''} onLogout={logout} isEmailLoading={isEmailLoading} />;
+};
+
+export { HostHeader };

--- a/components/layout/README.md
+++ b/components/layout/README.md
@@ -47,7 +47,7 @@ Figma에는 `Header/Desktop`과 `Header/mobile` 두 개가 있지만 코드는 �
 
 ### 세션은 밖에서 넘깁니다
 
-`email`과 `onLogout`을 props로 받습니다. `hooks/useAuth.ts`를 직접 부르지 않습니다.
+`email`·`onLogout`·`isEmailLoading`을 props로 받습니다. `hooks/useAuth.ts`를 직접 부르지 않습니다.
 
 Header가 세션을 알면 이 컴포넌트만 따로 보기 어려워지고, 로그인하지 않은 상태를 그려볼 수도 없습니다.
 
@@ -57,20 +57,40 @@ Header가 세션을 알면 이 컴포넌트만 따로 보기 어려워지고, �
 
 **호출부도 클라이언트여야 합니다.** 서버 컴포넌트는 함수를 props로 넘길 수 없습니다. `app/(host)/layout.tsx`는 서버 컴포넌트이므로 사이에 얇은 래퍼를 하나 두세요.
 
+실제 래퍼는 `components/layout/HostHeader.tsx`입니다. `app/(host)/layout.tsx`가 이 컴포넌트를 렌더링합니다.
+
 ```tsx
 'use client';
 
+import { usePathname } from 'next/navigation';
+
 import { Header } from '@/components/layout/Header';
-import { useAuth } from '@/hooks/useAuth';
+import useAuth from '@/hooks/useAuth';
 
-export const HostHeader = () => {
-  const { user, logout } = useAuth();
+const HEADER_HIDDEN_PATHS = ['/login', '/signup'];
 
-  if (!user) return null;
+const HostHeader = () => {
+  const pathname = usePathname();
 
-  return <Header email={user.email} onLogout={logout} />;
+  if (HEADER_HIDDEN_PATHS.includes(pathname)) {
+    return null;
+  }
+
+  return <SessionHeader />;
 };
+
+const SessionHeader = () => {
+  const { user, logout, isLoading: isEmailLoading } = useAuth();
+
+  return <Header email={user?.email ?? ''} onLogout={logout} isEmailLoading={isEmailLoading} />;
+};
+
+export { HostHeader };
 ```
+
+`/login`·`/signup`도 `app/(host)` 밑에 있어서, 이 pathname 확인이 없으면 로그인하지 않은 사용자에게도 Header가 노출됩니다. 이 확인은 `Header`가 아니라 `HostHeader`가 맡습니다 — `Header`가 라우팅까지 알게 되면 세션과 마찬가지로 이 컴포넌트만 따로 보기 어려워지기 때문입니다.
+
+`useAuth()`는 `HostHeader`가 아니라 `SessionHeader` 안에서 부릅니다. 훅은 조건 없이 항상 실행되므로, `HostHeader`에서 직접 불렀다면 `/login`에서도 세션 확인 요청이 나가버립니다. `SessionHeader`를 따로 둬서, `/login`·`/signup`에서는 이 컴포넌트 자체가 마운트되지 않게 만들었습니다.
 
 `'use client'`만 붙이고 서버 레이아웃에서 바로 `<Header onLogout={...} />`를 쓰면 안 됩니다. 지시문은 Header가 클라이언트에서 실행된다는 뜻일 뿐, 서버가 함수를 건네줄 수 있게 해주지는 않습니다.
 
@@ -96,3 +116,4 @@ import { Header } from '@/components/layout/Header';
 - 2026.08.06 — Header를 클라이언트 컴포넌트로 둠. 토큰이 `localStorage`에 있어 로그아웃이 브라우저 동작이라, 쿠키를 전제하는 Server Action을 지금 도입할 수 없음. 저장 위치가 확정되면 `<form action>`으로 바꾸고 래퍼를 없앨 수 있음
 - 2026.08.10 (#69) — 저장 위치가 HttpOnly 쿠키로 확정됐지만 Header는 클라이언트로 유지. 쿠키가 API 도메인 소유라 Next 서버가 읽지도 만료시키지도 못해서, `<form action>` 전환은 여전히 불가능함
 - 2026.08.06 — 로그아웃을 밑줄로 표시. 색을 바꾸는 대신 밑줄을 쓰면 강조가 늘어나지 않고, 색을 못 보는 사용자에게도 전달됨. 대시보드의 `전체보기` 링크와 같은 규칙
+- 2026.08.14 (#158) — `HostHeader`를 실제 코드로 구현하고 `app/(host)/layout.tsx`에 연결. 기존에는 `EventsListPage` 하나에서만 `Header`를 직접 렌더링해서, `app/(host)` 밑에 화면이 늘어날 때마다 각자 세션을 다시 연결해야 했음. `HostHeader`에 pathname 확인도 같이 넣어 `/login`·`/signup`에서는 `Header`를 숨김


### PR DESCRIPTION
## 변경 사항

`Header`(`components/layout/Header.tsx`)를 `EventsListPage` 내부가 아니라 `app/(host)/layout.tsx` 공통 레이아웃에서 렌더링하도록 옮겼습니다.

- `app/(host)/layout.tsx`를 서버 컴포넌트로 새로 만들었습니다.
- `components/layout/HostHeader.tsx`를 새로 추가했습니다.
  `HostHeader`(pathname 확인)와 `SessionHeader`(`useAuth()` 호출) 두 컴포넌트로 나눠서, `/login`·`/signup`에서는 `SessionHeader` 자체가 마운트되지 않도록 했습니다.
  `Header`에는 세션·라우팅 로직을 넣지 않았습니다. `components/layout/README.md`가 이미 "`Header`는 세션을 몰라야 한다"는 원칙을 정해뒀기 때문입니다.
- `app/(host)/events/page.tsx`에서 `Header` 렌더링과 `useAuth()` 호출을 제거했습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #158

## 검증 방법

아래는 전부 이 PR을 반영한 뒤 기준입니다.

- `npx tsc --noEmit`·`npm run lint`를 실행해 모두 통과를 확인했습니다.
- `npm run build`는 이 PR과 무관한 기존 문제(`@huggingface/transformers` 모듈이 로컬에 설치되어 있지 않음, `dev` 브랜치에서도 동일하게 재현됨)로 끝까지 실행하지 못했습니다.

**정상적으로 동작하는 경우**

아래 네 가지를 직접 브라우저로 확인했습니다.

- 로그인 후 `/events`에서 `Header`(로고·이메일·로그아웃)가 기존과 동일하게 보입니다.
- 로그인 후 `/events/new`·`/events/[eventCode]`·`/events/[eventCode]/dashboard`에도 새로 `Header`가 나타납니다. 이 PR 전에는 `/events`에만 있었습니다.
- 로그인된 상태에서 `/login`·`/signup`에 직접 들어가도 `Header`가 보이지 않습니다.
- `/events`를 새로고침하면 `/auth/me` 응답을 기다리는 동안 이메일 자리에 스켈레톤이 보였다가, 응답 후 실제 이메일로 바뀝니다.

이 PR은 표시 위치를 옮기는 리팩터링이라 별도의 실패 시나리오는 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음. `Header`를 직접 렌더링하던 곳은 `EventsListPage` 하나뿐이었고, 그 자리를 공통 레이아웃으로 옮긴 것이라 다른 화면에는 영향이 없습니다.

## 트러블슈팅 및 참고 사항

작업 중 `/login`에 접속만 해도 `GET /auth/me` 요청이 나가는 현상을 발견했습니다.
조사해보니 `components/auth/LoginForm.tsx`가 이미 갖고 있던 별개 코드 때문이었습니다.
`LoginForm`이 `login` 함수만 필요해서 `useAuth()`를 불렀는데, `useAuth()` 내부는 호출하는 쪽이 무엇을 쓰든 `meQuery`(`GET /auth/me`)를 항상 같이 실행합니다.
이 코드는 `origin/dev`에도 이미 있던 것이라 이번 PR과는 무관합니다.

로컬 환경이 `NEXT_PUBLIC_API_MOCKING=disabled`라 이 요청이 MSW 목이 아니라 실제 배포 백엔드로 나갔고, 마침 그 시점에 500 응답을 받아 "로그인이 실패한 것 아니냐"는 오해로 이어졌습니다.
실제로 이메일·비밀번호를 입력해 로그인해보니 `/events`로 정상 이동하는 것을 확인했습니다.

이 PR은 페어 모드가 아니라 Claude가 직접 작성했습니다. 코드·동작을 직접 확인하는 과정이 필요합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
