### PR TITLE
feat(dashboard): 실시간 소감 피드에 숨기기 버튼 추가

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/components/dashboard/metrics';
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
 import { Donut } from '@/components/feedback/Donut';
-import { FeedItem, type Sentiment as FeedItemSentiment } from '@/components/feedback/FeedItem';
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
@@ -46,7 +46,7 @@ import {
   updateSession,
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import type { Feedback, Sentiment } from '@/lib/schemas/api';
+import type { Feedback } from '@/lib/schemas/api';
 
 /**
  * 주최자 실시간 모니터링 대시보드입니다.
@@ -66,13 +66,6 @@ const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
  * 누른 사람이 결과를 기다리며 보고 있는 화면이라서입니다. 끝나는 즉시 타이머를 멈춥니다.
  */
 const REPORT_POLL_INTERVAL_MS = 1_500;
-
-const FEED_SENTIMENT: Record<Sentiment, FeedItemSentiment> = {
-  POS: 'positive',
-  NEU: 'neutral',
-  NEG: 'negative',
-  UNKNOWN: 'none',
-};
 
 const DashboardView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
@@ -317,8 +310,20 @@ const DashboardView = () => {
    * 이건 감정 집계가 아니라 모더레이션 지표라서, 숨겼어도 몇 건 들어왔는지는
    * 주최자에게 보여야 합니다. `visible` 기준으로 되돌리지 마세요.
    */
-  const toxicItems = items.filter((feedback) => feedback.toxic);
-  const toxicCount = toxicItems.length;
+  const toxicCount = items.filter((feedback) => feedback.toxic).length;
+
+  /*
+   * 모더레이션 큐가 받는 목록입니다. 자동 판정된 독성 소감에 더해, 주최자가 실시간 피드에서
+   * 직접 숨긴 소감도 넣습니다(#170).
+   *
+   * 숨김 조건을 빼면 안 됩니다. 자동 판정은 욕설만 잡아서 인신공격 같은 건 사람이 골라야
+   * 하는데, 숨긴 소감은 `visible`에서 빠지므로 큐에도 안 들어오면 화면 어디에도 남지
+   * 않습니다. 되돌릴 수도 삭제할 수도 없는 소감이 생깁니다.
+   *
+   * `DELETED`는 여기까지 오지 않습니다. `/admin/feedbacks`가 `includeHidden`과 무관하게
+   * 항상 빼고 내려줍니다.
+   */
+  const queueItems = items.filter((feedback) => feedback.toxic || feedback.status === 'HIDDEN');
 
   const trend = buildTrend(visible);
   const keywords = countKeywords(visible);
@@ -626,6 +631,24 @@ const DashboardView = () => {
                         sentiment={FEED_SENTIMENT[feedback.sentiment]}
                         meta={toMeta(feedback)}
                         content={feedback.text}
+                        /*
+                         * 자동 판정이 잡는 건 욕설뿐이라, 인신공격처럼 판정을 빠져나간 소감은
+                         * 주최자가 여기서 직접 내려야 합니다(#170).
+                         *
+                         * 삭제는 달지 않습니다. `DELETED`는 되돌릴 수 없는 종단 상태라 실시간으로
+                         * 흘러가는 목록에서 바로 누르게 둘 자리가 아닙니다. 숨기면 모더레이션
+                         * 큐로 넘어가서, 거기서 다시 보고 삭제하거나 되돌립니다.
+                         */
+                        actions={
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            disabled={moderation.isItemPending(feedback.id)}
+                            onClick={() => moderation.toggleHidden(feedback)}
+                          >
+                            숨기기
+                          </Button>
+                        }
                       />
                     </li>
                   ))}
