### PR TITLE
feat(event): 이벤트 설정 화면에 뒤로가기 버튼 추가

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -8,6 +8,7 @@ import { Textarea } from '@/components/ui/Textarea';
 import { Button } from '@/components/ui/Button';
 import { Banner } from '@/components/ui/Banner';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { ChevronLeftIcon } from '@/components/ui/icons';
 import ReportPanel from '@/components/report/ReportPanel';
 import { showToast } from '@/hooks/useToast';
 import { eventCreateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
@@ -221,6 +222,16 @@ const EventForm = ({ eventCode }: EventFormProps) => {
 
   return (
     <>
+      <div className="w-full max-w-190">
+        <button
+          type="button"
+          className="-ml-1 flex cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
+          aria-label="이벤트 목록으로 돌아가기"
+          onClick={() => router.push('/events')}
+        >
+          <ChevronLeftIcon className="h-6 w-6" />
+        </button>
+      </div>
       <h1 className="w-full max-w-190 text-xl font-semibold text-text-primary">이벤트 설정</h1>
       <form onSubmit={handleFormSubmit} className="w-full max-w-190 flex flex-col gap-6">
         <Field

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -47,5 +47,17 @@ const ChevronRightIcon = (props: IconProps) => (
   </svg>
 );
 
-export { AlertIcon, CheckIcon, InfoIcon, XIcon, ChevronRightIcon };
+const ChevronLeftIcon = (props: IconProps) => (
+  <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true" {...props}>
+    <path
+      d="M11.25 4.5L6.75 9L11.25 13.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+export { AlertIcon, CheckIcon, InfoIcon, XIcon, ChevronRightIcon, ChevronLeftIcon };
 export type { IconProps };


### PR DESCRIPTION
## 변경 사항
- 이벤트 설정 화면(`components/events/EventForm.tsx`)에 뒤로가기 버튼을 추가했습니다. 
`이벤트 설정` 제목 위 별도 줄에 왼쪽 화살표 아이콘(`ChevronLeftIcon`, `components/ui/icons.tsx`에 신규 추가) 버튼을 놓았고, 클릭하면 `/events`(이벤트 목록)로 이동합니다.
- 이 요소는 Figma 시안(node-id `3142-2238`)에는 없습니다. 
실사용성 테스트 중 발견된 사항(이슈 #169 참고)이라, 
위치·모양에 대한 팀 논의를 위해 draft로 먼저 공유합니다.
> <img width="927" height="878" alt="shot-msy5vih3" src="https://github.com/user-attachments/assets/fef4ccd5-b346-461d-9ab4-0e478f0093c3" />

## 관련 이슈

- Refs #169

## 검증 방법

- `npx tsc --noEmit`, `npm run lint` 모두 통과했습니다.

**뒤로가기 버튼 화면**
<!-- 스크린샷 첨부 위치 -->

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `status`가 `ENDED`인 이벤트는 `EventForm` 대신 `ReportPanel`이 렌더링되어 이번 버튼이 적용되지 않습니다. 이번 변경 범위 밖이라 별도로 다루지 않았습니다.

## 트러블슈팅 및 참고 사항

- 처음 구현 시 `ChevronLeftIcon`에 크기 클래스를 지정하지 않아 기본값(18px)으로 작게 렌더링됐습니다. 다른 아이콘 사용처(`EventCard.tsx`의 `ChevronRightIcon`, `EventListEmptyState.tsx`의 `InfoIcon`)와 같은 방식으로 `h-6 w-6`(24px)를 지정해 해결했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
