### PR TITLE
feat(event): 세션 추가/수정 입력창에 취소 버튼 추가

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -201,6 +201,15 @@ const EventForm = ({ eventCode }: EventFormProps) => {
     editSession({ sessionId, title: editingSessionTitle });
   };
 
+  const handleEditSessionCancel = () => {
+    setEditingSessionId(null);
+  };
+
+  const handleAddSessionCancel = () => {
+    setIsAddingSession(false);
+    setNewSessionTitle('');
+  };
+
   if (isEditMode && eventQuery.isPending) {
     return <p>불러오는 중...</p>;
   }
@@ -275,6 +284,9 @@ const EventForm = ({ eventCode }: EventFormProps) => {
                       value={editingSessionTitle}
                       onChange={(event) => setEditingSessionTitle(event.target.value)}
                     />
+                    <Button type="button" variant="secondary" onClick={handleEditSessionCancel}>
+                      취소
+                    </Button>
                     <Button
                       type="button"
                       variant="secondary"
@@ -316,6 +328,9 @@ const EventForm = ({ eventCode }: EventFormProps) => {
                   onChange={(event) => setNewSessionTitle(event.target.value)}
                   autoFocus
                 />
+                <Button type="button" variant="secondary" onClick={handleAddSessionCancel}>
+                  취소
+                </Button>
                 <Button
                   type="button"
                   variant="secondary"


### PR DESCRIPTION
## 변경 사항

세션 추가/수정 입력창에 취소 버튼을 추가했습니다.  
확인 버튼만 있어서 입력을 시작한 뒤 그만둘 방법이 없던 문제를 해결합니다.

<img width="964" height="937" alt="shot-msxwvkjw" src="https://github.com/user-attachments/assets/205a339a-568a-4e78-a463-76777f0560bf" />

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #188

## 검증 방법

정적 검증입니다.

- `npm run lint` 통과했습니다.
- `npx tsc --noEmit` 통과했습니다.

아래는 브라우저에서 직접 확인해야 하는 수동 검증 체크리스트입니다.

- [x] 이벤트 설정 화면(수정 모드)에서 "+ 세션추가" 버튼을 눌러 입력창을 엽니다.  
  제목을 입력한 뒤 "취소" 버튼을 누르면, 입력창이 닫히고 입력한 제목이 사라져야 합니다.
- [x] 세션 목록에서 항목의 "수정" 버튼을 눌러 입력창을 엽니다.  
  제목을 바꾼 뒤 "취소" 버튼을 누르면, 목록 화면으로 돌아가고 원래 제목이 그대로 보여야 합니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그를 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
