### PR TITLE
fix(live): 라이브 결과 화면의 폭을 형제 페이지와 맞춘다

### DIFF
--- a/app/e/[code]/live/page.tsx
+++ b/app/e/[code]/live/page.tsx
@@ -40,8 +40,12 @@ const LivePage = async ({ params, searchParams }: PageProps<'/e/[code]/live'>) =
     redirect(`/e/${code}`);
   }
 
+  /*
+   * 폭은 형제 페이지(`/e/[code]`·`report`·not-found)와 같은 열에 맞춥니다. 레이아웃의
+   * 로고도 `max-w-md`라, 여기만 넓히면 넓은 화면에서 로고와 본문의 왼쪽 끝이 어긋납니다.
+   */
   return (
-    <main className="flex flex-col gap-6 p-5">
+    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
       <Suspense fallback={<LiveSkeleton />}>
         <LiveResult />
       </Suspense>


### PR DESCRIPTION
## 변경 사항

참가자 공개 화면 중 **라이브 결과 화면만 폭 제한이 없어** 넓은 화면에서 본문이 전체 폭으로 늘어났습니다.

```tsx
- <main className="flex flex-col gap-6 p-5">
+ <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
```

같은 그룹의 나머지는 전부 `max-w-md` 모바일 열에 고정돼 있습니다.

| 화면 | 클래스 |
|---|---|
| `app/e/[code]/layout.tsx` (로고 헤더) | `mx-auto w-full max-w-md px-5` |
| `app/e/[code]/page.tsx` | `mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4` |
| `app/e/[code]/report/page.tsx` | 동일 |
| `app/e/[code]/not-found.tsx` | 동일 |
| **`app/e/[code]/live/page.tsx`** | **`flex flex-col gap-6 p-5`** ← 폭 제한 없음 |

## 왜 문제인가

**로고와 본문의 왼쪽 끝이 어긋납니다.** 레이아웃의 로고가 `max-w-md` 열 안에 있는데 본문만 화면 전체로 퍼지면, 데스크탑에서 로고는 가운데 열에 있고 온도계·워드클라우드는 양옆 끝까지 늘어납니다.

참가자 화면은 QR로 들어오는 모바일 전용이라 시안이 393px 하나뿐입니다. 하지만 **주소를 복사해 데스크탑에서 여는 경로가 막혀 있지 않습니다.** 주최자가 링크를 공유하면 노트북에서 열립니다.

## `p-5` → `px-5 py-4`

상하 여백이 20에서 16으로 줄어듭니다. 형제 페이지 셋이 전부 `py-4`라 그쪽에 맞췄습니다.

## 주석을 같이 넣었습니다

```tsx
/*
 * 폭은 형제 페이지(`/e/[code]`·`report`·not-found)와 같은 열에 맞춥니다. 레이아웃의
 * 로고도 `max-w-md`라, 여기만 넓히면 넓은 화면에서 로고와 본문의 왼쪽 끝이 어긋납니다.
 */
```

같은 취지의 주석이 `report/page.tsx`에는 이미 있는데 여기에만 없었습니다. **왜 폭을 묶어두는지가 적혀 있지 않으면 다음 사람이 또 뺍니다.**

## 관련 이슈

- Closes #207

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 7.6s / ✓ Finished TypeScript in 5.9s
npm run test    ✓ 5 files, 102 tests passed (1.11s)
```

넓은 화면에서 로고와 본문의 왼쪽 끝이 맞는지 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- 모바일(393px)에서는 `max-w-md`(448px)에 안 걸려서 **보이는 변화가 상하 여백 4px뿐**입니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
