### PR TITLE
feat(events): 이벤트 목록 로딩 상태를 텍스트 대신 스켈레톤으로 표시

### DIFF
--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -11,6 +11,7 @@ import EventStatusFilterTabs, {
 import Link from 'next/link';
 import { Banner } from '@/components/ui/Banner';
 import EventListEmptyState from '@/components/events/EventListEmptyState';
+import { EventListSkeleton } from '@/components/events/EventListSkeleton';
 import { buttonStyle } from '@/components/ui/Button';
 
 const EventsListPage = () => {
@@ -48,7 +49,7 @@ const EventsListPage = () => {
           + 새 이벤트
         </Link>
       </div>
-      {myEvents.isPending && <p>불러오는 중...</p>}
+      {myEvents.isPending && <EventListSkeleton />}
       {myEvents.isError && <Banner type="negative">이벤트 목록을 불러오지 못했습니다.</Banner>}
       {isEventsEmpty && (
         <EventListEmptyState

--- a/components/events/EventListSkeleton.tsx
+++ b/components/events/EventListSkeleton.tsx
@@ -1,0 +1,25 @@
+/**
+ * `EventsListPage`의 로딩 자리표시자입니다.
+ *
+ * `EventCard`와 같은 크기의 회색 블록을 3개 반복해서, 목록 자리가 갑자기
+ * 비었다가 채워지는 대신 카드가 놓일 자리를 먼저 잡아둡니다.
+ */
+const EventCardSkeleton = () => (
+  <div className="flex items-center justify-between rounded-xl border border-border-subtle p-4">
+    <div className="flex flex-col gap-2">
+      <div className="h-4 w-24 rounded bg-neutral-subtle" />
+      <div className="h-5 w-40 rounded bg-neutral-subtle" />
+    </div>
+    <div className="h-4 w-16 rounded bg-neutral-subtle" />
+  </div>
+);
+
+const EventListSkeleton = () => (
+  <div className="flex animate-pulse flex-col gap-3" aria-hidden>
+    {[0, 1, 2].map((slot) => (
+      <EventCardSkeleton key={slot} />
+    ))}
+  </div>
+);
+
+export { EventListSkeleton };


### PR DESCRIPTION
## 변경 사항

이벤트 목록 화면(`/events`)에서 로딩 중에 텍스트 대신 스켈레톤(회색 블록)을 보여주도록 고쳤습니다.

- AS-IS: `app/(host)/events/page.tsx`는 이벤트 목록 API(`GET /events`) 응답을 기다리는 동안 "불러오는 중..." 텍스트 한 줄만 보여주고 있었습니다.
- TO-BE: `EventCard`와 같은 크기의 회색 블록 3개(`components/events/EventListSkeleton.tsx`, 새로 추가)를 보여줍니다.

이미 구현되어 있는 `components/live/LiveSkeleton.tsx`와 같은 스타일 조합(`animate-pulse` + `bg-neutral-subtle`)을 따랐습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #151

## 검증 방법

```
npx tsc --noEmit   통과 (출력 없음)
npm run lint       통과 (출력 없음)
npm run build      ✓ Compiled successfully in 7.5s / ✓ Finished TypeScript in 8.6s
```

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

`/events`에 들어가서 이벤트 목록 API(`GET /events`) 응답을 기다리는 동안, `EventCard`와 비슷한 크기의 회색 블록 3개가 옅게 깜빡이며(`animate-pulse`) 뜹니다.  
응답이 도착하면 스켈레톤이 사라지고 실제 이벤트 카드 목록으로 바뀝니다.

### 실패하는 경우 (이 PR을 반영한 뒤 기준)

이벤트 목록 API가 실패하면(`myEvents.isError`) 기존과 동일하게 에러 배너("이벤트 목록을 불러오지 못했습니다.")가 뜹니다.  
이 부분은 이번 변경으로 바뀌지 않습니다.

### 화면 확인 체크리스트

로컬 `.env.local`이 이미 배포 백엔드(Render)를 가리키도록 설정되어 있어서, 별도 네트워크 스로틀링 없이 로컬 dev 서버(`localhost:3000`)에서 바로 확인했습니다.

- [x] `/events` 접속 시 "불러오는 중..." 텍스트 대신 회색 블록 3개가 뜨는지 확인합니다.
- [x] 회색 블록이 옅게 깜빡이는 애니메이션과 함께 보이는지 확인합니다.
- [x] 응답 도착 후 스켈레톤이 실제 이벤트 카드로 자연스럽게 바뀌는지 확인합니다.
- [x] 이벤트 0개(빈 상태) 화면은 기존과 동일하게 보이는지 확인합니다. (아직 확인하지 않았습니다.)

**스크린샷**
<!-- 여기에 로딩 중 화면 스크린샷을 첨부합니다. -->

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

이슈 #151 은 PR #141(배포 크로스 오리진 쿠키 문제 해결) 작업 중, 배포 백엔드(Render)와 3G 네트워크로 테스트하다가 "불러오는 중..." 문구가 눈에 띄게 오래 보이는 것을 발견하면서 나왔습니다.

화면 확인은 로컬 MSW(목 서버) 대신 배포 백엔드(Render)로 직접 연동해서 진행했습니다.  
Render 무료 티어는 일정 시간 요청이 없으면 서버가 잠들었다가 첫 요청에서 느리게 깨어나는 콜드 스타트가 있어서, 서버가 잠들어 있던 시점에는 첫 응답이 153초까지 걸렸습니다.  
서버가 깨어난 뒤에는 응답이 0.5초 수준으로 빨라졌고, 스켈레톤이 잠깐 보였다가 실제 카드로 바뀌는 전환은 이 응답 속도 상태에서 확인했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

