### PR TITLE
fix(event): 이벤트 설정 화면의 참가자 링크가 실제 주소와 다름

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -230,10 +230,13 @@ const EventForm = ({ eventCode }: EventFormProps) => {
           error={eventFormErrors.eventDate}
         />
         {isEditMode && eventQuery.data ? (
+          // window 접근은 이 블록이 eventQuery.data가 있을 때만 렌더링되기 때문에 안전합니다.
+          // 서버 렌더링에서는 eventQuery.data가 항상 비어있어 이 줄까지 오지 않습니다
+          // (DashboardView.tsx의 publicUrl과 같은 이유입니다).
           <Field
             label="참가자 링크"
             name="code"
-            value={`pulse.app/e/${eventQuery.data.code}`}
+            value={`${window.location.origin}/e/${eventQuery.data.code}`}
             readOnly
           />
         ) : null}


### PR DESCRIPTION
## 변경 사항

이벤트 설정 화면의 참가자 링크가 실제 접속 가능한 주소를 보여주도록 고쳤습니다.

- `components/events/EventForm.tsx`: 참가자 링크 값을 `pulse.app/e/{code}` 하드코딩 대신 `window.location.origin` 기준으로 바꿨습니다.

`DashboardView.tsx`의 "링크 복사" 버튼은 `window.location.origin`으로 실제 주소를 만드는데, 이벤트 설정 화면은 실제 도메인이 아닌 `pulse.app`을 그대로 하드코딩하고 있었습니다.
같은 이벤트인데 두 화면이 서로 다른 형식의 링크를 보여주는 문제였습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #178

## 검증 방법

- `npx tsc --noEmit`·`npm run lint`를 실행해 모두 통과를 확인했습니다.

**정상적으로 동작하는 경우**

이벤트 설정 화면의 참가자 링크가 지금 브라우저가 열고 있는 실제 주소(`window.location.origin`) 기준으로 표시됩니다.
이 변경은 표시 값만 바꾸는 것이라 별도의 실패 시나리오는 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

`window` 접근이 서버 렌더링에서 안전한 이유를 주석으로 남겼습니다.
이 `Field`는 `isEditMode && eventQuery.data`가 있을 때만 렌더링되는 조건 안에 있는데, 서버 렌더링 시점에는 `eventQuery.data`가 항상 비어있어 이 줄까지 오지 않습니다.
`DashboardView.tsx`의 `publicUrl`도 같은 방식(데이터가 로딩된 뒤에만 도달하는 지점에 `window` 접근을 둠)으로 안전성을 확보하고 있어서, 그 패턴을 그대로 따랐습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
