### PR TITLE
fix(event): 세션 목록에 순서 번호 표시 + 입력 안내 문구를 시안대로 통일

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -263,7 +263,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
         {isEditMode ? (
           <section className="flex flex-col gap-2">
             <p className="text-xs font-normal leading-4 text-text-secondary">세션 목록</p>
-            {sessions.map((session) => (
+            {sessions.map((session, index) => (
               <div
                 key={session.id}
                 className="flex items-center justify-between gap-2 rounded-lg border border-border-default px-4 py-3"
@@ -272,6 +272,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
                   <>
                     <input
                       className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
+                      placeholder="세션 이름 입력"
                       value={editingSessionTitle}
                       onChange={(event) => setEditingSessionTitle(event.target.value)}
                     />
@@ -286,7 +287,9 @@ const EventForm = ({ eventCode }: EventFormProps) => {
                   </>
                 ) : (
                   <>
-                    <span className="text-sm text-text-primary">{session.title}</span>
+                    <span className="text-sm text-text-primary">
+                      {index + 1}. {session.title}
+                    </span>
                     <div className="flex gap-2 text-xs text-text-secondary">
                       <button
                         type="button"
@@ -311,7 +314,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
               <div className="flex items-center gap-2 rounded-lg border border-border-default px-4 py-3">
                 <input
                   className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
-                  placeholder="세션 제목을 입력하세요."
+                  placeholder="세션 이름 입력"
                   value={newSessionTitle}
                   onChange={(event) => setNewSessionTitle(event.target.value)}
                   autoFocus


### PR DESCRIPTION
## 변경 사항

이벤트 설정 화면(`/events/{eventCode}`)의 세션 목록에서 두 가지를 시안대로 고쳤습니다.

- AS-IS: `components/events/EventForm.tsx`는 세션 목록 각 항목에 `session.title`만 그대로 보여주고 있었습니다.
  순서 번호가 화면에 나타나지 않았습니다.
  세션 추가 입력창 placeholder도 "세션 제목을 입력하세요."였고, 세션 수정 입력창에는 placeholder 자체가 없었습니다.
- TO-BE: 세션 목록 각 항목 제목 앞에 "1. AI 시대의 프론트엔드"처럼 순서 번호를 붙였습니다.
  세션 추가·수정 입력창 placeholder를 모두 "세션 이름 입력"으로 통일했습니다.

### 순서 번호는 `session.order` 필드가 아니라 화면에 렌더링되는 배열 순서를 쓰기로 결정했습니다.

이렇게 결정한 이유는 MSW 핸들러(`mocks/handlers/event.ts`)를 확인한 결과, 세션 목록 응답이 `order` 기준으로 정렬된다는 보장이 코드에 없었기 때문입니다.
`order` 필드를 그대로 번호로 쓰면 응답 순서와 표시 번호가 어긋나거나, 세션 삭제 후 값에 공백이 생겼을 때 "1, 2, 4"처럼 번호가 끊길 수 있습니다.
배열 렌더링 순서(`index + 1`)를 쓰면 화면에 보이는 목록과 번호가 항상 일치합니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #161

## 검증 방법

```
npx tsc --noEmit   통과 (출력 없음)
npm run lint       통과 (출력 없음)
```

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

주최자가 이벤트 수정 화면에서 세션 목록을 보면, 각 항목 제목 앞에 "1.", "2."처럼 순서 번호가 붙어서 보입니다.
세션을 추가하거나 수정할 때 입력창이 비어 있으면 "세션 이름 입력"이라는 안내 문구가 회색으로 보입니다.

### 실패하는 경우

이 변경은 이미 있는 데이터를 화면에 표시하는 방식만 바꾸는 것이라, 별도의 실패 시나리오는 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

이슈 본문에 적힌 라인 번호(289행·306행)와 실제 파일의 위치가 달랐습니다.
이슈 작성 이후 다른 PR이 먼저 머지되면서 `EventForm.tsx`의 줄 수가 밀린 것으로 보이고, 라인 번호가 아니라 실제 코드(`{session.title}`이 있는 자리, 추가 입력창의 `placeholder` 속성)를 기준으로 수정 위치를 찾았습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
