### PR TITLE
fix(live): 실시간 결과 화면의 레이아웃 점프와 여백을 보정한다

### DIFF
--- a/app/e/[code]/live/page.tsx
+++ b/app/e/[code]/live/page.tsx
@@ -41,8 +41,8 @@ const LivePage = async ({ params, searchParams }: PageProps<'/e/[code]/live'>) =
   }
 
   return (
-    <main className="flex flex-col gap-6 p-5">
-      <Suspense fallback={<LiveSkeleton />}>
+    <main className="flex flex-col gap-6 px-5 py-4">
+      <Suspense fallback={<LiveSkeleton withHeading />}>
         <LiveResult />
       </Suspense>
     </main>

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -196,11 +196,11 @@ const LiveResult = () => {
           <section className="flex flex-col gap-2">
             <h3 className="text-xs text-text-tertiary">많이 나온 말</h3>
             {keywords.length === 0 ? (
-              <p className="flex min-h-32 items-center justify-center rounded-xl border border-border-subtle px-5 py-8 text-sm text-text-tertiary">
+              <p className="flex min-h-32 items-center justify-center rounded-xl border border-border-subtle p-4 text-sm text-text-tertiary">
                 아직 모인 키워드가 없어요
               </p>
             ) : (
-              <ul className="flex min-h-32 flex-wrap items-center justify-center gap-x-6 gap-y-4 rounded-xl border border-border-subtle px-5 py-8">
+              <ul className="flex min-h-32 flex-wrap items-center justify-center gap-x-6 gap-y-4 rounded-xl border border-border-subtle p-4">
                 {keywords.map(({ keyword, count }) => (
                   <li key={keyword}>
                     {keyword}

--- a/components/live/LiveSkeleton.tsx
+++ b/components/live/LiveSkeleton.tsx
@@ -7,9 +7,31 @@
  * `useSearchParams`는 프리렌더 시 가장 가까운 Suspense 경계까지 클라이언트 렌더로
  * 떨어지므로, 이 컴포넌트가 그 경계의 fallback도 겸합니다.
  */
-const LiveSkeleton = () => {
+interface LiveSkeletonProps {
+  /**
+   * 제목 자리까지 대신 그릴지 여부입니다.
+   *
+   * 이 컴포넌트는 성격이 다른 두 자리에서 쓰입니다. `LiveResult` 안에서는 제목이 이미
+   * 위에 그려진 뒤라 켜면 제목이 두 번 나옵니다. 반대로 `LiveResult` 통째를 기다리는
+   * Suspense fallback에서는 켜야 합니다 — 끄면 이름이 도착할 때 아래가 통째로 밀립니다.
+   */
+  withHeading?: boolean;
+}
+
+const LiveSkeleton = ({ withHeading = false }: LiveSkeletonProps) => {
   return (
     <div className="flex animate-pulse flex-col gap-6" aria-hidden>
+      {/*
+       * 실제 제목 블록과 높이를 맞춥니다. `h-4`·`h-7`은 각각 이벤트명 `leading-4`,
+       * 세션명 `leading-7`의 줄 높이이고 `gap-1`도 같은 값입니다(`LiveResult`의 제목 묶음).
+       */}
+      {withHeading && (
+        <div className="flex flex-col gap-1">
+          <div className="h-4 w-28 rounded bg-neutral-subtle" />
+          <div className="h-7 w-48 rounded bg-neutral-subtle" />
+        </div>
+      )}
+
       <section className="flex flex-col gap-2">
         <div className="h-4 w-40 rounded bg-neutral-subtle" />
         {/* `h-4`는 Thermometer 막대와 같은 값입니다. 실제 화면으로 바뀔 때 자리가 흔들리지 않습니다. */}


### PR DESCRIPTION
## 변경 사항

#110의 세 항목을 모두 처리합니다. 로직 변경 없이 자리표시자와 여백만 손댔습니다.

**1. `LiveSkeleton`에 제목 자리 추가 (레이아웃 점프)**

이름이 도착해 `LiveResult`로 넘어갈 때 아래 내용이 통째로 내려갔습니다. 제목 두 줄 48px(`leading-4` 16 + `gap-1` 4 + `leading-7` 28)에 바깥 `gap-6` 24px가 더해져 **72px** 밀립니다. (이슈 본문의 68px은 추정치였고, 실제 토큰 값으로 계산하면 72px입니다.)

다만 `LiveSkeleton`을 무조건 고치면 안 됩니다. 이 컴포넌트는 성격이 다른 두 자리에 쓰입니다.

| 사용처 | 무엇을 대신하나 | 제목 자리 |
| --- | --- | --- |
| `app/e/[code]/live/page.tsx:45` (Suspense fallback) | `LiveResult` **통째** | **필요** |
| `components/live/LiveResult.tsx:184` (`isSnapshotPending`) | 제목 아래 섹션들만 (제목은 `:175-181`에 이미 그려짐) | 넣으면 **두 번** 나옴 |

두 번째 자리에 제목을 넣으면 밀림이 되레 늘어나므로, `withHeading` prop으로 가르고 기본값을 꺼둔 채 Suspense fallback에서만 켭니다. 자리표시자 높이는 실제 제목과 같은 토큰을 씁니다 — `h-4`는 이벤트명 `leading-4`, `h-7`은 세션명 `leading-7`, 묶음의 `gap-1`도 그대로입니다.

**2. content 패딩** — `p-5`(사방 20) → `px-5 py-4`(상하 16 / 좌우 20)

**3. 키워드 박스 패딩** — 빈 상태·목록 두 곳 모두 `px-5 py-8`(20/32) → `p-4`(16). 박스 높이는 `min-h-32`가 잡고 있어 여백만 줄고 크기는 그대로입니다.

이슈에서 "이미 맞다"고 한 값들(`gap-6`, `gap-1`, `gap-2`, `rounded-xl`, `border-border-subtle`, 헤더 56/좌우 20)은 건드리지 않았습니다.

## 관련 이슈

- Closes #110
- Refs #54

## 검증 방법

최신 `origin/dev`(222de3e)에서 브랜치를 따 작업했습니다.

```
$ npm run lint
(경고·오류 없음, 출력 없이 종료)

$ npm run test
 Test Files  5 passed (5)
      Tests  102 passed (102)
   Duration  2.23s

$ npm run build
✓ Compiled successfully in 11.1s
✓ Generating static pages using 7 workers (9/9) in 898ms
```

수동 확인은 리뷰어가 아래를 봐주시면 됩니다.

- `/e/<code>/live?sessionId=<id>` 진입 — 스켈레톤에서 실제 화면으로 넘어갈 때 감정 막대와 키워드 박스가 세로로 튀지 않는지 (네트워크 스로틀링을 걸면 잘 보입니다)
- 같은 화면에서 스냅샷만 늦게 올 때 — 제목이 두 번 나오지 않는지
- 여백 — content 상하 16 / 좌우 20, 키워드 박스 안쪽 16인지

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

`LiveSkeleton`에 선택적 prop이 하나 늘었지만 기본값이 기존 동작이라 기존 호출부(`LiveResult.tsx:184`)는 수정 없이 그대로 동작합니다.

## 트러블슈팅 및 참고 사항

이슈 본문은 "`LiveSkeleton`에 `PageHeading` 자리 추가"라고만 적혀 있어 그대로 따르면 `LiveResult` 안쪽 사용처에서 제목이 중복됩니다. 두 사용처를 확인하고 prop으로 갈랐습니다. 리뷰 시 이 판단이 맞는지 봐주시면 좋겠습니다 — 대안으로는 제목 자리표시자를 별도 컴포넌트로 빼서 `page.tsx`에서 `LiveSkeleton`과 나란히 두는 방법도 있습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
