### PR TITLE
feat(auth): 필드 재입력 시 이전 유효성 검사 에러 자동으로 지우기

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -36,6 +36,8 @@ const LoginForm = () => {
       ...prev,
       [event.target.name]: event.target.value,
     }));
+    setLoginFailed(false);
+    setLoginFailedMessage(null);
   };
 
   const handleSubmit = async (event: SubmitEvent<HTMLFormElement>) => {

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -59,9 +59,16 @@ const SignupForm = () => {
   const { signup } = useAuth();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setSignupInputs((prev) => ({
+    const { name, value } = event.target;
+
+    setSignupInputs((prev) => ({ ...prev, [name]: value }));
+
+    // 비밀번호 확인 에러는 password·passwordConfirm 두 값을 비교해서 나므로,
+    // 둘 중 어느 쪽이 바뀌어도 더 이상 유효하지 않은 판정이라 함께 지웁니다.
+    setSignupErrors((prev) => ({
       ...prev,
-      [event.target.name]: event.target.value,
+      [name]: undefined,
+      ...(name === 'password' ? { passwordConfirm: undefined } : {}),
     }));
   };
 


### PR DESCRIPTION
## 변경 사항

회원가입·로그인 폼에서 유효성 검사 에러가 뜬 뒤, 필드 값을 다시 입력하면 그 에러가 즉시 사라지도록 고쳤습니다.

- AS-IS: `SignupForm.tsx`·`LoginForm.tsx`의 `handleChange`는 입력값만 갱신하고 에러 상태는 건드리지 않았습니다.
  에러는 `handleSubmit`에서만 설정·리셋되어서, 한 번 제출해서 에러가 뜨면 필드를 다시 고쳐도 재제출 전까지 에러 문구와 invalid 스타일(빨간 테두리)이 그대로 남아 있었습니다.
- TO-BE: 필드 값이 바뀌는 즉시(`onChange` 시점) 관련 에러를 지웁니다.
  지운 뒤 값이 실제로 맞는지 다시 검사(재검증)하지는 않고, 그 검사는 다음 제출 시점에 다시 합니다.

### 비밀번호 확인 에러는 비밀번호 필드가 바뀔 때도 함께 지우기로 결정했습니다.

이렇게 결정한 이유는 "비밀번호가 일치하지 않습니다"라는 에러가 비밀번호·비밀번호 확인 두 필드 값을 비교해서 나는 에러라, 비밀번호 쪽 값이 바뀌면 그 판정 자체가 더 이상 유효하지 않기 때문입니다.
비밀번호 확인 필드 자신이 바뀔 때만 지우면, 비밀번호 필드를 고친 직후에는 여전히 옛날 값 기준으로 난 에러가 남아 있게 됩니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #185

## 검증 방법

```
npx tsc --noEmit   통과 (출력 없음)
npm run lint       통과 (출력 없음)
```

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

회원가입 화면에서 비밀번호와 비밀번호 확인 값을 다르게 입력하고 제출하면, 비밀번호 확인 필드에 "비밀번호가 일치하지 않습니다" 에러와 빨간 테두리가 뜹니다.
이 상태에서 비밀번호 필드나 비밀번호 확인 필드 중 어느 쪽이든 값을 다시 입력하기 시작하면, 에러 문구와 빨간 테두리가 즉시 사라집니다.

로그인 화면에서 로그인에 실패하면 "이메일 또는 비밀번호가 올바르지 않습니다" 에러 문구와 두 필드의 빨간 테두리가 뜹니다.
이 상태에서 이메일이나 비밀번호 중 어느 필드든 값을 다시 입력하기 시작하면, 에러 문구와 두 필드의 빨간 테두리가 즉시 사라집니다.

### 실패하는 경우

이 변경은 에러가 사라지는 타이밍만 바꾸는 것이라, 별도의 실패 시나리오는 없습니다.

### 화면 확인 체크리스트

- [x] 회원가입 화면에서 비밀번호 확인 불일치로 에러를 띄운 뒤, 비밀번호 확인 필드에 다시 타이핑하면 에러가 즉시 사라지는지 확인합니다.
- [x] 같은 상태에서 비밀번호 필드 쪽에 다시 타이핑해도 비밀번호 확인 필드의 에러가 함께 사라지는지 확인합니다.
- [x] 로그인 화면에서 로그인 실패 에러를 띄운 뒤, 이메일이나 비밀번호 필드에 다시 타이핑하면 에러 배너와 빨간 테두리가 즉시 사라지는지 확인합니다.

**스크린샷 또는 GIF**
<!-- 여기에 재입력 시 에러가 사라지는 화면을 첨부합니다. -->

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

이슈 #185 는 Slack에서 김효인님이 회원가입 화면 스크린샷과 함께 제안한 내용입니다.
코드로 확인한 결과 같은 패턴의 문제가 로그인 화면에도 있어서, 이슈 논의 과정에서 범위를 로그인 화면까지 넓히기로 결정했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

