### PR TITLE
fix(env): SSR에서 API 기본 주소를 절대 경로로 쓴다

### DIFF
--- a/lib/env.ts
+++ b/lib/env.ts
@@ -11,4 +11,8 @@
  * 환경변수)로 대신 전달합니다. 이 경로는 로컬(`npm run dev`)·Vercel 배포 양쪽에서 동일하게
  * 동작합니다.
  */
-export const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? '/api/proxy';
+const SERVER_API_BASE_URL = process.env.BACKEND_API_URL ?? 'http://localhost:8080/api/v1';
+
+export const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ??
+  (typeof window === 'undefined' ? SERVER_API_BASE_URL : '/api/proxy');


### PR DESCRIPTION
## 변경 사항

- `API_BASE_URL` 기본값이 상대 경로 `/api/proxy` 하나뿐이라 **서버에서 호출할 때 실패**했습니다. 브라우저에는 현재 주소라는 기준점이 있어서 해석되지만, 서버에는 없습니다.

```
TypeError: Failed to parse URL from /api/proxy/events/ab3f9x
code: 'ERR_INVALID_URL'
```

- SSR 페이지(`/e/[code]`, `/e/[code]/report` 등)가 이 경로를 탑니다. Vitest도 `environment: 'node'`라 같은 이유로 **66건이 깨져 있었습니다.**
- `.env.local`에 절대 주소를 넣어둔 사람만 통과해서, **로컬 설정에 따라 결과가 갈리는 상태**였습니다. `.env*`는 커밋되지 않으니까요.

실행 환경으로 갈랐습니다.

```ts
const SERVER_API_BASE_URL = process.env.BACKEND_API_URL ?? 'http://localhost:8080/api/v1';

export const API_BASE_URL =
  process.env.NEXT_PUBLIC_API_BASE_URL ??
  (typeof window === 'undefined' ? SERVER_API_BASE_URL : '/api/proxy');
```

| 실행 환경 | 주소 | 이유 |
|---|---|---|
| 브라우저 | `/api/proxy` | 프론트·백엔드 도메인이 달라 쿠키를 못 읽는 문제(#139·#140)를 피하려면 이 경로가 필요합니다 |
| 서버 | 백엔드 절대 주소 | 서버가 자기 자신의 프록시를 다시 부를 이유가 없고, 쿠키 도메인 문제도 서버에서는 헤더를 직접 실으므로 해당되지 않습니다 |

MSW 핸들러도 같은 상수로 경로를 등록하므로 목 서버 매칭은 그대로 동작합니다.

## 관련 이슈

- Closes #175

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 5.7s / ✓ Finished TypeScript in 5.1s
npm run test    ✓ 5 files, 95 tests passed (819ms)
```

**변경 전에는 `66 failed | 29 passed`였습니다.** 깨져 있던 건 `mocks/handlers.test.ts`와 `lib/api/endpoints.test.ts` 두 파일 전체입니다.

## 영향 범위

- 새 환경 변수: 없음 (기존 `BACKEND_API_URL`을 서버 쪽에서도 읽게 됐습니다)
- 의존성 추가: 없음
- Breaking Change: 없음
- 로컬에서 추가로 할 일: 없음. 오히려 `.env.local` 없이도 테스트가 통과합니다.

## ⚠️ 배포 환경 확인 부탁드립니다

```ts
process.env.BACKEND_API_URL ?? 'http://localhost:8080/api/v1'
```

Vercel에 `BACKEND_API_URL`이 설정돼 있지 않으면 **배포된 SSR이 조용히 `localhost:8080`을 호출합니다.** 에러도 안 나고 화면만 비어 보입니다.

`next.config.ts`의 `rewrites`가 이미 같은 변수를 쓰고 있어서 설정돼 있을 가능성이 크지만, 배포를 보시는 분이 한 번 확인해주시면 좋겠습니다.

기본값 없이 즉시 실패하게 만드는 방법도 있었는데, 로컬 개발이 번거로워져서 이번에는 기본값을 유지했습니다. 다르게 보시면 말씀해주세요.

## 트러블슈팅 및 참고 사항

원인을 처음에는 제 쪽 변경으로 의심했습니다. `lib/tagger/`에 테스트를 추가하던 중 66건이 한꺼번에 깨져서요.

실제로는 새로 추가한 파일은 통과했고, 깨진 두 파일은 공통적으로 `API_BASE_URL`로 `fetch`를 부르는 파일이었습니다. 상대 경로가 Node에서 해석되지 않는다는 점이 맞아떨어졌습니다.

SSR 쪽 진단은 팀 논의 중 나온 지적("SSR 페이지에서 프록시로 걸려서 에러나는 것 같다")을 따랐습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