@@ -635,8 +658,8 @@ const DashboardView = () => {
 
             <div className="flex flex-col gap-3">
               <ModerationQueue
-                items={toxicItems}
-                waitingCount={toxicCount}
+                items={queueItems}
+                waitingCount={queueItems.length}
                 formatMeta={toMeta}
                 actions={moderation}
               />

--- a/components/feedback/FeedItem.tsx
+++ b/components/feedback/FeedItem.tsx
@@ -1,9 +1,26 @@
 import type { ComponentProps, ReactNode } from 'react';
 
 import { Badge } from '@/components/ui/Badge';
+import type { Sentiment as FeedbackSentiment } from '@/lib/schemas/api';
 
 type FeedItemState = 'normal' | 'flagged' | 'hidden';
 type Sentiment = 'positive' | 'neutral' | 'negative' | 'none' | 'toxic';
+
+/**
+ * 서버가 내려주는 감정 코드를 배지 종류로 바꿉니다.
+ *
+ * 유니온과 같은 파일에 두는 이유는 감정을 하나 더 늘릴 때 짝을 빠뜨릴 수 없게 하려는
+ * 것입니다. 실시간 피드와 모더레이션 큐가 같이 쓰는데, 화면마다 두면 한쪽만 고쳐집니다.
+ *
+ * `toxic`은 이 표에 없습니다. 독성은 감정 분류가 아니라 따로 붙는 플래그라, 같은 소감의
+ * 감정 대신 독성을 보여줄지는 쓰는 화면이 정합니다.
+ */
+const FEED_SENTIMENT: Record<FeedbackSentiment, Sentiment> = {
+  POS: 'positive',
+  NEU: 'neutral',
+  NEG: 'negative',
+  UNKNOWN: 'none',
+};
 
 interface FeedItemProps extends Omit<ComponentProps<'article'>, 'children'> {
   state: FeedItemState;
@@ -27,13 +44,14 @@ const CONTENT: Record<FeedItemState, string> = {
   hidden: 'text-text-tertiary',
 };
 
-const SENTIMENT: Record<Sentiment, { tone: ComponentProps<typeof Badge>['tone']; label: string }> = {
-  positive: { tone: 'positive', label: '긍정' },
-  neutral: { tone: 'neutral', label: '중립' },
-  negative: { tone: 'negative', label: '부정' },
-  none: { tone: 'outline', label: '미분류' },
-  toxic: { tone: 'toxic', label: '⚑ 독성 의심' },
-};
+const SENTIMENT: Record<Sentiment, { tone: ComponentProps<typeof Badge>['tone']; label: string }> =
+  {
+    positive: { tone: 'positive', label: '긍정' },
+    neutral: { tone: 'neutral', label: '중립' },
+    negative: { tone: 'negative', label: '부정' },
+    none: { tone: 'outline', label: '미분류' },
+    toxic: { tone: 'toxic', label: '⚑ 독성 의심' },
+  };
 
 const FeedItem = ({
   state,
@@ -62,5 +80,5 @@ const FeedItem = ({
   );
 };
 
-export { FeedItem };
+export { FeedItem, FEED_SENTIMENT };
 export type { FeedItemState, Sentiment };

--- a/components/feedback/README.md
+++ b/components/feedback/README.md
@@ -38,6 +38,20 @@
 
 이 표가 여기 있는 이유는 `ui/Badge`가 Pulse를 몰라야 하기 때문입니다. 감정을 문구로 바꾸는 일은 도메인 컴포넌트가 합니다.
 
+### 서버 코드 → `sentiment`는 `FEED_SENTIMENT`가 바꿉니다
+
+API의 `Sentiment`(`POS`·`NEU`·`NEG`·`UNKNOWN`)를 위 prop 값으로 옮기는 표를 같은 파일에서 내보냅니다.
+
+```tsx
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
+
+<FeedItem sentiment={FEED_SENTIMENT[feedback.sentiment]} ... />;
+```
+
+유니온과 같은 파일에 둬서 감정을 하나 더 늘릴 때 짝을 빠뜨릴 수 없게 했습니다. 실시간 피드와 모더레이션 큐가 같이 씁니다.
+
+**`toxic`은 이 표에 없습니다.** 독성은 감정 분류가 아니라 따로 붙는 플래그라, 감정 대신 독성 배지를 보여줄지는 쓰는 화면이 정합니다. 모더레이션 큐는 `feedback.toxic ? 'toxic' : FEED_SENTIMENT[feedback.sentiment]`로 가릅니다 — 주최자가 손으로 숨긴 소감까지 `⚑ 독성 의심`으로 그리면 자동 판정 결과처럼 읽힙니다.
+
 ### `· 숨김`은 자동으로 붙습니다
 
 `state="hidden"`이면 메타 문구 끝에 `· 숨김`이 붙습니다.
@@ -252,6 +266,7 @@ import { Donut } from '@/components/feedback/Donut';
 
 ## 결정 기록
 
+- 2026.08.14 (#170) — 서버 감정 코드 → `sentiment` 매핑(`FEED_SENTIMENT`)을 `DashboardView`에서 `FeedItem.tsx`로 옮겨 내보냄. 실시간 피드에 숨기기 버튼이 붙으면서 모더레이션 큐도 같은 매핑이 필요해졌는데, 화면마다 두면 한쪽만 고쳐짐. 독성은 감정 분류가 아니라 별도 플래그라 표에 넣지 않음
 - 2026.08.07 (#63) — 범례를 `SentimentLegend`로 분리하고 계산을 `sentiment.ts`로 뺌. 두 차트의 범례가 글자 하나까지 같아서, 각자 두면 감정 → 색·문구 매핑이 두 파일에 생기고 한쪽만 고쳐짐
 - 2026.08.07 (#63) — Donut 링 두께를 16으로 정함. 시안이 원 세 개를 겹쳐놓은 상태라 두께도 각도도 없었음. Thermometer 막대 높이(`h-4`)와 맞춤
 - 2026.08.07 (#63) — Donut에 카드를 넣지 않음. 시안의 240 × 178은 옆 카드와 높이를 맞춘 값이고 내용에서 계산하면 172임. Thermometer와 같은 판단

--- a/components/moderation/ModerationQueue.tsx
+++ b/components/moderation/ModerationQueue.tsx
@@ -1,4 +1,4 @@
-import { FeedItem } from '@/components/feedback/FeedItem';
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
 import { Badge } from '@/components/ui/Badge';
 import { Button } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
@@ -6,8 +6,12 @@ import type { ModerationActions } from '@/hooks/useModerationActions';
 import type { Feedback } from '@/lib/schemas/api';
 
 /**
- * 대시보드의 모더레이션 큐 위젯입니다. 독성으로 표시된 소감을 몇 건만 미리 보여주고
+ * 대시보드의 모더레이션 큐 위젯입니다. 검토가 필요한 소감을 몇 건만 미리 보여주고
  * 항목마다 숨기기·삭제를 답니다.
+ *
+ * 들어오는 경로가 둘입니다. 자동 판정된 독성 소감과, 주최자가 실시간 피드에서 직접 숨긴
+ * 소감입니다(#170). 자동 판정이 잡는 건 욕설뿐이라 인신공격 같은 건 사람이 골라야 하는데,
+ * 숨기기만 하고 큐에 안 들이면 그 소감은 피드에서도 큐에서도 사라져 삭제할 길이 없어집니다.
  *
  * 조치 자체는 `useModerationActions`가 알고 이 컴포넌트는 그리기만 합니다. 그래서
  * "처리 실패" 배너를 화면 상단에 둘지 카드 안에 둘지도 이 파일이 정하지 않습니다.
@@ -23,7 +27,7 @@ const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
 const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
 
 interface ModerationQueueProps {
-  /** 독성으로 표시된 소감입니다. 이미 숨긴 건도 들어옵니다. */
+  /** 독성으로 표시됐거나 주최자가 숨긴 소감입니다. 이미 숨긴 건도 들어옵니다. */
   items: Feedback[];
   /** "N건 대기"에 쓰는 값입니다. 처리를 끝낸 건은 빠진 숫자여야 합니다. */
   waitingCount: number;
@@ -64,7 +68,12 @@ const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: Moderatio
             <li key={feedback.id}>
               <FeedItem
                 state={isHidden ? 'hidden' : 'flagged'}
-                sentiment="toxic"
+                /*
+                 * 독성 배지는 독성 판정을 받은 건에만 답니다. 주최자가 손으로 숨긴 소감까지
+                 * "⚑ 독성 의심"으로 그리면 자동 판정 결과처럼 읽혀서, 왜 큐에 있는지가
+                 * 뒤바뀝니다. 그런 건은 원래 감정을 그대로 보여줍니다.
+                 */
+                sentiment={feedback.toxic ? 'toxic' : FEED_SENTIMENT[feedback.sentiment]}
                 meta={formatMeta(feedback)}
                 content={feedback.text}
                 actions={


### PR DESCRIPTION
## 변경 사항

실시간 소감 피드의 각 항목에 `숨기기` 버튼을 달았습니다. 자동 판정이 잡는 건 욕설뿐이라, 인신공격처럼 판정을 빠져나간 소감은 주최자가 직접 내려야 합니다.

- **피드에 숨기기 버튼 추가** — 기존 `useModerationActions.toggleHidden`을 그대로 재사용합니다. 토스트·재조회·중복 클릭 잠금(`isItemPending`)이 모더레이션 큐와 같게 동작합니다.
- **모더레이션 큐 대상 확장** (`toxic` → `toxic || status === 'HIDDEN'`) — 버튼만 달면 누른 소감이 증발합니다. 숨기면 `visible`에서 빠지는데 큐가 `toxic`만 받고 있어서, 손으로 숨긴 비독성 소감은 피드에서도 큐에서도 사라져 되돌릴 수도 삭제할 수도 없어집니다. 큐로 넘어가야 거기서 삭제·복구할 수 있습니다.
- **큐의 감정 배지 수정** — `sentiment="toxic"` 하드코딩이라 손으로 숨긴 소감까지 `⚑ 독성 의심`으로 그려졌습니다. `feedback.toxic ? 'toxic' : FEED_SENTIMENT[...]`로 가릅니다. 두 화면이 같은 매핑을 쓰게 되어 `FEED_SENTIMENT`를 `DashboardView`에서 `FeedItem.tsx`로 옮겨 내보냅니다.

`Stat`의 "독성 플래그" 숫자는 자동 판정 지표라 `toxic`만 세는 그대로 뒀습니다. 큐의 `N건 대기`만 새 목록 기준으로 바뀝니다.

### 삭제 버튼은 피드에 달지 않았습니다

`DELETED`는 되돌릴 수 없는 종단 상태라, 5초마다 갱신되며 흘러가는 목록에서 바로 누르게 둘 자리가 아닙니다. 숨기면 큐로 넘어가서 거기서 다시 보고 삭제하거나 되돌립니다.
<img width="1920" height="1080" alt="스크린샷 2026-08-14 155407" src="https://github.com/user-attachments/assets/7896cb12-0e76-4ac2-9310-1fab7720c057" />
<img width="1920" height="1080" alt="스크린샷 2026-08-14 155358" src="https://github.com/user-attachments/assets/29abc13f-8048-4073-b78d-ad81e421a441" />

## 관련 이슈

- Closes #170

## 검증 방법

리베이스 후 상태에서 실행했습니다.

```
npm run lint    통과 (출력 없음)
npm run test    Test Files 4 passed (4) / Tests 89 passed (89)
npm run build   Compiled successfully in 14.8s, TypeScript 통과, 9/9 페이지 생성
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
  `ModerationQueue`의 props 시그니처는 그대로입니다. `items`가 받는 범위만 넓어졌고(주석·prop 문서 갱신), `FEED_SENTIMENT`는 새로 내보내는 값이라 기존 import를 깨지 않습니다.

## 트러블슈팅 및 참고 사항

이슈 #170의 범위는 "버튼만 생성, 다른 것은 수정 없음"이었는데, 그대로 하면 버튼이 동작하지 않는 상태로 남습니다. 숨긴 소감이 어느 목록에도 속하지 않게 되기 때문입니다. 큐 필터 확장은 버튼을 쓸 수 있게 만드는 최소 조건이라 함께 넣었습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
