### PR TITLE
feat(event): 이벤트 시작 시 대시보드로 자동 이동

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -115,6 +115,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
       showToast('이벤트를 시작했어요');
+      router.push(`/events/${eventCode}/dashboard`);
     },
     onError: (error) => {
       if (error instanceof ApiError && error.code === 'INVALID_EVENT_STATE_TRANSITION') {


### PR DESCRIPTION
## 변경 사항

"이벤트 시작" 버튼을 눌러 성공하면 대시보드로 자동 이동하도록 고쳤습니다.

- `components/events/EventForm.tsx`: `startEvent` 뮤테이션 성공 시 `router.push(`/events/${eventCode}/dashboard`)`를 추가했습니다.

기존에는 이벤트 시작이 성공해도 화면이 그대로 이벤트 설정 화면에 남아있어서, 대시보드로 가려면 이벤트 목록으로 돌아가 `LIVE`로 바뀐 카드를 다시 눌러야 했습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #177

## 검증 방법

- `npx tsc --noEmit`·`npm run lint`를 실행해 모두 통과를 확인했습니다.

**정상적으로 동작하는 경우**

세션을 1개 이상 등록한 뒤 "이벤트 시작"을 누르면, 요청이 성공한 뒤 대시보드 화면(`/events/{eventCode}/dashboard`)으로 이동합니다.
기존에 있던 "이벤트를 시작했어요" 토스트는 그대로 유지되며, `ToastViewport`가 루트 레이아웃에 있어서 페이지 이동 후에도 계속 보입니다.

**실패하는 경우**

세션 없이 "이벤트 시작"을 시도하면 여전히 서버가 409(`INVALID_EVENT_STATE_TRANSITION`)를 돌려주고, 기존 `onError` 그대로 토스트 안내만 뜨고 화면 이동은 없습니다. 이 부분은 이번 변경으로 바뀌지 않았습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

안치호님이 Slack에서 요청한 내용입니다. "이벤트 생성 직후(DRAFT)"를 뜻하는지 "세션 등록 후 이벤트 시작 시점"을 뜻하는지 확인이 필요했는데, 안치호님이 후자로 확인해줬습니다.
이벤트 생성 직후(DRAFT, 세션 0개) 상태로 대시보드에 보내는 것은 이번 범위에 포함하지 않았습니다. 대시보드는 `LIVE`일 때만 QR·링크 복사 같은 주요 버튼이 나타나서, `DRAFT` 상태로 보내면 빈 화면만 뜹니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
