### PR TITLE
feat(ui): 이벤트 상태 표기 한글화 + Badge에 info 톤 추가

### DIFF
--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -10,11 +10,11 @@ export interface EventCardProps {
 
 const TONE_BY_STATUS: Record<
   'LIVE' | 'DRAFT' | 'ENDED',
-  { tone: 'positive' | 'neutral' | 'outline'; label: string }
+  { tone: 'positive' | 'neutral' | 'info'; label: string }
 > = {
-  LIVE: { tone: 'positive', label: 'LIVE' },
-  DRAFT: { tone: 'neutral', label: 'DRAFT' },
-  ENDED: { tone: 'outline', label: 'ENDED' },
+  LIVE: { tone: 'positive', label: '● 진행 중' },
+  DRAFT: { tone: 'neutral', label: '준비 중' },
+  ENDED: { tone: 'info', label: '종료' },
 };
 
 const RIGHT_CONTENT_BY_STATUS = {

--- a/components/events/EventStatusFilterTabs.tsx
+++ b/components/events/EventStatusFilterTabs.tsx
@@ -10,9 +10,9 @@ export interface EventStatusFilterTabsProps {
 
 const TABS: { label: string; value: EventStatusFilter }[] = [
   { label: '전체', value: 'ALL' },
-  { label: 'DRAFT', value: 'DRAFT' },
-  { label: 'LIVE', value: 'LIVE' },
-  { label: 'ENDED', value: 'ENDED' },
+  { label: '준비 중', value: 'DRAFT' },
+  { label: '진행 중', value: 'LIVE' },
+  { label: '종료', value: 'ENDED' },
 ];
 
 const EventStatusFilterTabs = ({ selectedStatus, onChange }: EventStatusFilterTabsProps) => {
@@ -25,7 +25,7 @@ const EventStatusFilterTabs = ({ selectedStatus, onChange }: EventStatusFilterTa
     <div className="flex gap-2">
       {TABS.map((tab) => (
         <Chip
-          key={tab.label}
+          key={tab.value}
           selected={tab.value === selectedStatus}
           onClick={() => onChange(tab.value)}
         >

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -1,6 +1,6 @@
 import type { ComponentProps } from 'react';
 
-type BadgeTone = 'positive' | 'neutral' | 'negative' | 'toxic' | 'outline';
+type BadgeTone = 'positive' | 'neutral' | 'negative' | 'toxic' | 'outline' | 'info';
 
 interface BadgeProps extends ComponentProps<'span'> {
   tone: BadgeTone;
@@ -17,6 +17,7 @@ const TONE: Record<BadgeTone, string> = {
   neutral: 'bg-neutral-subtle text-neutral-darker',
   negative: 'bg-negative-subtle text-negative-darker',
   toxic: 'bg-toxic-subtle text-toxic-darker',
+  info: 'bg-primary-subtle text-primary-darker',
   outline: 'border border-border-strong bg-background-default text-text-secondary',
 };
 

--- a/components/ui/README.md
+++ b/components/ui/README.md
@@ -519,6 +519,7 @@ import { Textarea } from '@/components/ui/Textarea';
 | positive | `bg-positive-subtle`                             | `text-positive-darker` | 8.21:1 |
 | neutral  | `bg-neutral-subtle`                              | `text-neutral-darker`  | 8.49:1 |
 | negative | `bg-negative-subtle`                             | `text-negative-darker` | 8.86:1 |
+| info     | `bg-primary-subtle`                              | `text-primary-darker`  | 5.05:1 |
 | toxic    | `bg-toxic-subtle`                                | `text-toxic-darker`    | 8.98:1 |
 | outline  | `bg-background-default` + `border-border-strong` | `text-text-secondary`  | 6.49:1 |
 
@@ -540,7 +541,8 @@ import { Badge } from '@/components/ui/Badge';
 <Badge tone="toxic">⚑ 독성 의심</Badge>
 <Badge tone="outline">미분류</Badge>
 <Badge tone="positive">● LIVE</Badge>
-<Badge tone="neutral">ENDED</Badge>
+<Badge tone="info">종료</Badge>
+
 ```
 
 ---
@@ -823,6 +825,14 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 ---
 
 ## 결정 기록
+
+- **2026.08.15 #191** — `Badge`에 `info` 톤을 추가하고 `ENDED` 배지를 `outline`에서 `info`로 바꿨습니다.
+
+  위 결정(variant 제거) 당시 근거는 `ENDED`가 `neutral`과 같은 색이라 따로 둘 이유가 없다는 것이었습니다. 이후 시안이 `ENDED`를 Primary 계열로 바꾸면서 그 근거가 성립하지 않게 됐습니다. `outline`으로 대체하면 `DRAFT`(`neutral`)와 시각적 구분이 약합니다.
+
+  이름을 `primary`가 아니라 `info`로 정한 이유는, 다른 톤이 전부 의미(`positive`·`neutral`·`negative`·`toxic`)로 나뉘어 있고 `primary`는 색 이름이라 축이 어긋나기 때문입니다. `Banner`에 이미 `info` 타입이 있어 같은 말이 같은 뜻으로 쓰입니다.
+
+  대비 `5.05:1`로 12px 기준 WCAG AA(4.5:1)를 충족합니다.
 
 - 2026.08.11 (#106) — `Button`·`Chip`에 `cursor-pointer` 추가. 비활성 커서만 정하고 기본 커서를 안 정해서, `<button>`의 브라우저 기본값인 `default`가 그대로 나왔음. #54가 화면에서 `className="cursor-pointer"`로 덧대고 있었는데 `Chip`은 전부 클릭 가능한 `<button>`이라 예외가 없어 컴포넌트로 올림. 칩 아이콘은 새 prop 없이 `children`으로 넣기로 함 — `gap-2.5`가 이미 있어 간격이 붙고, Figma의 `icon` Boolean과 대응됨
 - 2026.08.11 (#88) — 버튼 모양의 링크를 위해 `buttonStyle(variant, size)`를 export. `<a>` 안에 `<button>`을 넣을 수 없어(HTML 콘텐츠 모델) 요소는 `next/link`로 두고 모양만 가져옴. `as` prop으로 폴리모픽하게 만드는 방법도 있었지만 제네릭 타입이 복잡해지고 `type="button"` 기본값이 `<a>`로 새는 것도 막아야 해서 미룸. 사용처가 서넛 넘어가면 `LinkButton` 래퍼를 두기로 함


### PR DESCRIPTION
## 변경 사항

#105 리뷰에서 나온 두 건을 마무리합니다.

- **상태 표기를 한글로 바꿨습니다.** @Dante0214 님 제안이고 제가 동의했던 건입니다.
- **`Badge`에 `info` 톤을 추가했습니다.** @ndopy 님이 PR 본문에 "추후 `Badge`에 `primary` 톤 추가를 고려해야 합니다"라고 남기신 건에 대한 결론입니다.

### 1. 상태 표기 한글화

`DRAFT` · `LIVE` · `ENDED`는 **우리 enum 값이지 사용자에게 보여주려고 정한 말이 아닙니다.**

참가자 화면이 이미 전부 한글입니다(`종료된 이벤트예요`, `지금은 소감을 받는 세션이 없어요`). 주최자 화면만 영어면 같은 서비스 안에서 말이 갈립니다.

| enum | 배지 | 필터 탭 |
|---|---|---|
| `DRAFT` | `준비 중` | `준비 중` |
| `LIVE` | `● 진행 중` | `진행 중` |
| `ENDED` | `종료` | `종료` |
| — | — | `전체` |

**배지와 탭을 같이 바꿨습니다.** 한쪽만 바꾸면 같은 화면에서 배지는 `LIVE`, 탭은 `진행 중`이 됩니다.

`●`는 **지금 돌아가는 중**이라는 신호라 배지에만 남겼습니다. 필터 탭은 상태를 고르는 자리지 지금 상태를 알리는 자리가 아닙니다.

### 2. `Badge`에 `info` 톤 추가

```tsx
type BadgeTone = 'positive' | 'neutral' | 'negative' | 'toxic' | 'outline' | 'info';

const TONE: Record<BadgeTone, string> = {
  // ...
  info: 'bg-primary-subtle text-primary-darker',
};
```

```tsx
// EventCard.tsx
ENDED: { tone: 'info', label: '종료' },   // outline → info
```

시안이 `ENDED`를 Primary 계열로 그렸는데 해당 톤이 없어서 #105에서 `outline`으로 대체돼 있었습니다. `outline`은 테두리 방식이라 `DRAFT`(`neutral`)와 시각적 구분이 약합니다.

**이름을 `primary`가 아니라 `info`로 정했습니다.** 다른 톤이 전부 의미(`positive`·`neutral`·`negative`·`toxic`)로 나뉘어 있는데 `primary`는 색 이름이라 축이 어긋납니다. 브랜드 색이 바뀌면 이름과 실제도 갈라지고요. `Banner`에 이미 `info` 타입이 있어 시스템 안에서 같은 말이 같은 뜻으로 쓰입니다.

토큰은 `primary` 계열을 그대로 씁니다. **토큰은 색이고 톤은 의미**라 이름이 달라도 됩니다.

## ⚠️ 이전 결정을 뒤집습니다

`components/ui/README.md`의 결정 기록에 `LIVE`·`ENDED` variant를 제거했던 항목이 있습니다. 당시 근거는 **`ENDED`가 `neutral`과 같은 색이라 따로 둘 이유가 없다**는 것이었습니다.

시안이 바뀌면서 그 근거가 성립하지 않게 됐습니다.

**기존 기록은 지우지 않았습니다.** 그 시점의 사실이라 고치면 기록이 거짓이 됩니다. 뒤집은 사실과 이유를 새 항목으로 덧붙였습니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| `a42316b` | feat(ui): Badge 에 info 톤을 추가한다 | 톤 이름을 색(`primary`)이 아니라 의미(`info`)로. 결정 기록은 덮지 않고 덧붙임 |
| `a3e16a2` | feat(event): 이벤트 상태 표기를 한글로 바꾼다 | 배지·탭을 같이 교체. `value`는 그대로라 API 계약 무영향 |

## 관련 이슈

- Closes #191
- Refs #105

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 5.8s / ✓ Finished TypeScript in 5.6s
npm run test    ✓ 5 files, 97 tests passed (823ms)
```

### 접근성

```
bg-primary-subtle   #e3f8fd
text-primary-darker #04728b
대비 5.05:1
```

12px 보조 텍스트 기준 WCAG AA(4.5:1)를 넘습니다. 다른 톤과 같은 `subtle` 배경 + `darker` 글자 조합이라 시각적 무게도 어긋나지 않습니다.

### 시안

Figma 시안의 상태 문구도 같이 한글로 고쳤습니다. **한쪽만 바꾸면 다음에 대조할 때 또 어긋납니다.**

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **바꾼 것은 화면에 보이는 문구와 배지 색뿐입니다.** `EventStatusFilter`의 `value`와 `PulseEvent.status`는 그대로라 API 계약에 영향이 없습니다.

## 트러블슈팅 및 참고 사항

### 필터 탭의 React key를 바꿨습니다

```tsx
- key={tab.label}
+ key={tab.value}
```

표시 문구를 키로 쓰면 문구가 겹치는 순간 React가 항목을 헷갈립니다. 지금 값으로는 안 겹치지만, **방금 문구를 바꿔봤듯 `label`은 바뀌는 값**이고 `key`는 안 바뀌는 값이어야 합니다.

요청 범위 밖이지만 같은 줄을 건드리는 김에 넣었습니다. 따로 빼는 게 낫다고 보시면 말씀해주세요.

### 남은 것

용어집에 상태 표기가 없으면 이 값으로 추가하겠습니다. Notion 쪽이라 이 PR 범위 밖입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
