### PR TITLE
fix(ui): 삭제 확인 다이얼로그의 삭제 버튼이 danger 색상이 아님

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -372,7 +372,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
             </Button>
             <Button
               type="button"
-              variant="primary"
+              variant="danger"
               disabled={isDeleting}
               onClick={() => removeEvent()}
             >
@@ -394,7 +394,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
             </Button>
             <Button
               type="button"
-              variant="primary"
+              variant="danger"
               disabled={isRemovingSession}
               onClick={() => deletingSessionId !== null && removeSession(deletingSessionId)}
             >


### PR DESCRIPTION
## 변경 사항

이벤트 삭제·세션 삭제 확인 다이얼로그의 "삭제" 버튼 색상을 시안대로 고쳤습니다.

- `components/events/EventForm.tsx`: 두 삭제 확인 버튼을 `variant="primary"`에서 `variant="danger"`로 바꿨습니다.

되돌릴 수 없는 삭제 동작인데 일반 강조색(`primary`, `#04728b` 청록색)을 쓰고 있었습니다.
`Button` 컴포넌트(`components/ui/Button.tsx`)의 `danger` variant(`#712b13`, 적갈색)가 첨부된 Figma 시안의 "삭제" 버튼 색과 일치하는 것을 확인했습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #172

## 검증 방법

- `npx tsc --noEmit`·`npm run lint`를 실행해 모두 통과를 확인했습니다.
- "이벤트 시작" 버튼(353행)은 이번 변경 대상이 아니라서 `variant="primary"`로 그대로 남아있는 것을 `grep`으로 확인했습니다.

**정상적으로 동작하는 경우**

이벤트 삭제·세션 삭제 확인 다이얼로그에서 "삭제" 버튼이 적갈색(`danger`)으로 보입니다.
이 변경은 색상만 바꾸는 것이라 별도의 실패 시나리오는 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
