### PR TITLE
fix(dashboard): 헤더의 이벤트 상태 배지를 한글 표기로 맞춘다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -25,6 +25,7 @@ import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
 import { Donut } from '@/components/feedback/Donut';
 import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
 import { Thermometer } from '@/components/feedback/Thermometer';
+import { EVENT_STATUS_BADGE, isVisibleEvent } from '@/components/events/eventStatusBadge';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
@@ -258,7 +259,14 @@ const DashboardView = () => {
    * 같아서 문구를 나누지 않습니다. 나누면 코드를 하나씩 넣어보며 남의 이벤트가 실재하는지
    * 알아낼 수 있습니다.
    */
-  const event = events.find((item) => item.code === eventCode) ?? null;
+  const found = events.find((item) => item.code === eventCode) ?? null;
+
+  /*
+   * `DELETED`도 "볼 수 없다"로 접습니다. 목록 응답에서 이미 빠지는 상태라 실제로는 오지
+   * 않지만, 여기서 좁혀야 아래 상태 배지 표(`EVENT_STATUS_BADGE`)가 DELETED 없는 키로
+   * 안전하게 인덱싱됩니다.
+   */
+  const event = found !== null && isVisibleEvent(found) ? found : null;
 
   if (event === null) {
     return <Banner type="negative">이 이벤트를 볼 수 없어요</Banner>;
@@ -382,7 +390,10 @@ const DashboardView = () => {
         <div className="flex flex-col gap-1">
           <div className="flex items-center gap-2">
             <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
-            <Badge tone={event.status === 'LIVE' ? 'positive' : 'neutral'}>{event.status}</Badge>
+            {/* 이벤트 목록과 같은 표를 씁니다. 따로 쓰면 #192처럼 한쪽만 한글화되는 일이 반복됩니다. */}
+            <Badge tone={EVENT_STATUS_BADGE[event.status].tone}>
+              {EVENT_STATUS_BADGE[event.status].label}
+            </Badge>
           </div>
           {/* 복사되는 값과 같은 것을 보여줍니다. 다르면 눈으로 옮겨 적는 사람이 틀립니다. */}
           <p className="text-xs font-normal leading-4 break-all text-primary-darker">{publicUrl}</p>

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -3,19 +3,11 @@ import { Badge } from '@/components/ui/Badge';
 import { ChevronRightIcon } from '@/components/ui/icons';
 import Link from 'next/link';
 import formatEventDate from '@/lib/formatEventDate';
+import { EVENT_STATUS_BADGE } from '@/components/events/eventStatusBadge';
 
 export interface EventCardProps {
   event: PulseEvent;
 }
-
-const TONE_BY_STATUS: Record<
-  'LIVE' | 'DRAFT' | 'ENDED',
-  { tone: 'positive' | 'neutral' | 'info'; label: string }
-> = {
-  LIVE: { tone: 'positive', label: '● 진행 중' },
-  DRAFT: { tone: 'neutral', label: '준비 중' },
-  ENDED: { tone: 'info', label: '종료' },
-};
 
 const RIGHT_CONTENT_BY_STATUS = {
   LIVE: (event: PulseEvent) => ({
@@ -38,7 +30,7 @@ const ROUTE_BY_STATUS = {
 const EventCard = ({ event }: EventCardProps) => {
   if (event.status === 'DELETED') return;
 
-  const { tone, label } = TONE_BY_STATUS[event.status];
+  const { tone, label } = EVENT_STATUS_BADGE[event.status];
 
   // TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가 추가되면 해당 날짜로 사용해야 함.
   const datetime = formatEventDate(event.createdAt);

--- a/components/events/eventStatusBadge.ts
+++ b/components/events/eventStatusBadge.ts
@@ -1,0 +1,31 @@
+import type { BadgeTone } from '@/components/ui/Badge';
+import type { EventStatus, PulseEvent } from '@/lib/schemas/api';
+
+/**
+ * 이벤트 상태 배지의 톤·한글 라벨 표입니다.
+ *
+ * 이벤트 목록(`EventCard`)과 대시보드 헤더(`DashboardView`)가 같은 상태를 다른 자리에서
+ * 그립니다. 표가 한 곳에 있어야 라벨을 바꿀 때 두 화면이 갈라지지 않습니다 — #192가
+ * 목록만 한글화하고 대시보드를 빠뜨린 것이 이 표를 만든 이유입니다.
+ *
+ * `DELETED`는 없습니다. 삭제된 이벤트는 목록 응답에서 빠지고 화면도 그리지 않습니다.
+ */
+type VisibleEventStatus = Exclude<EventStatus, 'DELETED'>;
+
+const EVENT_STATUS_BADGE: Record<VisibleEventStatus, { tone: BadgeTone; label: string }> = {
+  LIVE: { tone: 'positive', label: '● 진행 중' },
+  DRAFT: { tone: 'neutral', label: '준비 중' },
+  ENDED: { tone: 'info', label: '종료' },
+};
+
+/**
+ * 화면에 그릴 수 있는 이벤트인지 봅니다.
+ *
+ * 위 표가 `DELETED` 키를 갖지 않아서, 상태를 좁히지 않은 이벤트로는 표를 인덱싱할 수
+ * 없습니다. `event.status !== 'DELETED'` 비교만으로는 `event` 자체가 좁혀지지 않아
+ * 타입 가드로 둡니다.
+ */
+const isVisibleEvent = (event: PulseEvent): event is PulseEvent & { status: VisibleEventStatus } =>
+  event.status !== 'DELETED';
+
+export { EVENT_STATUS_BADGE, isVisibleEvent, type VisibleEventStatus };

--- a/components/ui/Badge.tsx
+++ b/components/ui/Badge.tsx
@@ -25,4 +25,4 @@ const Badge = ({ tone, className = '', ...props }: BadgeProps) => {
   return <span className={`${BASE} ${TONE[tone]} ${className}`} {...props} />;
 };
 
-export { Badge };
+export { Badge, type BadgeTone };


### PR DESCRIPTION
## 변경 사항

대시보드 헤더의 이벤트 상태 배지가 **영문으로 남아 있었습니다.**

#192에서 상태 표기를 한글로 바꿨는데 손댄 곳이 `EventCard`와 `EventStatusFilterTabs` 둘뿐이었습니다. 대시보드 헤더는 `event.status`를 그대로 그리고 있어서, **같은 이벤트가 목록에서는 `● 진행 중`, 대시보드에서는 `LIVE`**로 보였습니다.

## 원인

상태 → 라벨·톤 대응이 `EventCard.tsx` 안에만 있었습니다.

```tsx
// components/events/EventCard.tsx — 변경 전
const TONE_BY_STATUS: Record<'LIVE' | 'DRAFT' | 'ENDED', { tone: ...; label: string }> = { ... };
```

**같은 상태를 그리는 자리가 둘인데 표가 한 곳에만 있으면**, 한쪽을 바꿔도 다른 쪽이 안 따라옵니다. #192가 정확히 그렇게 빠뜨렸습니다.

## 수정

표를 밖으로 뺐습니다.

```ts
// components/events/eventStatusBadge.ts
const EVENT_STATUS_BADGE: Record<VisibleEventStatus, { tone: BadgeTone; label: string }> = {
  LIVE: { tone: 'positive', label: '● 진행 중' },
  DRAFT: { tone: 'neutral', label: '준비 중' },
  ENDED: { tone: 'info', label: '종료' },
};
```

문구를 다시 바꿀 때 두 화면이 갈라지지 않게 하는 것이 목적이라, **라벨만이 아니라 톤도 같이** 옮겼습니다.

### `DELETED`를 표에 넣지 않은 이유

삭제된 이벤트는 목록 응답에서 빠지고 화면도 그리지 않습니다. 표에 없는 상태를 억지로 채우면 "이 배지는 언제 뜨나"를 판단할 근거가 없어집니다.

다만 `event.status !== 'DELETED'` 비교만으로는 `event` 자체가 좁혀지지 않아 타입 가드를 뒀습니다.

```ts
const isVisibleEvent = (event: PulseEvent): event is PulseEvent & { status: VisibleEventStatus } =>
  event.status !== 'DELETED';
```

이게 없으면 `DELETED` 키가 없는 표를 인덱싱할 수 없습니다.

### `BadgeTone`을 export한 이유

표가 톤 값을 들고 있으려면 그 타입이 밖에서 보여야 합니다. 문자열 리터럴 유니온을 손으로 다시 적으면 **`Badge`의 톤이 늘어날 때 따라오지 않습니다.**

```tsx
- export { Badge };
+ export { Badge, type BadgeTone };
```

## 관련 이슈

- Closes #209
- Refs #191, #192

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 7.2s / ✓ Finished TypeScript in 6.6s
npm run test    ✓ 5 files, 102 tests passed (1.16s)
```

이벤트 목록과 대시보드 헤더에서 같은 이벤트의 배지 문구가 일치하는지 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `Badge`가 `BadgeTone` 타입을 새로 export합니다. 기존 사용처에는 영향이 없습니다.

## 트러블슈팅 및 참고 사항

### 시안도 같이 고쳐야 합니다

대시보드 시안의 상태 배지가 아직 `● LIVE`입니다. 한쪽만 바꾸면 다음에 대조할 때 또 어긋납니다.

### 남은 TODO

`EventCard.tsx`에 조건이 충족된 TODO가 남아 있습니다.

```tsx
// TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가
// 추가되면 해당 날짜로 사용해야 함.
const datetime = formatEventDate(event.createdAt);
```

`eventDate`가 이미 명세에 들어와 있어서 목록에 **등록일이 뜨고 있습니다.** 이 PR 범위가 아니라 별도 이슈로 넘깁니다. 공개 리포트 화면에서는 같은 건을 이미 고쳤습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
