### PR TITLE
fix(build): prepare 스크립트가 .git 없는 환경에서 실패하지 않도록 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format:check": "prettier --check .",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepare": "git config core.hooksPath .githooks"
+    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.7.1",


### PR DESCRIPTION
## 변경 사항

`.git` 디렉토리가 없는 배포 환경(Vercel 빌드 등)에서 `npm install`이 항상 실패하는 문제를 고쳤습니다.

**`package.json`(14행)** 의 `prepare` 스크립트는 npm이 `install` 시점에 자동으로 실행하는 
생명주기 스크립트(=별도로 호출하지 않아도 `npm install`마다 같이 도는 스크립트)입니다.  

**AS-IS:** 
지금은 이 스크립트가 `git config core.hooksPath .githooks` 명령을 조건 없이 실행하고 있어서, 
`.git`이 없는 환경에서는 `fatal: not in a git directory`로 실패하고 npm이 exit code 128을 내며 
`npm install` 전체를 중단시킵니다.  

**TO-BE:** 
명령 뒤에 `2>/dev/null || true`를 붙여서, 
`.git`이 없는 환경에서는 이 실패를 무시하고 `npm install`이 계속 진행되도록 했습니다.

## 개발 과정 로그

커밋이 1개뿐이라 생략합니다.

## 관련 이슈

- Closes #201

## 검증 방법

두 환경 각각에서 `npm run prepare`를 직접 실행해서 확인했습니다.

- **`.git`이 있는 환경** (이 저장소를 그대로 clone한 디렉토리)  
  `npm run prepare` 실행 후 `git config core.hooksPath`로 조회한 값이 `.githooks`로 정상 설정됨을 확인했습니다.
- **`.git`이 없는 환경** (`package.json`만 복사한 별도 빈 디렉토리)  
  `npm run prepare`가 exit code 0으로 끝나는 것을 확인했습니다. 수정 전 코드로는 이 환경에서 exit code 128로 실패했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

이슈 #201 에 기록한 것처럼, 이 문제는 CLI 배포(`vercel --prod`)와 Vercel 대시보드의 Redeploy 두 방법 모두에서 동일하게 재현됐습니다.  
`.git`이 없는 배포 환경 전반(Vercel 외 다른 CI 포함)에 공통으로 적용되는 수정입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
