### PR TITLE
fix(report): 공개 리포트에 행사 날짜를 쓰고 빈 상태를 EmptyState로 통일한다

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -1,6 +1,7 @@
 import { notFound } from 'next/navigation';
 import { Donut } from '@/components/feedback/Donut';
 import { toRates } from '@/components/feedback/sentiment';
+import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
@@ -33,21 +34,12 @@ const PAGE = 'mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4';
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle bg-background-default p-4';
 
 /**
- * 서버 타임존에 따라 하루가 밀리지 않도록 Asia/Seoul로 고정합니다.
- * Vercel 서버는 UTC라 자정 근처에 만든 이벤트의 날짜가 어긋납니다.
+ * `eventDate`는 시각이 없는 `YYYY-MM-DD`라(API 명세) 구분자만 바꿉니다.
+ *
+ * `Date`로 파싱하지 않습니다. 날짜만 있는 문자열은 UTC 자정으로 읽히는데, 그걸 다시
+ * 지역 시간으로 그리면 타임존에 따라 하루가 밀립니다. Vercel 서버는 UTC입니다.
  */
-const formatDate = (iso: string) => {
-  const parts = new Intl.DateTimeFormat('ko-KR', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(new Date(iso));
-  const valueOf = (type: Intl.DateTimeFormatPartTypes) =>
-    parts.find((part) => part.type === type)?.value ?? '';
-
-  return `${valueOf('year')}.${valueOf('month')}.${valueOf('day')}`;
-};
+const formatDate = (isoDate: string) => isoDate.replaceAll('-', '.');
 
 // 목 데이터가 매 요청 반영되도록 캐시하지 않습니다(app/dev/msw/ssr/page.tsx와 같은 이유).
 export const dynamic = 'force-dynamic';
@@ -66,15 +58,10 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   if (report === null) {
     return (
       <main className={PAGE}>
-        {/* not-found.tsx의 빈 상태 카드와 같은 모양을 씁니다. */}
-        <div className="flex flex-col items-center gap-1 rounded-xl border border-border-subtle px-5 py-10">
-          <p className="text-base font-medium leading-6 text-text-primary">
-            공개된 리포트가 없어요
-          </p>
-          <p className="text-sm font-normal leading-5 text-text-secondary">
-            주최자가 공개하면 이 페이지에서 볼 수 있어요
-          </p>
-        </div>
+        <EmptyState
+          title="공개된 리포트가 없어요"
+          description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
+        />
       </main>
     );
   }
@@ -102,9 +89,14 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   return (
     <main className={PAGE}>
       <header className="flex flex-col gap-1">
-        {/* 소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다. */}
+        {/*
+          행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
+          일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
+
+          소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
+        */}
         <p className="text-xs leading-4 text-text-tertiary">
-          <time dateTime={event.createdAt}>{formatDate(event.createdAt)}</time> · 소감{' '}
+          <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
           {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
         </p>
 


### PR DESCRIPTION
## 변경 사항

공개 리포트 화면 두 곳을 고쳤습니다.

### 1. 헤더 날짜가 행사일이 아니라 등록일이었습니다

```tsx
- <time dateTime={event.createdAt}>{formatDate(event.createdAt)}</time>
+ <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time>
```

`createdAt`은 **주최자가 이벤트를 등록한 시각**입니다. 일주일 전에 만들어뒀으면 참가자에게 일주일 전 날짜가 보입니다.

`eventDate`는 2026-08-12 명세로 들어와 있었는데 화면이 아직 안 쓰고 있었습니다.

### 2. 빈 상태가 `EmptyState`와 중복이었습니다

```tsx
- <div className="flex flex-col items-center gap-1 rounded-xl border border-border-subtle px-5 py-10">
-   <p className="text-base font-medium leading-6 text-text-primary">공개된 리포트가 없어요</p>
-   <p className="text-sm font-normal leading-5 text-text-secondary">주최자가 공개하면 …</p>
- </div>
+ <EmptyState
+   title="공개된 리포트가 없어요"
+   description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
+ />
```

테두리·여백·글자 스타일이 `EmptyState`와 **한 글자도 다르지 않았습니다.** 두 벌이 남아 있으면 디자인 토큰을 고칠 때 한쪽만 따라갑니다. 8/11에 12px 보조 텍스트 대비를 고칠 때 같은 종류의 문제를 겪었습니다.

## `formatDate`를 갈아엎었습니다

`eventDate`는 **시각이 없는 `YYYY-MM-DD`** 입니다. `Date`로 파싱하면 UTC 자정으로 읽히고, 그걸 다시 지역 시간으로 그리면 **타임존에 따라 하루가 밀립니다.** Vercel 서버는 UTC입니다.

```tsx
- const parts = new Intl.DateTimeFormat('ko-KR', { timeZone: 'Asia/Seoul', ... })
-   .formatToParts(new Date(iso));
- // … 12줄
+ const formatDate = (isoDate: string) => isoDate.replaceAll('-', '.');
```

기존 코드는 `Asia/Seoul` 고정으로 그 문제를 막고 있었습니다. **파싱을 안 하면 막을 것 자체가 없어집니다.** `Intl` 블록 12줄도 같이 사라졌습니다.

`dateTime` 속성에는 `YYYY-MM-DD`가 그대로 들어갑니다. HTML `<time>`이 받는 유효한 형식입니다.

## 손대지 않은 것

**키워드 목록은 지금이 맞습니다.** `Chip`으로 그리지 않은 이유가 코드에 적혀 있고, 타당합니다.

```tsx
{/* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */}
```

시안이 `Chip`으로 그려져 있는데, **코드가 맞고 시안을 고치는 쪽**으로 정했습니다. Figma도 이 PR에 맞춰 수정했습니다.

## 관련 이슈

- Closes #200 
- Refs #197 — `EventCard`에 같은 날짜 문제가 있습니다. 축 3 파일이라 분리했습니다.

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 5.7s / ✓ Finished TypeScript in 6.1s
npm run test    ✓ 5 files, 102 tests passed (883ms)
```

`/e/kd7m2p/report`(시드의 ENDED 이벤트)에서 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- SSR 페이지라 `dynamic = 'force-dynamic'`가 걸려 있습니다. pull 후 dev 서버 재시작이 필요할 수 있습니다.

## 트러블슈팅 및 참고 사항

`EventCard.tsx`에 같은 TODO가 달려 있습니다.

```tsx
/* TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가
   추가되면 해당 날짜로 사용해야 함. */
```

**조건이 충족됐습니다.** 다만 축 3 담당 파일이고 `lib/formatEventDate.ts`도 같이 봐야 해서 이슈로 분리했습니다. `formatEventDate`가 `Date`를 거친다면 위와 같은 타임존 처리가 필요합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
