### PR TITLE
fix(dashboard): 모더레이션 큐의 건수 표기를 사실대로 바꾼다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -657,12 +657,7 @@ const DashboardView = () => {
             </section>
 
             <div className="flex flex-col gap-3">
-              <ModerationQueue
-                items={queueItems}
-                waitingCount={queueItems.length}
-                formatMeta={toMeta}
-                actions={moderation}
-              />
+              <ModerationQueue items={queueItems} formatMeta={toMeta} actions={moderation} />
 
               <section className={CARD}>
                 <h2 className={CARD_TITLE}>상위 키워드</h2>

--- a/components/moderation/ModerationQueue.tsx
+++ b/components/moderation/ModerationQueue.tsx
@@ -29,22 +29,23 @@ const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
 interface ModerationQueueProps {
   /** 독성으로 표시됐거나 주최자가 숨긴 소감입니다. 이미 숨긴 건도 들어옵니다. */
   items: Feedback[];
-  /** "N건 대기"에 쓰는 값입니다. 처리를 끝낸 건은 빠진 숫자여야 합니다. */
-  waitingCount: number;
   /** 소감 하나의 메타 문구를 만듭니다. 세션 제목을 아는 건 화면 쪽이라 밖에서 받습니다. */
   formatMeta: (feedback: Feedback) => string;
   actions: ModerationActions;
 }
 
-const ModerationQueue = ({ items, waitingCount, formatMeta, actions }: ModerationQueueProps) => (
+const ModerationQueue = ({ items, formatMeta, actions }: ModerationQueueProps) => (
   <section className={CARD}>
     <div className="flex items-center justify-between gap-2">
       <h2 className={CARD_TITLE}>모더레이션 큐</h2>
-      <div className="flex items-center gap-2">
-        <Badge tone="toxic">{waitingCount}건 대기</Badge>
-        {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
-        <span className="text-xs font-normal leading-4 text-text-tertiary">전체보기</span>
-      </div>
+      {/*
+       * "N건 대기"라고 쓰지 않습니다. 독성 소감은 제출 시점에 이미 숨겨져서 들어오므로
+       * 조치가 끝난 상태이고, 주최자가 큐를 열어 "이건 숨긴 게 맞네" 하고 닫아도 숫자가
+       * 그대로입니다. 줄지 않는 대기 카운터는 며칠이면 안 보게 됩니다.
+       *
+       * 건수는 목록 길이 그대로입니다. 밖에서 따로 받으면 목록과 숫자가 어긋날 수 있습니다.
+       */}
+      <Badge tone="toxic">{items.length}건</Badge>
     </div>
 
     {/*


### PR DESCRIPTION
## 변경 사항

모더레이션 큐의 건수 표기를 사실대로 바꿨습니다.

```tsx
- <Badge tone="toxic">{waitingCount}건 대기</Badge>
+ <Badge tone="toxic">{items.length}건</Badge>
```

`대기`는 **주최자가 아직 조치하지 않았다**는 뜻인데, 독성 소감은 제출 시점에 이미 숨겨져서 들어옵니다(#150). 조치가 끝난 상태예요.

주최자가 큐를 열어 "이건 숨긴 게 맞네" 하고 닫아도 아무 일이 일어나지 않아 **숫자가 그대로입니다.** 줄지 않는 대기 카운터는 며칠이면 안 보게 됩니다.

`N건`은 숫자가 그대로여도 거짓이 아니고, 카드 제목이 이미 「모더레이션 큐」라 무슨 건수인지 읽힙니다.

## `waitingCount` prop을 없앴습니다

값이 항상 `items.length`와 같았습니다. 밖에서 따로 받으면 **목록과 숫자가 어긋날 수 있습니다.**

실제로 그럴 뻔했습니다. #150 직후 큐 목록은 `toxic`을 전체 기준으로 세는데 배지는 `VISIBLE` 기준이라, 독성이 자동 숨김되는 순간 **"목록엔 N건, 배지엔 0건 대기"**가 될 상황이었습니다. 그때는 계산식을 맞춰서 넘겼는데, 안에서 세면 그런 어긋남이 생길 자리 자체가 없습니다.

## `전체보기` 자리표시자를 지웠습니다

```tsx
- {/* 전체보기 모달은 별도 이슈입니다. 지금은 자리만 잡습니다. */}
- <span className="...">전체보기</span>
```

전체보기 모달은 만들지 않고 **각 목록 안에서 스크롤로** 보기로 했습니다(#168). 자리만 잡아둔 채로 두면 다음 사람이 아직 만들 화면이 남아 있다고 읽습니다.

## ⚠️ 이슈 범위가 줄었습니다

#195를 열 때 적었던 항목 중 **두 개는 #170에서 이미 처리됐습니다.**

| 이슈에 적은 것 | 상태 |
|---|---|
| 큐가 받는 목록 기준 | ✅ #170 — `toxic \|\| status === 'HIDDEN'` |
| `sentiment="toxic"` 하드코딩 | ✅ #170 — `feedback.toxic ? 'toxic' : FEED_SENTIMENT[...]` |
| `N건 대기` 문구 | 이 PR |
| props·컴포넌트 주석 | 일부 #170, 나머지 이 PR |

큐 목록 기준은 **제가 제안했던 `HIDDEN`만이 아니라 `toxic || HIDDEN`**으로 들어갔습니다. 되돌린(`보이기`) 독성 소감이 큐에 남는다는 차이인데, 추적이 끊기지 않아서 이쪽이 낫다고 봅니다. 그대로 뒀습니다.

## 관련 이슈

- Closes #195
- Refs #150, #168, #170

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 6.1s / ✓ Finished TypeScript in 5.4s
npm run test    ✓ 5 files, 102 tests passed (907ms)
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `ModerationQueue`의 `waitingCount` prop이 사라집니다. 이 컴포넌트를 쓰는 곳은 `DashboardView` 하나라 같이 고쳤습니다.

## 트러블슈팅 및 참고 사항

`DashboardView.tsx`는 축 3 담당 파일인데 **한 줄만 건드렸습니다.** prop을 없앤 결과라 이 PR 없이는 고칠 수 없습니다.

```tsx
- <ModerationQueue items={queueItems} waitingCount={queueItems.length} formatMeta={toMeta} actions={moderation} />
+ <ModerationQueue items={queueItems} formatMeta={toMeta} actions={moderation} />
```

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
