### PR TITLE
fix(dashboard): 대시보드 모바일 레이아웃을 시안에 맞춘다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -401,7 +401,13 @@ const DashboardView = () => {
         <div className="flex w-full flex-col gap-2 md:w-auto md:items-end">
           <div className="flex items-center justify-between gap-2 md:justify-end">
             {event.status === 'ENDED' && (
-              <div className="flex shrink-0 items-center gap-2">
+              /*
+               * 모바일에서는 이 묶음이 줄을 다 차지하고(`flex-1`) 버튼만 오른쪽 끝으로
+               * 밀립니다(`ml-auto`). 배지가 함께 서는 생성 중·완료 상태에서는 배지가 왼쪽에
+               * 남아 양끝 정렬이 됩니다. 데스크톱은 `md:flex-none`으로 내용 폭인 원래
+               * 배치로 돌아가고, 그때는 밀어낼 여백이 없어 `ml-auto`도 함께 죽습니다.
+               */
+              <div className="flex flex-1 items-center gap-2 md:flex-none">
                 {isReportGenerating && <Badge tone="neutral">생성 중</Badge>}
                 {isReportGenerated && <Badge tone="positive">생성 완료</Badge>}
 
@@ -410,6 +416,7 @@ const DashboardView = () => {
                   <Button
                     variant="secondary"
                     size="sm"
+                    className="ml-auto"
                     disabled={event.status !== 'ENDED' || isReportUnknown || isReportGenerating}
                     onClick={() => generateReportMutation.mutate()}
                   >

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -24,6 +24,7 @@ import {
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
 import { Donut } from '@/components/feedback/Donut';
 import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
+import { Thermometer } from '@/components/feedback/Thermometer';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
@@ -355,6 +356,17 @@ const DashboardView = () => {
 
   const isReportPublic = report?.isPublic ?? false;
 
+  /*
+   * 리포트 카드의 상태 배지입니다. 모바일에선 제목 옆, 데스크톱에선 오른쪽 조치 자리에
+   * 서는데 부모가 달라 CSS로는 옮길 수 없습니다. 두 자리에 같은 것을 두고 감싸는 span으로
+   * 하나씩 감추므로, 본문은 여기서 한 번만 만듭니다.
+   */
+  const reportBadge = isReportGenerating ? (
+    <Badge tone="neutral">생성 중</Badge>
+  ) : isReportGenerated ? (
+    <Badge tone="positive">생성 완료</Badge>
+  ) : null;
+
   /* 칩에서 고른 세션입니다. "전체"(`null`)에는 켜고 끌 대상이 없어 아래 토글을 감춥니다. */
   const selectedSession =
     sessionId === null ? null : (sessions.find((session) => session.id === sessionId) ?? null);
@@ -373,7 +385,7 @@ const DashboardView = () => {
             <Badge tone={event.status === 'LIVE' ? 'positive' : 'neutral'}>{event.status}</Badge>
           </div>
           {/* 복사되는 값과 같은 것을 보여줍니다. 다르면 눈으로 옮겨 적는 사람이 틀립니다. */}
-          <p className="text-xs font-normal leading-4 break-all text-text-tertiary">{publicUrl}</p>
+          <p className="text-xs font-normal leading-4 break-all text-primary-darker">{publicUrl}</p>
         </div>
 
         {/*
@@ -386,8 +398,8 @@ const DashboardView = () => {
          *
          * 리포트 공개 전환만 `ENDED` 쪽에 남습니다. 주소는 제목 아래에 늘 떠 있습니다.
          */}
-        <div className="flex flex-col items-end gap-2">
-          <div className="flex items-center gap-2">
+        <div className="flex w-full flex-col gap-2 md:w-auto md:items-end">
+          <div className="flex items-center justify-between gap-2 md:justify-end">
             {event.status === 'ENDED' && (
               <div className="flex shrink-0 items-center gap-2">
                 {isReportGenerating && <Badge tone="neutral">생성 중</Badge>}
@@ -408,10 +420,20 @@ const DashboardView = () => {
             )}
             {event.status === 'LIVE' && (
               <>
-                <Button variant="secondary" size="sm" onClick={() => setIsQrOpen(true)}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="flex-1 md:flex-none"
+                  onClick={() => setIsQrOpen(true)}
+                >
                   QR
                 </Button>
-                <Button variant="secondary" size="sm" onClick={handleCopyLink}>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  className="flex-1 md:flex-none"
+                  onClick={handleCopyLink}
+                >
                   링크 복사
                 </Button>
               </>
@@ -435,10 +457,13 @@ const DashboardView = () => {
               <Button
                 variant="secondary"
                 size="sm"
+                className="flex-1 md:flex-none"
+                aria-label="이벤트 종료"
                 disabled={endEventMutation.isPending}
                 onClick={() => setIsEndConfirmOpen(true)}
               >
-                이벤트 종료
+                <span className="md:hidden">종료</span>
+                <span className="hidden md:inline">이벤트 종료</span>
               </Button>
             )}
           </div>
@@ -451,7 +476,7 @@ const DashboardView = () => {
            * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다.
            */}
           {event.status === 'LIVE' && selectedSession !== null && (
-            <div className="flex items-center gap-2">
+            <div className="hidden items-center gap-2 md:flex">
               <Badge tone={selectedSession.status === 'ACTIVE' ? 'positive' : 'neutral'}>
                 {selectedSession.status === 'ACTIVE'
                   ? '소감 받는 중'
@@ -497,6 +522,34 @@ const DashboardView = () => {
         <span className="ml-auto text-xs font-normal leading-4 text-text-tertiary">
           총 {sessions.length}개 중 {openSessionCount}개 열림
         </span>
+        {event.status === 'LIVE' && selectedSession !== null && (
+          <div className="flex w-full items-center justify-between gap-2 md:hidden">
+            <Badge tone={selectedSession.status === 'ACTIVE' ? 'positive' : 'neutral'}>
+              {selectedSession.status === 'ACTIVE'
+                ? '소감 받는 중'
+                : isSelectedSessionPaused
+                  ? '소감 멈춤'
+                  : '시작 전'}
+            </Badge>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={toggleSessionMutation.isPending}
+              onClick={() =>
+                toggleSessionMutation.mutate({
+                  id: selectedSession.id,
+                  status: selectedSession.status === 'ACTIVE' ? 'CLOSED' : 'ACTIVE',
+                })
+              }
+            >
+              {selectedSession.status === 'ACTIVE'
+                ? '멈추기'
+                : isSelectedSessionPaused
+                  ? '다시 받기'
+                  : '소감 받기'}
+            </Button>
+          </div>
+        )}
       </div>
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
@@ -529,7 +582,18 @@ const DashboardView = () => {
           <div className="grid gap-3 md:grid-cols-[16rem_1fr]">
             <section className={CARD}>
               <h2 className={CARD_TITLE}>감정 분포</h2>
-              <Donut positive={positive} neutral={neutral} negative={negative} className="py-2" />
+              <Donut
+                positive={positive}
+                neutral={neutral}
+                negative={negative}
+                className="py-2 hidden md:flex"
+              />
+              <Thermometer
+                positive={positive}
+                neutral={neutral}
+                negative={negative}
+                className="py-2 md:hidden"
+              />
             </section>
 
             <section className={CARD}>
@@ -690,12 +754,16 @@ const DashboardView = () => {
            * 멈춰서(위 `refetchInterval`) 기다려도 아무것도 다시 오지 않습니다.
            */}
           <section
-            className={`${CARD} flex-row items-start justify-between gap-4 bg-background-muted`}
+            className={`${CARD} flex-col items-start justify-between gap-4 bg-background-muted md:flex-row`}
           >
-            <div className="flex flex-col gap-1">
-              <h2 className="text-base font-semibold leading-6 text-text-primary">
-                AI 요약 리포트
-              </h2>
+            <div className="flex w-full flex-col gap-1 md:w-auto">
+              {/* 배지를 오른쪽 끝에 붙이려면 이 열이 폭을 다 써야 합니다(`w-full`). */}
+              <div className="flex items-center justify-between gap-2">
+                <h2 className="text-base font-semibold leading-6 text-text-primary">
+                  AI 요약 리포트
+                </h2>
+                {reportBadge && <span className="md:hidden">{reportBadge}</span>}
+              </div>
 
               {summaryText !== null ? (
                 <p className="text-sm font-normal leading-5 text-text-secondary">{summaryText}</p>
@@ -713,14 +781,22 @@ const DashboardView = () => {
             {/*
              * 오른쪽은 이 카드의 상태와 조치가 함께 서는 자리입니다. 상태 배지를 제목이 아니라
              * 여기 두는 이유는, 다 만들고 나면 버튼이 빠져서 이 자리가 비기 때문입니다.
+             *
+             * 모바일에서는 카드가 세로로 서면서 이 자리가 제목에서 멀어지므로, 배지만 제목 옆으로
+             * 올립니다(`reportBadge`). 그러면 생성 완료 상태의 모바일에서는 배지도 버튼도 없어
+             * 이 자리가 통째로 비므로 아예 감춥니다 — 안 그러면 section의 `gap-4`만 남습니다.
              */}
-            <div className="flex shrink-0 items-center gap-2">
-              {isReportGenerating && <Badge tone="neutral">생성 중</Badge>}
-              {isReportGenerated && <Badge tone="positive">생성 완료</Badge>}
+            <div
+              className={`flex w-full shrink-0 items-center gap-2 md:w-auto ${
+                isReportGenerated ? 'hidden md:flex' : ''
+              }`}
+            >
+              {reportBadge && <span className="hidden md:contents">{reportBadge}</span>}
 
               {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
               {!isReportGenerated && (
                 <Button
+                  className="flex-1 md:flex-none"
                   variant="primary"
                   disabled={event.status !== 'ENDED' || isReportUnknown || isReportGenerating}
                   onClick={() => generateReportMutation.mutate()}


### PR DESCRIPTION
## 변경 사항

대시보드가 좁은 폭에서 데스크톱 배치를 그대로 쓰고 있어 시안과 어긋나던 부분을 고칩니다. 로직 변경은 없고 반응형 분기와 색상 토큰만 손댔습니다. 데스크톱(`md` 이상) 레이아웃은 이번 변경 전과 동일합니다.

- 헤더 우측 열을 모바일에서 전폭으로 펴고 QR·링크 복사·이벤트 종료 버튼에 `flex-1`을 줘 한 줄을 고르게 나눠 쓰게 했습니다. 이벤트 종료는 좁은 폭에서 "종료"로 줄이되 `aria-label`에 원래 이름을 남겨 접근명이 바뀌지 않게 했습니다.
- `ENDED` 이벤트 헤더에서는 요약 생성 버튼을 모바일에서 오른쪽 끝에 붙입니다. 배지가 함께 서는 생성 중·완료 상태에서는 배지가 왼쪽에 남아 양끝 정렬이 됩니다.
- 세션 상태 배지와 소감 수신 토글을 모바일에서 헤더 아래 세션 칩 줄로 내립니다. 부모가 달라 CSS로는 옮길 수 없어 두 자리에 두고 한쪽씩 감춥니다.
- 리포트 카드도 같은 이유로 상태 배지를 제목 옆과 우측 조치 자리에 함께 뒀습니다. 생성 완료 상태의 모바일에서는 우측에 배지도 버튼도 남지 않아 빈 열과 `gap-4`만 보이므로 그 열을 통째로 감춥니다.
- 감정 분포는 모바일에서 도넛 대신 `Thermometer`를 씁니다. 도넛은 112px 고정 폭이라 좁은 화면에서 카드 가운데에 홀로 떠 공간을 낭비합니다.
- 참가자 링크 주소를 `text-tertiary`에서 `primary-darker`로 바꿔 시안의 강조를 따릅니다. 대비는 4.56:1에서 5.55:1로 올라갑니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| d61945e | fix(dashboard): 대시보드 모바일 레이아웃을 시안에 맞춘다 | 헤더·세션 토글·감정 분포·리포트 카드의 반응형 분기와 링크 색상을 시안 기준으로 정리 |
| f9e9bab | fix(dashboard): 모바일 헤더의 요약 생성 버튼을 오른쪽 끝에 붙인다 | `ENDED` 헤더 묶음이 `shrink-0`라 모바일에서 왼쪽에 몰려 있던 것을 `flex-1` + `ml-auto`로 교정 |

## 관련 이슈

- Closes #187

## 검증 방법

`origin/dev`(222de3e) 리베이스 후 실행했습니다.

```
$ npm run lint
(경고·오류 없음, 출력 없이 종료)

$ npm run test
 Test Files  5 passed (5)
      Tests  102 passed (102)
   Duration  2.61s

$ npm run build
✓ Compiled successfully in 12.7s
✓ Generating static pages using 7 workers (9/9) in 1008ms
(13개 라우트 모두 빌드 성공)
```

수동 확인은 리뷰어가 아래를 봐주시면 됩니다.

- `LIVE` 이벤트 대시보드를 모바일 폭에서 열기 — 헤더 버튼 세 개가 한 줄을 균등하게 나눠 쓰고, 종료 버튼 문구가 "종료"인지
- 세션 칩을 하나 고르기 — 상태 배지와 소감 받기/멈추기 버튼이 헤더가 아니라 칩 줄 아래에 오는지
- 감정 분포 카드 — 모바일에서 가로 막대, `md` 이상에서 도넛인지
- `ENDED` 이벤트에서 요약 생성 전 / 생성 중 / 생성 완료 세 상태를 모두 보기 — 헤더 버튼이 오른쪽 끝에 붙는지, 배지가 있을 때 양끝 정렬이 되는지, 리포트 카드의 생성 완료 상태에서 우측 열이 사라지는지

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

Tailwind에서 `display` 유틸리티는 클래스를 쓴 순서가 아니라 생성된 CSS의 순서로 승부가 납니다. 실제 컴파일 결과를 확인해보니 `.contents` → `.flex` → `.hidden` → `.inline-flex` 순이었습니다.

- 이 PR이 쓰는 `flex … hidden md:flex` 조합은 `.hidden`이 `.flex`보다 뒤에 나오므로 의도대로 동작합니다.
- 다만 `.inline-flex`가 `.hidden`보다도 뒤라, **`<Button className="hidden md:…">`은 동작하지 않습니다**(`Button`의 기본 클래스가 `inline-flex`). 나중에 버튼을 반응형으로 숨겨야 하면 래퍼 요소로 감싸야 합니다. 이 PR에는 해당 사례가 없습니다.

`DashboardView.tsx`가 이미 길고 이번 변경으로 세션 토글 블록이 데스크톱·모바일용으로 중복됐습니다. 컴포넌트 분리는 이 PR 범위를 벗어나 별도 작업으로 진행할 예정입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
