### PR TITLE
refactor(dashboard): DashboardView를 카드 단위 컴포넌트로 나눈다

### DIFF
--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import type { ReactNode } from 'react';
+
+import { EVENT_STATUS_BADGE, type VisibleEventStatus } from '@/components/events/eventStatusBadge';
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import type { EventReportControls } from '@/hooks/useEventReport';
+import type { PulseEvent } from '@/lib/schemas/api';
+
+/**
+ * 대시보드 맨 위 줄입니다. 이벤트 제목·상태·참가자 주소를 왼쪽에, 이 화면에서 할 수 있는
+ * 조치를 오른쪽에 둡니다.
+ *
+ * 조치가 상태별로 갈리는 게 이 컴포넌트가 아는 전부입니다. 실제로 무엇을 하는지는 전부
+ * 밖에서 받습니다 — QR 모달을 여는 것도, 종료 확인을 띄우는 것도 이 화면의 다른 조각과
+ * 얽혀 있어서 헤더 혼자 정할 문제가 아닙니다.
+ */
+
+interface DashboardHeaderProps {
+  /**
+   * `DELETED`가 빠진 이벤트입니다. 상태 배지 표(`EVENT_STATUS_BADGE`)에 그 키가 없어서,
+   * 부르는 쪽이 `isVisibleEvent`로 좁힌 값을 넘겨야 합니다.
+   */
+  event: PulseEvent & { status: VisibleEventStatus };
+  /** 참가자가 들어오는 주소입니다. `window`를 읽어 만들기 때문에 밖에서 받습니다. */
+  publicUrl: string;
+  report: EventReportControls;
+  /**
+   * 데스크톱에서 조치 버튼 아래 서는 세션 토글입니다. 모바일에서는 세션 칩 줄이 같은 것을
+   * 그리므로, 두 자리 중 어디에 무엇을 둘지는 부르는 쪽이 정합니다.
+   */
+  sessionToggle?: ReactNode;
+  onOpenQr: () => void;
+  onCopyLink: () => void;
+  /** 확인 다이얼로그를 엽니다. 되돌릴 수 없는 전이라 버튼이 바로 쏘지 않습니다. */
+  onEndEvent: () => void;
+  isEndEventPending: boolean;
+}
+
+const DashboardHeader = ({
+  event,
+  publicUrl,
+  report,
+  sessionToggle,
+  onOpenQr,
+  onCopyLink,
+  onEndEvent,
+  isEndEventPending,
+}: DashboardHeaderProps) => (
+  <div className="flex flex-wrap items-start justify-between gap-3">
+    {/* 제목과 상태는 붙어 있어야 해서 바깥 `gap-4`에서 빼고 따로 묶습니다. */}
+    <div className="flex flex-col gap-1">
+      <div className="flex items-center gap-2">
+        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
+        {/* 이벤트 목록과 같은 표를 씁니다. 따로 쓰면 #192처럼 한쪽만 한글화되는 일이 반복됩니다. */}
+        <Badge tone={EVENT_STATUS_BADGE[event.status].tone}>
+          {EVENT_STATUS_BADGE[event.status].label}
+        </Badge>
+      </div>
+      {/* 복사되는 값과 같은 것을 보여줍니다. 다르면 눈으로 옮겨 적는 사람이 틀립니다. */}
+      <p className="text-xs font-normal leading-4 break-all text-primary-darker">{publicUrl}</p>
+    </div>
+
+    {/*
+     * QR·링크 복사·이벤트 종료는 `LIVE`에서만 내놓습니다.
+     *
+     * 종료는 서버가 허용하는 전이가 `DRAFT → LIVE`와 `LIVE → ENDED` 둘뿐이라, 그 밖에서
+     * 누르면 INVALID_EVENT_STATE_TRANSITION만 받습니다. QR과 참가자 링크는 소감을 받는
+     * 동안에만 쓸모가 있습니다 — 시작 전이거나 끝난 이벤트의 주소를 건네봐야 받는 쪽은
+     * 제출이 막힌 화면을 봅니다. 눌러보고 실패하게 두는 대신 아예 내놓지 않습니다.
+     *
+     * 리포트 공개 전환만 `ENDED` 쪽에 남습니다. 주소는 제목 아래에 늘 떠 있습니다.
+     */}
+    <div className="flex w-full flex-col gap-2 md:w-auto md:items-end">
+      <div className="flex items-center justify-between gap-2 md:justify-end">
+        {event.status === 'ENDED' && (
+          /*
+           * 모바일에서는 이 묶음이 줄을 다 차지하고(`flex-1`) 버튼만 오른쪽 끝으로
+           * 밀립니다(`ml-auto`). 배지가 함께 서는 생성 중·완료 상태에서는 배지가 왼쪽에
+           * 남아 양끝 정렬이 됩니다. 데스크톱은 `md:flex-none`으로 내용 폭인 원래
+           * 배치로 돌아가고, 그때는 밀어낼 여백이 없어 `ml-auto`도 함께 죽습니다.
+           */
+          <div className="flex flex-1 items-center gap-2 md:flex-none">
+            {report.isGenerating && <Badge tone="neutral">생성 중</Badge>}
+            {report.isGenerated && <Badge tone="positive">생성 완료</Badge>}
+
+            {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
+            {!report.isGenerated && (
+              <Button
+                variant="secondary"
+                size="sm"
+                className="ml-auto"
+                disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
+                onClick={report.generate}
+              >
+                요약 생성
+              </Button>
+            )}
+          </div>
+        )}
+        {event.status === 'LIVE' && (
+          <>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="flex-1 md:flex-none"
+              onClick={onOpenQr}
+            >
+              QR
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              className="flex-1 md:flex-none"
+              onClick={onCopyLink}
+            >
+              링크 복사
+            </Button>
+          </>
+        )}
+
+        {/*
+         * 다 만든 리포트에만 붙습니다. 만들기 전이나 만드는 중에는 뒤집을 공개 여부 자체가
+         * 없습니다(`GENERATED`가 아니면 공개해도 게스트는 404를 봅니다).
+         */}
+        {report.isGenerated && (
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={report.isTogglePublicPending}
+            onClick={report.togglePublic}
+          >
+            {report.isPublic ? '리포트 비공개' : '리포트 공개'}
+          </Button>
+        )}
+        {event.status === 'LIVE' && (
+          <Button
+            variant="secondary"
+            size="sm"
+            className="flex-1 md:flex-none"
+            aria-label="이벤트 종료"
+            disabled={isEndEventPending}
+            onClick={onEndEvent}
+          >
+            <span className="md:hidden">종료</span>
+            <span className="hidden md:inline">이벤트 종료</span>
+          </Button>
+        )}
+      </div>
+
+      {sessionToggle}
+    </div>
+  </div>
+);
+
+export { DashboardHeader };

--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -91,7 +91,7 @@ const DashboardHeader = ({
                 variant="secondary"
                 size="sm"
                 className="ml-auto"
-                disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
+                disabled={report.isGenerateDisabled}
                 onClick={report.generate}
               >
                 요약 생성

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
+import { LiveFeedCard } from '@/components/dashboard/LiveFeedCard';
 import {
   buildTrend,
   countKeywords,
@@ -18,7 +19,6 @@ import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
 import { SessionFilterBar } from '@/components/dashboard/SessionFilterBar';
 import { SessionToggle } from '@/components/dashboard/SessionToggle';
 import { Donut } from '@/components/feedback/Donut';
-import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
 import { Thermometer } from '@/components/feedback/Thermometer';
 import { isVisibleEvent } from '@/components/events/eventStatusBadge';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
@@ -26,7 +26,6 @@ import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { useCopyLink } from '@/hooks/useCopyLink';
 import { useDashboardFeed } from '@/hooks/useDashboardFeed';
@@ -387,49 +386,7 @@ const DashboardView = () => {
           </div>
 
           <div className="grid gap-3 md:grid-cols-2">
-            <section className={CARD}>
-              <h2 className={CARD_TITLE}>실시간 소감 피드</h2>
-
-              {/* 모더레이션 큐와 같은 이유로 높이를 고정합니다(`ModerationQueue.tsx`). */}
-              {visible.length === 0 ? (
-                <EmptyState
-                  className="h-80 justify-center"
-                  title="아직 들어온 소감이 없어요"
-                  description="참가자가 소감을 남기면 여기에 바로 올라와요"
-                />
-              ) : (
-                <ul className="flex h-80 flex-col gap-2 overflow-y-auto">
-                  {visible.map((feedback) => (
-                    <li key={feedback.id}>
-                      <FeedItem
-                        state="normal"
-                        sentiment={FEED_SENTIMENT[feedback.sentiment]}
-                        meta={toMeta(feedback)}
-                        content={feedback.text}
-                        /*
-                         * 자동 판정이 잡는 건 욕설뿐이라, 인신공격처럼 판정을 빠져나간 소감은
-                         * 주최자가 여기서 직접 내려야 합니다(#170).
-                         *
-                         * 삭제는 달지 않습니다. `DELETED`는 되돌릴 수 없는 종단 상태라 실시간으로
-                         * 흘러가는 목록에서 바로 누르게 둘 자리가 아닙니다. 숨기면 모더레이션
-                         * 큐로 넘어가서, 거기서 다시 보고 삭제하거나 되돌립니다.
-                         */
-                        actions={
-                          <Button
-                            variant="secondary"
-                            size="sm"
-                            disabled={moderation.isItemPending(feedback.id)}
-                            onClick={() => moderation.toggleHidden(feedback)}
-                          >
-                            숨기기
-                          </Button>
-                        }
-                      />
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </section>
+            <LiveFeedCard items={visible} formatMeta={toMeta} actions={moderation} />
 
             <div className="flex flex-col gap-3">
               <ModerationQueue items={queueItems} formatMeta={toMeta} actions={moderation} />

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -31,13 +31,9 @@ import { useCopyLink } from '@/hooks/useCopyLink';
 import { useDashboardFeed } from '@/hooks/useDashboardFeed';
 import { useEventReport } from '@/hooks/useEventReport';
 import { useModerationActions } from '@/hooks/useModerationActions';
+import { useSessionControls } from '@/hooks/useSessionControls';
 import { showToast } from '@/hooks/useToast';
-import {
-  fetchMyEvents,
-  fetchSessionsByEventCode,
-  updateEvent,
-  updateSession,
-} from '@/lib/api/endpoints';
+import { fetchMyEvents, fetchSessionsByEventCode, updateEvent } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import type { Feedback } from '@/lib/schemas/api';
 
@@ -62,15 +58,6 @@ const DashboardView = () => {
 
   const [isQrOpen, setIsQrOpen] = useState(false);
   const [isEndConfirmOpen, setIsEndConfirmOpen] = useState(false);
-
-  /*
-   * 이 화면에서 멈춘 세션입니다. 세션은 생성 시 `CLOSED`라(2026-08-07 명세) 상태만으로는 "아직
-   * 열지 않았다"와 "열었다가 멈췄다"를 가를 수 없는데, 버튼이 권하는 다음 행동은 그 둘이 다릅니다.
-   *
-   * `SessionView`에는 열린 적이 있는지 알려주는 필드가 없어서 화면이 직접 기억합니다. 새로고침하면
-   * 잊고 다른 기기에서 멈춘 것도 모릅니다 — 정확히 하려면 서버에 흔적이 필요합니다(#143).
-   */
-  const [pausedSessionIds, setPausedSessionIds] = useState<ReadonlySet<number>>(new Set());
 
   const { copy: copyLink, isFailed: isCopyFailed } = useCopyLink();
 
@@ -151,28 +138,8 @@ const DashboardView = () => {
   /* 조회·생성·공개 전환이 같은 캐시 칸을 두고 움직여서 한 훅으로 묶여 있습니다. */
   const report = useEventReport(eventCode, eventStatus);
 
-  /*
-   * 선택한 세션의 소감 수신을 켜고 끕니다. 세션은 생성 시 `CLOSED`라, 발표가 시작될 때 주최자가
-   * 열어야 소감이 들어옵니다(2026-08-07 명세).
-   *
-   * 이벤트 종료와 달리 확인 다이얼로그를 두지 않습니다. `ACTIVE ↔ CLOSED`는 되돌릴 수 있어서
-   * 잘못 눌러도 다시 누르면 그만입니다.
-   */
-  const toggleSessionMutation = useMutation({
-    mutationFn: ({ id, status }: { id: number; status: 'ACTIVE' | 'CLOSED' }) =>
-      updateSession(eventCode, id, { status }),
-    onSuccess: (session) => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
-      /* 다시 열면 지웁니다. 남겨두면 멈췄다 연 세션을 또 멈출 때가 아니라 처음 열 때부터 "다시"가 됩니다. */
-      setPausedSessionIds((previous) => {
-        const next = new Set(previous);
-        if (session.status === 'ACTIVE') next.delete(session.id);
-        else next.add(session.id);
-        return next;
-      });
-      showToast(session.status === 'ACTIVE' ? '이제 소감을 받아요' : '소감 받기를 멈췄어요');
-    },
-  });
+  /* 뒤집기와 「이 화면에서 멈춘 세션인가」 판정이 한 덩어리라 훅으로 묶여 있습니다. */
+  const sessionControls = useSessionControls(eventCode);
 
   const handleSelectSession = (nextSessionId: number | null) => {
     setSessionId(nextSessionId);
@@ -290,10 +257,6 @@ const DashboardView = () => {
   const selectedSession =
     sessionId === null ? null : (sessions.find((session) => session.id === sessionId) ?? null);
 
-  /* 같은 `CLOSED`라도 이 화면에서 멈춘 세션은 "다시", 아직 안 연 세션은 "처음"입니다. */
-  const isSelectedSessionPaused =
-    selectedSession !== null && pausedSessionIds.has(selectedSession.id);
-
   /*
    * 세션 토글은 데스크톱에선 헤더 안, 모바일에선 칩 줄 아래에 섭니다. 부모가 달라 CSS로는 옮길
    * 수 없어서 자리마다 하나씩 두고 `className`으로 감춥니다. 조건과 넘기는 값이 같으므로
@@ -307,9 +270,9 @@ const DashboardView = () => {
     event.status === 'LIVE' && selectedSession !== null ? (
       <SessionToggle
         session={selectedSession}
-        isPaused={isSelectedSessionPaused}
-        isPending={toggleSessionMutation.isPending}
-        onToggle={(status) => toggleSessionMutation.mutate({ id: selectedSession.id, status })}
+        isPaused={sessionControls.isPaused(selectedSession.id)}
+        isPending={sessionControls.isPending}
+        onToggle={(status) => sessionControls.toggle(selectedSession.id, status)}
         className={className}
       />
     ) : null;
@@ -341,7 +304,7 @@ const DashboardView = () => {
       {report.isTogglePublicError && (
         <Banner type="negative">리포트 공개 설정을 바꾸지 못했어요</Banner>
       )}
-      {toggleSessionMutation.isError && (
+      {sessionControls.isError && (
         <Banner type="negative">세션의 소감 수신 상태를 바꾸지 못했어요</Banner>
       )}
       {isCopyFailed && (

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -3,16 +3,6 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
-import {
-  CartesianGrid,
-  Line,
-  LineChart,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
-
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import {
@@ -20,9 +10,9 @@ import {
   countKeywords,
   summarizeSentiments,
   toRelativeTime,
-  TREND_BUCKET_MS,
 } from '@/components/dashboard/metrics';
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
+import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
 import { SessionToggle } from '@/components/dashboard/SessionToggle';
 import { Donut } from '@/components/feedback/Donut';
 import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
@@ -410,83 +400,13 @@ const DashboardView = () => {
               />
             </section>
 
-            <section className={CARD}>
-              <div className="flex items-center justify-between gap-2">
-                <h2 className={CARD_TITLE}>시간대별 감정 추이</h2>
-                {refreshIntervalMs !== null && (
-                  <span className="text-xs font-normal leading-4 text-text-tertiary">
-                    {refreshIntervalMs / 1000}초마다 갱신
-                  </span>
-                )}
-              </div>
-
-              {trend.length === 0 ? (
-                <p className="flex h-40 items-center justify-center text-sm text-text-tertiary">
-                  아직 그릴 소감이 없어요
-                </p>
-              ) : (
-                /* 색만으로는 세 선이 구분되지 않아 스크린리더용 설명을 따로 답니다. */
-                <div
-                  className="h-40"
-                  role="img"
-                  aria-label={`${TREND_BUCKET_MS / 60_000}분 단위 감정별 소감 건수 추이. 긍정 ${positive}건, 중립 ${neutral}건, 부정 ${negative}건.`}
-                >
-                  <ResponsiveContainer width="100%" height="100%">
-                    <LineChart data={trend} margin={{ top: 8, right: 8, bottom: 0, left: -24 }}>
-                      <CartesianGrid
-                        strokeDasharray="3 3"
-                        stroke="var(--color-border-subtle)"
-                        vertical={false}
-                      />
-                      <XAxis
-                        dataKey="label"
-                        tickLine={false}
-                        axisLine={false}
-                        tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
-                      />
-                      <YAxis
-                        allowDecimals={false}
-                        tickLine={false}
-                        axisLine={false}
-                        width={40}
-                        tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
-                      />
-                      <Tooltip
-                        contentStyle={{
-                          borderRadius: '0.5rem',
-                          border: '1px solid var(--color-border-subtle)',
-                          fontSize: '0.75rem',
-                        }}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="POS"
-                        name="긍정"
-                        stroke="var(--color-positive-default)"
-                        strokeWidth={2}
-                        dot={false}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="NEU"
-                        name="중립"
-                        stroke="var(--color-neutral-default)"
-                        strokeWidth={2}
-                        dot={false}
-                      />
-                      <Line
-                        type="monotone"
-                        dataKey="NEG"
-                        name="부정"
-                        stroke="var(--color-negative-default)"
-                        strokeWidth={2}
-                        dot={false}
-                      />
-                    </LineChart>
-                  </ResponsiveContainer>
-                </div>
-              )}
-            </section>
+            <SentimentTrendCard
+              trend={trend}
+              positive={positive}
+              neutral={neutral}
+              negative={negative}
+              refreshIntervalMs={refreshIntervalMs}
+            />
           </div>
 
           <div className="grid gap-3 md:grid-cols-2">

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -13,6 +13,7 @@ import {
   YAxis,
 } from 'recharts';
 
+import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import {
   buildTrend,
@@ -22,10 +23,11 @@ import {
   TREND_BUCKET_MS,
 } from '@/components/dashboard/metrics';
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
+import { SessionToggle } from '@/components/dashboard/SessionToggle';
 import { Donut } from '@/components/feedback/Donut';
 import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
 import { Thermometer } from '@/components/feedback/Thermometer';
-import { EVENT_STATUS_BADGE, isVisibleEvent } from '@/components/events/eventStatusBadge';
+import { isVisibleEvent } from '@/components/events/eventStatusBadge';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
@@ -314,146 +316,38 @@ const DashboardView = () => {
   const isSelectedSessionPaused =
     selectedSession !== null && pausedSessionIds.has(selectedSession.id);
 
+  /*
+   * 세션 토글은 데스크톱에선 헤더 안, 모바일에선 칩 줄 아래에 섭니다. 부모가 달라 CSS로는 옮길
+   * 수 없어서 자리마다 하나씩 두고 `className`으로 감춥니다. 조건과 넘기는 값이 같으므로
+   * 여기서 한 번만 만듭니다.
+   *
+   * `LIVE`에서만 내놓습니다. 제출은 이벤트가 `LIVE`이고 세션이 `ACTIVE`여야 통과하는데,
+   * 시작 전이나 끝난 뒤에 세션만 열어두면 화면은 "소감 받는 중"이라고 하고 참가자는
+   * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다.
+   */
+  const renderSessionToggle = (className: string) =>
+    event.status === 'LIVE' && selectedSession !== null ? (
+      <SessionToggle
+        session={selectedSession}
+        isPaused={isSelectedSessionPaused}
+        isPending={toggleSessionMutation.isPending}
+        onToggle={(status) => toggleSessionMutation.mutate({ id: selectedSession.id, status })}
+        className={className}
+      />
+    ) : null;
+
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        {/* 제목과 상태는 붙어 있어야 해서 바깥 `gap-4`에서 빼고 따로 묶습니다. */}
-        <div className="flex flex-col gap-1">
-          <div className="flex items-center gap-2">
-            <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
-            {/* 이벤트 목록과 같은 표를 씁니다. 따로 쓰면 #192처럼 한쪽만 한글화되는 일이 반복됩니다. */}
-            <Badge tone={EVENT_STATUS_BADGE[event.status].tone}>
-              {EVENT_STATUS_BADGE[event.status].label}
-            </Badge>
-          </div>
-          {/* 복사되는 값과 같은 것을 보여줍니다. 다르면 눈으로 옮겨 적는 사람이 틀립니다. */}
-          <p className="text-xs font-normal leading-4 break-all text-primary-darker">{publicUrl}</p>
-        </div>
-
-        {/*
-         * QR·링크 복사·이벤트 종료는 `LIVE`에서만 내놓습니다.
-         *
-         * 종료는 서버가 허용하는 전이가 `DRAFT → LIVE`와 `LIVE → ENDED` 둘뿐이라, 그 밖에서
-         * 누르면 INVALID_EVENT_STATE_TRANSITION만 받습니다. QR과 참가자 링크는 소감을 받는
-         * 동안에만 쓸모가 있습니다 — 시작 전이거나 끝난 이벤트의 주소를 건네봐야 받는 쪽은
-         * 제출이 막힌 화면을 봅니다. 눌러보고 실패하게 두는 대신 아예 내놓지 않습니다.
-         *
-         * 리포트 공개 전환만 `ENDED` 쪽에 남습니다. 주소는 제목 아래에 늘 떠 있습니다.
-         */}
-        <div className="flex w-full flex-col gap-2 md:w-auto md:items-end">
-          <div className="flex items-center justify-between gap-2 md:justify-end">
-            {event.status === 'ENDED' && (
-              /*
-               * 모바일에서는 이 묶음이 줄을 다 차지하고(`flex-1`) 버튼만 오른쪽 끝으로
-               * 밀립니다(`ml-auto`). 배지가 함께 서는 생성 중·완료 상태에서는 배지가 왼쪽에
-               * 남아 양끝 정렬이 됩니다. 데스크톱은 `md:flex-none`으로 내용 폭인 원래
-               * 배치로 돌아가고, 그때는 밀어낼 여백이 없어 `ml-auto`도 함께 죽습니다.
-               */
-              <div className="flex flex-1 items-center gap-2 md:flex-none">
-                {report.isGenerating && <Badge tone="neutral">생성 중</Badge>}
-                {report.isGenerated && <Badge tone="positive">생성 완료</Badge>}
-
-                {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
-                {!report.isGenerated && (
-                  <Button
-                    variant="secondary"
-                    size="sm"
-                    className="ml-auto"
-                    disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
-                    onClick={report.generate}
-                  >
-                    요약 생성
-                  </Button>
-                )}
-              </div>
-            )}
-            {event.status === 'LIVE' && (
-              <>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="flex-1 md:flex-none"
-                  onClick={() => setIsQrOpen(true)}
-                >
-                  QR
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  className="flex-1 md:flex-none"
-                  onClick={handleCopyLink}
-                >
-                  링크 복사
-                </Button>
-              </>
-            )}
-
-            {/*
-             * 다 만든 리포트에만 붙습니다. 만들기 전이나 만드는 중에는 뒤집을 공개 여부 자체가
-             * 없습니다(`GENERATED`가 아니면 공개해도 게스트는 404를 봅니다).
-             */}
-            {report.isGenerated && (
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={report.isTogglePublicPending}
-                onClick={report.togglePublic}
-              >
-                {report.isPublic ? '리포트 비공개' : '리포트 공개'}
-              </Button>
-            )}
-            {event.status === 'LIVE' && (
-              <Button
-                variant="secondary"
-                size="sm"
-                className="flex-1 md:flex-none"
-                aria-label="이벤트 종료"
-                disabled={endEventMutation.isPending}
-                onClick={() => setIsEndConfirmOpen(true)}
-              >
-                <span className="md:hidden">종료</span>
-                <span className="hidden md:inline">이벤트 종료</span>
-              </Button>
-            )}
-          </div>
-
-          {/*
-           * 선택한 세션의 소감 수신 상태와 그걸 뒤집는 버튼입니다.
-           *
-           * `LIVE`에서만 내놓습니다. 제출은 이벤트가 `LIVE`이고 세션이 `ACTIVE`여야 통과하는데,
-           * 시작 전이나 끝난 뒤에 세션만 열어두면 여기서는 "소감 받는 중"이라고 하고 참가자는
-           * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다.
-           */}
-          {event.status === 'LIVE' && selectedSession !== null && (
-            <div className="hidden items-center gap-2 md:flex">
-              <Badge tone={selectedSession.status === 'ACTIVE' ? 'positive' : 'neutral'}>
-                {selectedSession.status === 'ACTIVE'
-                  ? '소감 받는 중'
-                  : isSelectedSessionPaused
-                    ? '소감 멈춤'
-                    : '시작 전'}
-              </Badge>
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={toggleSessionMutation.isPending}
-                onClick={() =>
-                  toggleSessionMutation.mutate({
-                    id: selectedSession.id,
-                    status: selectedSession.status === 'ACTIVE' ? 'CLOSED' : 'ACTIVE',
-                  })
-                }
-              >
-                {selectedSession.status === 'ACTIVE'
-                  ? '멈추기'
-                  : isSelectedSessionPaused
-                    ? '다시 받기'
-                    : '소감 받기'}
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
+      <DashboardHeader
+        event={event}
+        publicUrl={publicUrl}
+        report={report}
+        sessionToggle={renderSessionToggle('hidden md:flex')}
+        onOpenQr={() => setIsQrOpen(true)}
+        onCopyLink={handleCopyLink}
+        onEndEvent={() => setIsEndConfirmOpen(true)}
+        isEndEventPending={endEventMutation.isPending}
+      />
 
       <div className="flex flex-wrap items-center gap-2">
         <Chip selected={sessionId === null} onClick={() => handleSelectSession(null)}>
@@ -471,34 +365,7 @@ const DashboardView = () => {
         <span className="ml-auto text-xs font-normal leading-4 text-text-tertiary">
           총 {sessions.length}개 중 {openSessionCount}개 열림
         </span>
-        {event.status === 'LIVE' && selectedSession !== null && (
-          <div className="flex w-full items-center justify-between gap-2 md:hidden">
-            <Badge tone={selectedSession.status === 'ACTIVE' ? 'positive' : 'neutral'}>
-              {selectedSession.status === 'ACTIVE'
-                ? '소감 받는 중'
-                : isSelectedSessionPaused
-                  ? '소감 멈춤'
-                  : '시작 전'}
-            </Badge>
-            <Button
-              variant="secondary"
-              size="sm"
-              disabled={toggleSessionMutation.isPending}
-              onClick={() =>
-                toggleSessionMutation.mutate({
-                  id: selectedSession.id,
-                  status: selectedSession.status === 'ACTIVE' ? 'CLOSED' : 'ACTIVE',
-                })
-              }
-            >
-              {selectedSession.status === 'ACTIVE'
-                ? '멈추기'
-                : isSelectedSessionPaused
-                  ? '다시 받기'
-                  : '소감 받기'}
-            </Button>
-          </div>
-        )}
+        {renderSessionToggle('flex w-full justify-between md:hidden')}
       </div>
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
+import { KeywordCard } from '@/components/dashboard/KeywordCard';
 import { LiveFeedCard } from '@/components/dashboard/LiveFeedCard';
 import {
   buildTrend,
@@ -22,7 +23,6 @@ import { Donut } from '@/components/feedback/Donut';
 import { Thermometer } from '@/components/feedback/Thermometer';
 import { isVisibleEvent } from '@/components/events/eventStatusBadge';
 import { ModerationQueue } from '@/components/moderation/ModerationQueue';
-import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
@@ -354,23 +354,7 @@ const DashboardView = () => {
             <div className="flex flex-col gap-3">
               <ModerationQueue items={queueItems} formatMeta={toMeta} actions={moderation} />
 
-              <section className={CARD}>
-                <h2 className={CARD_TITLE}>상위 키워드</h2>
-
-                {keywords.length === 0 ? (
-                  <p className="text-sm text-text-tertiary">아직 모인 키워드가 없어요</p>
-                ) : (
-                  <ul className="flex flex-wrap gap-2">
-                    {keywords.map(([keyword, count]) => (
-                      <li key={keyword}>
-                        <Badge tone="outline">
-                          {keyword} {count}
-                        </Badge>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </section>
+              <KeywordCard keywords={keywords} />
             </div>
           </div>
 

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -15,6 +15,7 @@ import {
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
 import { ReportSection } from '@/components/dashboard/ReportSection';
 import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
+import { SessionFilterBar } from '@/components/dashboard/SessionFilterBar';
 import { SessionToggle } from '@/components/dashboard/SessionToggle';
 import { Donut } from '@/components/feedback/Donut';
 import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
@@ -24,7 +25,6 @@ import { ModerationQueue } from '@/components/moderation/ModerationQueue';
 import { Badge } from '@/components/ui/Badge';
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
-import { Chip } from '@/components/ui/Chip';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
@@ -231,8 +231,6 @@ const DashboardView = () => {
     return <DashboardSkeleton />;
   }
 
-  const openSessionCount = sessions.filter((session) => session.status === 'ACTIVE').length;
-
   /*
    * 참가자가 QR을 찍거나 링크를 눌러 들어오는 주소입니다. 배포 도메인을 환경 변수로 들고 있지
    * 않아서 지금 출처를 알 방법은 브라우저가 열고 있는 주소뿐입니다.
@@ -330,24 +328,12 @@ const DashboardView = () => {
         isEndEventPending={endEventMutation.isPending}
       />
 
-      <div className="flex flex-wrap items-center gap-2">
-        <Chip selected={sessionId === null} onClick={() => handleSelectSession(null)}>
-          전체
-        </Chip>
-        {sessions.map((session) => (
-          <Chip
-            key={session.id}
-            selected={sessionId === session.id}
-            onClick={() => handleSelectSession(session.id)}
-          >
-            {session.title}
-          </Chip>
-        ))}
-        <span className="ml-auto text-xs font-normal leading-4 text-text-tertiary">
-          총 {sessions.length}개 중 {openSessionCount}개 열림
-        </span>
-        {renderSessionToggle('flex w-full justify-between md:hidden')}
-      </div>
+      <SessionFilterBar
+        sessions={sessions}
+        selectedSessionId={sessionId}
+        onSelectSession={handleSelectSession}
+        sessionToggle={renderSessionToggle('flex w-full justify-between md:hidden')}
+      />
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
       {moderation.isError && <Banner type="negative">소감 처리에 실패했어요</Banner>}

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -3,6 +3,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
 import { useState } from 'react';
+
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import {
@@ -12,6 +13,7 @@ import {
   toRelativeTime,
 } from '@/components/dashboard/metrics';
 import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
+import { ReportSection } from '@/components/dashboard/ReportSection';
 import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
 import { SessionToggle } from '@/components/dashboard/SessionToggle';
 import { Donut } from '@/components/feedback/Donut';
@@ -287,17 +289,6 @@ const DashboardView = () => {
   const toMeta = (feedback: Feedback) =>
     `${toRelativeTime(feedback.createdAt)} · ${sessionTitle(feedback.sessionId)}`;
 
-  /*
-   * 리포트 카드의 상태 배지입니다. 모바일에선 제목 옆, 데스크톱에선 오른쪽 조치 자리에
-   * 서는데 부모가 달라 CSS로는 옮길 수 없습니다. 두 자리에 같은 것을 두고 감싸는 span으로
-   * 하나씩 감추므로, 본문은 여기서 한 번만 만듭니다.
-   */
-  const reportBadge = report.isGenerating ? (
-    <Badge tone="neutral">생성 중</Badge>
-  ) : report.isGenerated ? (
-    <Badge tone="positive">생성 완료</Badge>
-  ) : null;
-
   /* 칩에서 고른 세션입니다. "전체"(`null`)에는 켜고 끌 대상이 없어 아래 토글을 감춥니다. */
   const selectedSession =
     sessionId === null ? null : (sessions.find((session) => session.id === sessionId) ?? null);
@@ -477,71 +468,7 @@ const DashboardView = () => {
             </div>
           </div>
 
-          {/*
-           * 카드 아래 한 줄이 상태에 따라 다른 일을 합니다. 생성 전에는 왜 눌러야 하는지 알리는
-           * 안내문이고, 끝나면 요약 본문이 그 자리에 들어옵니다. 자리를 나누지 않는 이유는
-           * 안내문이 요약이 없을 때만 필요한 문장이라서입니다.
-           *
-           * 생성이 끝났는데 본문이 비어 있는 경우를 따로 받습니다. 여기서 "생성하시면…"으로
-           * 되돌리면 오른쪽 버튼은 이미 빠진 뒤라(`report.isGenerated`) 시키는 대로 할 수단이
-           * 없습니다. `GENERATING` 문구로 묶지 않는 것도 같은 이유입니다 — 폴링이 `GENERATED`에서
-           * 멈춰서(위 `refetchInterval`) 기다려도 아무것도 다시 오지 않습니다.
-           */}
-          <section
-            className={`${CARD} flex-col items-start justify-between gap-4 bg-background-muted md:flex-row`}
-          >
-            <div className="flex w-full flex-col gap-1 md:w-auto">
-              {/* 배지를 오른쪽 끝에 붙이려면 이 열이 폭을 다 써야 합니다(`w-full`). */}
-              <div className="flex items-center justify-between gap-2">
-                <h2 className="text-base font-semibold leading-6 text-text-primary">
-                  AI 요약 리포트
-                </h2>
-                {reportBadge && <span className="md:hidden">{reportBadge}</span>}
-              </div>
-
-              {report.summaryText !== null ? (
-                <p className="text-sm font-normal leading-5 text-text-secondary">
-                  {report.summaryText}
-                </p>
-              ) : (
-                <p className="text-xs font-normal leading-4 text-text-tertiary">
-                  {report.isGenerating
-                    ? '요약을 만들고 있어요. 끝나면 여기에 올라와요'
-                    : report.isGenerated
-                      ? '요약 본문을 받지 못했어요. 잠시 후 다시 열어봐 주세요'
-                      : '생성하시면 읽어보고 공개할 수 있어요'}
-                </p>
-              )}
-            </div>
-
-            {/*
-             * 오른쪽은 이 카드의 상태와 조치가 함께 서는 자리입니다. 상태 배지를 제목이 아니라
-             * 여기 두는 이유는, 다 만들고 나면 버튼이 빠져서 이 자리가 비기 때문입니다.
-             *
-             * 모바일에서는 카드가 세로로 서면서 이 자리가 제목에서 멀어지므로, 배지만 제목 옆으로
-             * 올립니다(`reportBadge`). 그러면 생성 완료 상태의 모바일에서는 배지도 버튼도 없어
-             * 이 자리가 통째로 비므로 아예 감춥니다 — 안 그러면 section의 `gap-4`만 남습니다.
-             */}
-            <div
-              className={`flex w-full shrink-0 items-center gap-2 md:w-auto ${
-                report.isGenerated ? 'hidden md:flex' : ''
-              }`}
-            >
-              {reportBadge && <span className="hidden md:contents">{reportBadge}</span>}
-
-              {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
-              {!report.isGenerated && (
-                <Button
-                  className="flex-1 md:flex-none"
-                  variant="primary"
-                  disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
-                  onClick={report.generate}
-                >
-                  요약 생성
-                </Button>
-              )}
-            </div>
-          </section>
+          <ReportSection report={report} />
         </>
       )}
 

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -36,14 +36,12 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { useCopyLink } from '@/hooks/useCopyLink';
 import { useDashboardFeed } from '@/hooks/useDashboardFeed';
+import { useEventReport } from '@/hooks/useEventReport';
 import { useModerationActions } from '@/hooks/useModerationActions';
 import { showToast } from '@/hooks/useToast';
 import {
   fetchMyEvents,
-  fetchOwnReport,
   fetchSessionsByEventCode,
-  generateReport,
-  setReportPublic,
   updateEvent,
   updateSession,
 } from '@/lib/api/endpoints';
@@ -62,12 +60,6 @@ import type { Feedback } from '@/lib/schemas/api';
 
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
 const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
-
-/**
- * 리포트가 만들어지는 동안만 쓰는 간격입니다. 소감 폴링(5초)보다 짧은 이유는, 이쪽은 버튼을
- * 누른 사람이 결과를 기다리며 보고 있는 화면이라서입니다. 끝나는 즉시 타이머를 멈춥니다.
- */
-const REPORT_POLL_INTERVAL_MS = 1_500;
 
 const DashboardView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
@@ -163,48 +155,8 @@ const DashboardView = () => {
    */
   const eventStatus = events?.find((item) => item.code === eventCode)?.status;
 
-  const reportQueryKey = ['report', eventCode];
-
-  /*
-   * 리포트 행이 없는 상태(개념상 NONE)는 404 REPORT_NOT_FOUND로 옵니다. 에러로 오지만 "아직
-   * 생성하지 않았다"는 정상 상태라, 화면은 이걸 실패가 아니라 생성 전으로 읽습니다.
-   * `QueryProvider`의 `retry`가 4xx를 이미 거르므로 없는 리포트를 두들기지도 않습니다.
-   *
-   * 생성이 비동기라 폴링이 필요합니다. `GENERATING` 동안에만 돌리고 나머지 상태에서는 멈춥니다.
-   * 완료된 리포트를 계속 다시 받아봐야 같은 답이고, 여기서 멈추지 않으면 이 화면을 열어둔 내내
-   * 1.5초마다 요청이 나갑니다.
-   */
-  const reportQuery = useQuery({
-    queryKey: reportQueryKey,
-    queryFn: () => fetchOwnReport(eventCode),
-    // 생성 자체가 `ENDED`에서만 가능해서, 그 전에는 물어볼 이유가 없습니다.
-    enabled: eventStatus === 'ENDED',
-    refetchInterval: ({ state }) =>
-      state.data?.status === 'GENERATING' ? REPORT_POLL_INTERVAL_MS : false,
-  });
-
-  const generateReportMutation = useMutation({
-    mutationFn: () => generateReport(eventCode),
-    /*
-     * 202 응답이 이미 `GENERATING` 상태의 리포트입니다. 캐시에 바로 꽂아야 위 폴링이 그 자리에서
-     * 시작합니다. `invalidateQueries`로도 되지만 방금 받은 답을 한 번 더 물어보게 됩니다.
-     */
-    onSuccess: (report) => {
-      queryClient.setQueryData(reportQueryKey, report);
-    },
-  });
-
-  /*
-   * 공개 여부만 뒤집습니다. 생성 직후 리포트는 비공개라(`isPublic: false`), 공개 페이지가 열리려면
-   * 주최자가 한 번 더 눌러야 합니다. 요약을 먼저 읽어보고 내보낼지 정하라는 순서입니다.
-   */
-  const setReportPublicMutation = useMutation({
-    mutationFn: (isPublic: boolean) => setReportPublic(eventCode, isPublic),
-    onSuccess: (report) => {
-      queryClient.setQueryData(reportQueryKey, report);
-      showToast(report.isPublic ? '리포트를 공개했어요' : '리포트를 비공개로 바꿨어요');
-    },
-  });
+  /* 조회·생성·공개 전환이 같은 캐시 칸을 두고 움직여서 한 훅으로 묶여 있습니다. */
+  const report = useEventReport(eventCode, eventStatus);
 
   /*
    * 선택한 세션의 소감 수신을 켜고 끕니다. 세션은 생성 시 `CLOSED`라, 발표가 시작될 때 주최자가
@@ -343,35 +295,14 @@ const DashboardView = () => {
   const toMeta = (feedback: Feedback) =>
     `${toRelativeTime(feedback.createdAt)} · ${sessionTitle(feedback.sessionId)}`;
 
-  const report = reportQuery.data ?? null;
-
-  /*
-   * 요청을 보낸 순간부터 "생성 중"입니다. 202가 돌아오기를 기다리는 동안에도 버튼은 이미
-   * 눌렸으므로, 서버 응답이 오기 전 빈 구간을 mutation의 대기 상태가 메웁니다.
-   */
-  const isReportGenerating = generateReportMutation.isPending || report?.status === 'GENERATING';
-  const isReportGenerated = report?.status === 'GENERATED';
-
-  /*
-   * 본문은 `GENERATED`에서만 채워집니다. 다만 `reportSchema`가 `status`와 `summaryText`를 묶지
-   * 않아서 `GENERATED`인데 본문이 비어 오는 응답도 검증을 통과합니다. 그 경우까지 아래 안내문이
-   * 갈라 받습니다.
-   */
-  const summaryText = report?.status === 'GENERATED' ? report.summaryText : null;
-
-  /* 상태를 모르는 동안은 잠급니다. 이미 리포트가 있는 이벤트에서 눌리면 REPORT_ALREADY_EXISTS만 받습니다. */
-  const isReportUnknown = event.status === 'ENDED' && reportQuery.isPending;
-
-  const isReportPublic = report?.isPublic ?? false;
-
   /*
    * 리포트 카드의 상태 배지입니다. 모바일에선 제목 옆, 데스크톱에선 오른쪽 조치 자리에
    * 서는데 부모가 달라 CSS로는 옮길 수 없습니다. 두 자리에 같은 것을 두고 감싸는 span으로
    * 하나씩 감추므로, 본문은 여기서 한 번만 만듭니다.
    */
-  const reportBadge = isReportGenerating ? (
+  const reportBadge = report.isGenerating ? (
     <Badge tone="neutral">생성 중</Badge>
-  ) : isReportGenerated ? (
+  ) : report.isGenerated ? (
     <Badge tone="positive">생성 완료</Badge>
   ) : null;
 
@@ -419,17 +350,17 @@ const DashboardView = () => {
                * 배치로 돌아가고, 그때는 밀어낼 여백이 없어 `ml-auto`도 함께 죽습니다.
                */
               <div className="flex flex-1 items-center gap-2 md:flex-none">
-                {isReportGenerating && <Badge tone="neutral">생성 중</Badge>}
-                {isReportGenerated && <Badge tone="positive">생성 완료</Badge>}
+                {report.isGenerating && <Badge tone="neutral">생성 중</Badge>}
+                {report.isGenerated && <Badge tone="positive">생성 완료</Badge>}
 
                 {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
-                {!isReportGenerated && (
+                {!report.isGenerated && (
                   <Button
                     variant="secondary"
                     size="sm"
                     className="ml-auto"
-                    disabled={event.status !== 'ENDED' || isReportUnknown || isReportGenerating}
-                    onClick={() => generateReportMutation.mutate()}
+                    disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
+                    onClick={report.generate}
                   >
                     요약 생성
                   </Button>
@@ -461,14 +392,14 @@ const DashboardView = () => {
              * 다 만든 리포트에만 붙습니다. 만들기 전이나 만드는 중에는 뒤집을 공개 여부 자체가
              * 없습니다(`GENERATED`가 아니면 공개해도 게스트는 404를 봅니다).
              */}
-            {isReportGenerated && (
+            {report.isGenerated && (
               <Button
                 variant="secondary"
                 size="sm"
-                disabled={setReportPublicMutation.isPending}
-                onClick={() => setReportPublicMutation.mutate(!isReportPublic)}
+                disabled={report.isTogglePublicPending}
+                onClick={report.togglePublic}
               >
-                {isReportPublic ? '리포트 비공개' : '리포트 공개'}
+                {report.isPublic ? '리포트 비공개' : '리포트 공개'}
               </Button>
             )}
             {event.status === 'LIVE' && (
@@ -573,10 +504,8 @@ const DashboardView = () => {
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
       {moderation.isError && <Banner type="negative">소감 처리에 실패했어요</Banner>}
       {endEventMutation.isError && <Banner type="negative">이벤트를 종료하지 못했어요</Banner>}
-      {generateReportMutation.isError && (
-        <Banner type="negative">요약 리포트를 만들지 못했어요</Banner>
-      )}
-      {setReportPublicMutation.isError && (
+      {report.isGenerateError && <Banner type="negative">요약 리포트를 만들지 못했어요</Banner>}
+      {report.isTogglePublicError && (
         <Banner type="negative">리포트 공개 설정을 바꾸지 못했어요</Banner>
       )}
       {toggleSessionMutation.isError && (
@@ -767,7 +696,7 @@ const DashboardView = () => {
            * 안내문이 요약이 없을 때만 필요한 문장이라서입니다.
            *
            * 생성이 끝났는데 본문이 비어 있는 경우를 따로 받습니다. 여기서 "생성하시면…"으로
-           * 되돌리면 오른쪽 버튼은 이미 빠진 뒤라(`isReportGenerated`) 시키는 대로 할 수단이
+           * 되돌리면 오른쪽 버튼은 이미 빠진 뒤라(`report.isGenerated`) 시키는 대로 할 수단이
            * 없습니다. `GENERATING` 문구로 묶지 않는 것도 같은 이유입니다 — 폴링이 `GENERATED`에서
            * 멈춰서(위 `refetchInterval`) 기다려도 아무것도 다시 오지 않습니다.
            */}
@@ -783,13 +712,15 @@ const DashboardView = () => {
                 {reportBadge && <span className="md:hidden">{reportBadge}</span>}
               </div>
 
-              {summaryText !== null ? (
-                <p className="text-sm font-normal leading-5 text-text-secondary">{summaryText}</p>
+              {report.summaryText !== null ? (
+                <p className="text-sm font-normal leading-5 text-text-secondary">
+                  {report.summaryText}
+                </p>
               ) : (
                 <p className="text-xs font-normal leading-4 text-text-tertiary">
-                  {isReportGenerating
+                  {report.isGenerating
                     ? '요약을 만들고 있어요. 끝나면 여기에 올라와요'
-                    : isReportGenerated
+                    : report.isGenerated
                       ? '요약 본문을 받지 못했어요. 잠시 후 다시 열어봐 주세요'
                       : '생성하시면 읽어보고 공개할 수 있어요'}
                 </p>
@@ -806,18 +737,18 @@ const DashboardView = () => {
              */}
             <div
               className={`flex w-full shrink-0 items-center gap-2 md:w-auto ${
-                isReportGenerated ? 'hidden md:flex' : ''
+                report.isGenerated ? 'hidden md:flex' : ''
               }`}
             >
               {reportBadge && <span className="hidden md:contents">{reportBadge}</span>}
 
               {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
-              {!isReportGenerated && (
+              {!report.isGenerated && (
                 <Button
                   className="flex-1 md:flex-none"
                   variant="primary"
-                  disabled={event.status !== 'ENDED' || isReportUnknown || isReportGenerating}
-                  onClick={() => generateReportMutation.mutate()}
+                  disabled={event.status !== 'ENDED' || report.isUnknown || report.isGenerating}
+                  onClick={report.generate}
                 >
                   요약 생성
                 </Button>

--- a/components/dashboard/KeywordCard.tsx
+++ b/components/dashboard/KeywordCard.tsx
@@ -1,0 +1,40 @@
+import type { KeywordCount } from '@/components/dashboard/metrics';
+import { Badge } from '@/components/ui/Badge';
+
+/**
+ * 상위 키워드 카드입니다. 소감에 붙은 키워드를 빈도순으로 보여줍니다.
+ *
+ * 높이를 고정하지 않습니다. 옆 카드들과 달리 내용이 몇 줄로 끝나고, 폴링으로 키워드가
+ * 늘어도 순서가 고정돼 있어(`countKeywords`) 목록이 통째로 뒤바뀌지 않습니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+interface KeywordCardProps {
+  /** 빈도순으로 이미 정렬·상위 N개로 잘린 목록입니다. */
+  keywords: KeywordCount[];
+}
+
+const KeywordCard = ({ keywords }: KeywordCardProps) => (
+  <section className={CARD}>
+    <h2 className={CARD_TITLE}>상위 키워드</h2>
+
+    {keywords.length === 0 ? (
+      <p className="text-sm text-text-tertiary">아직 모인 키워드가 없어요</p>
+    ) : (
+      <ul className="flex flex-wrap gap-2">
+        {keywords.map(([keyword, count]) => (
+          <li key={keyword}>
+            <Badge tone="outline">
+              {keyword} {count}
+            </Badge>
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+);
+
+export { KeywordCard };

--- a/components/dashboard/LiveFeedCard.tsx
+++ b/components/dashboard/LiveFeedCard.tsx
@@ -1,0 +1,72 @@
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import type { ModerationActions } from '@/hooks/useModerationActions';
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 실시간 소감 피드 카드입니다. 참가자가 남긴 소감이 폴링으로 들어오는 대로 쌓입니다.
+ *
+ * 옆에 서는 `ModerationQueue`와 짝입니다. 받는 것도 같아서 props 이름을 맞췄습니다 —
+ * 이쪽은 보이는 소감을, 그쪽은 숨겨진 소감을 받습니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+interface LiveFeedCardProps {
+  /** 이미 `VISIBLE`만 걸러진 목록입니다. 숨긴 건은 모더레이션 큐가 받습니다. */
+  items: Feedback[];
+  /** 소감 하나의 메타 문구를 만듭니다. 세션 제목을 아는 건 화면 쪽이라 밖에서 받습니다. */
+  formatMeta: (feedback: Feedback) => string;
+  actions: ModerationActions;
+}
+
+const LiveFeedCard = ({ items, formatMeta, actions }: LiveFeedCardProps) => (
+  <section className={CARD}>
+    <h2 className={CARD_TITLE}>실시간 소감 피드</h2>
+
+    {/* 모더레이션 큐와 같은 이유로 높이를 고정합니다(`ModerationQueue.tsx`). */}
+    {items.length === 0 ? (
+      <EmptyState
+        className="h-80 justify-center"
+        title="아직 들어온 소감이 없어요"
+        description="참가자가 소감을 남기면 여기에 바로 올라와요"
+      />
+    ) : (
+      <ul className="flex h-80 flex-col gap-2 overflow-y-auto">
+        {items.map((feedback) => (
+          <li key={feedback.id}>
+            <FeedItem
+              state="normal"
+              sentiment={FEED_SENTIMENT[feedback.sentiment]}
+              meta={formatMeta(feedback)}
+              content={feedback.text}
+              /*
+               * 자동 판정이 잡는 건 욕설뿐이라, 인신공격처럼 판정을 빠져나간 소감은
+               * 주최자가 여기서 직접 내려야 합니다(#170).
+               *
+               * 삭제는 달지 않습니다. `DELETED`는 되돌릴 수 없는 종단 상태라 실시간으로
+               * 흘러가는 목록에서 바로 누르게 둘 자리가 아닙니다. 숨기면 모더레이션
+               * 큐로 넘어가서, 거기서 다시 보고 삭제하거나 되돌립니다.
+               */
+              actions={
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  disabled={actions.isItemPending(feedback.id)}
+                  onClick={() => actions.toggleHidden(feedback)}
+                >
+                  숨기기
+                </Button>
+              }
+            />
+          </li>
+        ))}
+      </ul>
+    )}
+  </section>
+);
+
+export { LiveFeedCard };

--- a/components/dashboard/ReportSection.tsx
+++ b/components/dashboard/ReportSection.tsx
@@ -1,0 +1,92 @@
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import type { EventReportControls } from '@/hooks/useEventReport';
+
+/**
+ * AI 요약 리포트 카드입니다. 생성 전·생성 중·완료 세 상태를 한 자리에서 갈아입습니다.
+ *
+ * 카드 아래 한 줄이 상태에 따라 다른 일을 합니다. 생성 전에는 왜 눌러야 하는지 알리는 안내문이고,
+ * 끝나면 요약 본문이 그 자리에 들어옵니다. 자리를 나누지 않는 이유는 안내문이 요약이 없을 때만
+ * 필요한 문장이라서입니다.
+ *
+ * 생성이 끝났는데 본문이 비어 있는 경우를 따로 받습니다. 여기서 "생성하시면…"으로 되돌리면
+ * 오른쪽 버튼은 이미 빠진 뒤라(`isGenerated`) 시키는 대로 할 수단이 없습니다. `GENERATING`
+ * 문구로 묶지 않는 것도 같은 이유입니다 — 폴링이 `GENERATED`에서 멈춰서 기다려도 아무것도
+ * 다시 오지 않습니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+
+interface ReportSectionProps {
+  report: EventReportControls;
+}
+
+const ReportSection = ({ report }: ReportSectionProps) => {
+  /*
+   * 상태 배지입니다. 모바일에선 제목 옆, 데스크톱에선 오른쪽 조치 자리에 서는데 부모가 달라
+   * CSS로는 옮길 수 없습니다. 두 자리에 같은 것을 두고 감싸는 span으로 하나씩 감추므로,
+   * 본문은 여기서 한 번만 만듭니다.
+   */
+  const badge = report.isGenerating ? (
+    <Badge tone="neutral">생성 중</Badge>
+  ) : report.isGenerated ? (
+    <Badge tone="positive">생성 완료</Badge>
+  ) : null;
+
+  return (
+    <section
+      className={`${CARD} flex-col items-start justify-between gap-4 bg-background-muted md:flex-row`}
+    >
+      <div className="flex w-full flex-col gap-1 md:w-auto">
+        {/* 배지를 오른쪽 끝에 붙이려면 이 열이 폭을 다 써야 합니다(`w-full`). */}
+        <div className="flex items-center justify-between gap-2">
+          <h2 className="text-base font-semibold leading-6 text-text-primary">AI 요약 리포트</h2>
+          {badge && <span className="md:hidden">{badge}</span>}
+        </div>
+
+        {report.summaryText !== null ? (
+          <p className="text-sm font-normal leading-5 text-text-secondary">{report.summaryText}</p>
+        ) : (
+          <p className="text-xs font-normal leading-4 text-text-tertiary">
+            {report.isGenerating
+              ? '요약을 만들고 있어요. 끝나면 여기에 올라와요'
+              : report.isGenerated
+                ? '요약 본문을 받지 못했어요. 잠시 후 다시 열어봐 주세요'
+                : '생성하시면 읽어보고 공개할 수 있어요'}
+          </p>
+        )}
+      </div>
+
+      {/*
+       * 오른쪽은 이 카드의 상태와 조치가 함께 서는 자리입니다. 상태 배지를 제목이 아니라
+       * 여기 두는 이유는, 다 만들고 나면 버튼이 빠져서 이 자리가 비기 때문입니다.
+       *
+       * 모바일에서는 카드가 세로로 서면서 이 자리가 제목에서 멀어지므로, 배지만 제목 옆으로
+       * 올립니다(`badge`). 그러면 생성 완료 상태의 모바일에서는 배지도 버튼도 없어
+       * 이 자리가 통째로 비므로 아예 감춥니다 — 안 그러면 section의 `gap-4`만 남습니다.
+       */}
+      <div
+        className={`flex w-full shrink-0 items-center gap-2 md:w-auto ${
+          report.isGenerated ? 'hidden md:flex' : ''
+        }`}
+      >
+        {badge && <span className="hidden md:contents">{badge}</span>}
+
+        {/* 다 만든 리포트에는 다시 만들 길이 없습니다(재생성은 REPORT_ALREADY_EXISTS). */}
+        {!report.isGenerated && (
+          <Button
+            className="flex-1 md:flex-none"
+            variant="primary"
+            disabled={report.isGenerateDisabled}
+            onClick={report.generate}
+          >
+            요약 생성
+          </Button>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export { ReportSection };

--- a/components/dashboard/SentimentTrendCard.tsx
+++ b/components/dashboard/SentimentTrendCard.tsx
@@ -1,0 +1,55 @@
+import type { TrendPoint } from '@/components/dashboard/metrics';
+import { SentimentTrendChart } from '@/components/dashboard/SentimentTrendChart';
+import type { SentimentCounts } from '@/components/feedback/sentiment';
+
+/**
+ * 시간대별 감정 추이 카드입니다. 제목·갱신 주기 표시·빈 상태를 맡고, 선을 그리는 일은
+ * `SentimentTrendChart`가 합니다.
+ *
+ * 빈 상태를 차트 안에 넣지 않는 이유는 높이를 카드가 잡기 때문입니다. 「아직 그릴 소감이
+ * 없어요」도 `h-40`이라, 소감이 처음 들어오는 순간 카드가 들썩이지 않습니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+interface SentimentTrendCardProps extends SentimentCounts {
+  trend: TrendPoint[];
+  /** 폴링 간격(ms)입니다. 영구 실패로 폴링이 멈추면 `null`이라 문구를 감춥니다. */
+  refreshIntervalMs: number | null;
+}
+
+const SentimentTrendCard = ({
+  trend,
+  positive,
+  neutral,
+  negative,
+  refreshIntervalMs,
+}: SentimentTrendCardProps) => (
+  <section className={CARD}>
+    <div className="flex items-center justify-between gap-2">
+      <h2 className={CARD_TITLE}>시간대별 감정 추이</h2>
+      {refreshIntervalMs !== null && (
+        <span className="text-xs font-normal leading-4 text-text-tertiary">
+          {refreshIntervalMs / 1000}초마다 갱신
+        </span>
+      )}
+    </div>
+
+    {trend.length === 0 ? (
+      <p className="flex h-40 items-center justify-center text-sm text-text-tertiary">
+        아직 그릴 소감이 없어요
+      </p>
+    ) : (
+      <SentimentTrendChart
+        trend={trend}
+        positive={positive}
+        neutral={neutral}
+        negative={negative}
+      />
+    )}
+  </section>
+);
+
+export { SentimentTrendCard };

--- a/components/dashboard/SentimentTrendChart.tsx
+++ b/components/dashboard/SentimentTrendChart.tsx
@@ -1,0 +1,81 @@
+import {
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { TREND_BUCKET_MS, type TrendPoint } from '@/components/dashboard/metrics';
+import type { SentimentCounts } from '@/components/feedback/sentiment';
+
+interface SentimentTrendChartProps extends SentimentCounts {
+  trend: TrendPoint[];
+}
+const SentimentTrendChart = ({ trend, positive, neutral, negative }: SentimentTrendChartProps) => {
+  return (
+    <div
+      className="h-40"
+      role="img"
+      aria-label={`${TREND_BUCKET_MS / 60_000}분 단위 감정별 소감 건수 추이. 긍정 ${positive}건, 중립 ${neutral}건, 부정 ${negative}건.`}
+    >
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={trend} margin={{ top: 8, right: 8, bottom: 0, left: -24 }}>
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke="var(--color-border-subtle)"
+            vertical={false}
+          />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
+          />
+          <YAxis
+            allowDecimals={false}
+            tickLine={false}
+            axisLine={false}
+            width={40}
+            tick={{ fontSize: 11, fill: 'var(--color-text-tertiary)' }}
+          />
+          <Tooltip
+            contentStyle={{
+              borderRadius: '0.5rem',
+              border: '1px solid var(--color-border-subtle)',
+              fontSize: '0.75rem',
+            }}
+          />
+          <Line
+            type="monotone"
+            dataKey="POS"
+            name="긍정"
+            stroke="var(--color-positive-default)"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="NEU"
+            name="중립"
+            stroke="var(--color-neutral-default)"
+            strokeWidth={2}
+            dot={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="NEG"
+            name="부정"
+            stroke="var(--color-negative-default)"
+            strokeWidth={2}
+            dot={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+};
+
+export { SentimentTrendChart };

--- a/components/dashboard/SessionFilterBar.tsx
+++ b/components/dashboard/SessionFilterBar.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from 'react';
+
+import { Chip } from '@/components/ui/Chip';
+import type { SessionView } from '@/lib/schemas/api';
+
+/**
+ * 세션 칩 줄입니다. 고른 세션으로 아래 숫자와 목록을 모두 거릅니다.
+ *
+ * 열림 개수를 밖에서 받지 않고 여기서 셉니다. 목록과 숫자를 따로 받으면 폴링으로 세션이
+ * 늘었을 때 둘이 어긋날 수 있습니다(`ModerationQueue`와 같은 이유).
+ */
+
+interface SessionFilterBarProps {
+  sessions: SessionView[];
+  /** `null`이 "전체"입니다. 시안의 기본 선택값입니다. */
+  selectedSessionId: number | null;
+  onSelectSession: (sessionId: number | null) => void;
+  /** 모바일에서 칩 아래 줄에 서는 세션 토글입니다. 데스크톱은 헤더가 같은 것을 그립니다. */
+  sessionToggle?: ReactNode;
+}
+
+const SessionFilterBar = ({
+  sessions,
+  selectedSessionId,
+  onSelectSession,
+  sessionToggle,
+}: SessionFilterBarProps) => {
+  const openSessionCount = sessions.filter((session) => session.status === 'ACTIVE').length;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Chip selected={selectedSessionId === null} onClick={() => onSelectSession(null)}>
+        전체
+      </Chip>
+      {sessions.map((session) => (
+        <Chip
+          key={session.id}
+          selected={selectedSessionId === session.id}
+          onClick={() => onSelectSession(session.id)}
+        >
+          {session.title}
+        </Chip>
+      ))}
+      <span className="ml-auto text-xs font-normal leading-4 text-text-tertiary">
+        총 {sessions.length}개 중 {openSessionCount}개 열림
+      </span>
+      {sessionToggle}
+    </div>
+  );
+};
+
+export { SessionFilterBar };

--- a/components/dashboard/SessionToggle.tsx
+++ b/components/dashboard/SessionToggle.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { Badge } from '@/components/ui/Badge';
+import { Button } from '@/components/ui/Button';
+import type { SessionStatus, SessionView } from '@/lib/schemas/api';
+
+/**
+ * 고른 세션의 소감 수신을 켜고 끕니다. 지금 상태를 알리는 배지와 그걸 뒤집는 버튼 한 쌍입니다.
+ *
+ * 화면에 두 벌이 그려집니다. 데스크톱은 헤더의 조치 버튼 아래, 모바일은 세션 칩 줄 아래인데
+ * 부모가 달라 CSS로는 옮길 수 없습니다. 그래서 자리마다 하나씩 두고 `className`으로 감춥니다 —
+ * 붙이고 떼는 쪽은 부르는 쪽이고, 이 파일은 문구와 분기만 압니다.
+ *
+ * 문구가 세 갈래인 이유는 세션이 생성 시 `CLOSED`이기 때문입니다(2026-08-07 명세). 상태만으로는
+ * "아직 열지 않았다"와 "열었다가 멈췄다"를 가를 수 없는데 권하는 다음 행동이 달라서,
+ * 이 화면에서 멈춘 적이 있는지를 `isPaused`로 받습니다.
+ */
+
+interface SessionToggleProps {
+  session: SessionView;
+  /** 이 화면에서 멈춘 세션인지입니다. 같은 `CLOSED`라도 「다시 받기」와 「소감 받기」로 갈립니다. */
+  isPaused: boolean;
+  isPending: boolean;
+  /** 뒤집을 다음 상태를 넘깁니다. 어느 세션인지는 부르는 쪽이 이미 압니다. */
+  onToggle: (status: Extract<SessionStatus, 'ACTIVE' | 'CLOSED'>) => void;
+  /** 자리마다 배치가 달라서 `display`까지 밖에서 정합니다(`hidden md:flex` / `flex md:hidden`). */
+  className?: string;
+}
+
+const SessionToggle = ({
+  session,
+  isPaused,
+  isPending,
+  onToggle,
+  className = '',
+}: SessionToggleProps) => {
+  const isActive = session.status === 'ACTIVE';
+
+  return (
+    <div className={`items-center gap-2 ${className}`}>
+      <Badge tone={isActive ? 'positive' : 'neutral'}>
+        {isActive ? '소감 받는 중' : isPaused ? '소감 멈춤' : '시작 전'}
+      </Badge>
+      <Button
+        variant="secondary"
+        size="sm"
+        disabled={isPending}
+        onClick={() => onToggle(isActive ? 'CLOSED' : 'ACTIVE')}
+      >
+        {isActive ? '멈추기' : isPaused ? '다시 받기' : '소감 받기'}
+      </Button>
+    </div>
+  );
+};
+
+export { SessionToggle };

--- a/components/dashboard/metrics.ts
+++ b/components/dashboard/metrics.ts
@@ -48,6 +48,9 @@ interface SentimentSummary {
   positiveRate: number;
 }
 
+/** 키워드 하나와 그 횟수입니다. `Map` 엔트리 모양 그대로라 라벨로 자리를 표시합니다. */
+type KeywordCount = [keyword: string, count: number];
+
 /**
  * 소감을 5분 칸으로 묶어 감정별 건수를 셉니다.
  *
@@ -81,7 +84,7 @@ const buildTrend = (feedbacks: Feedback[]) => {
 };
 
 /** 빈도순 상위 키워드입니다. 같은 횟수면 가나다순으로 고정해서 폴링마다 순서가 바뀌지 않게 합니다. */
-const countKeywords = (feedbacks: Feedback[]) => {
+const countKeywords = (feedbacks: Feedback[]): KeywordCount[] => {
   const counts = new Map<string, number>();
 
   feedbacks.forEach((feedback) => {
@@ -129,5 +132,6 @@ export {
   countKeywords,
   summarizeSentiments,
   toRelativeTime,
+  type KeywordCount,
   type TrendPoint,
 };

--- a/hooks/useEventReport.ts
+++ b/hooks/useEventReport.ts
@@ -40,6 +40,14 @@ interface EventReportControls {
   isUnknown: boolean;
   isPublic: boolean;
   generate: () => void;
+  /**
+   * 생성 버튼을 잠글지입니다. `ENDED`가 아니거나, 상태를 모르거나, 이미 만드는 중이면 잠깁니다.
+   *
+   * 판정을 훅이 하는 이유는 버튼이 헤더와 리포트 카드 두 곳에 있기 때문입니다. 화면마다 세 조건을
+   * 다시 조합하면 한쪽만 빠뜨렸을 때 INVALID_EVENT_STATE_TRANSITION이나 REPORT_ALREADY_EXISTS를
+   * 받는 버튼이 열립니다.
+   */
+  isGenerateDisabled: boolean;
   /** 공개 ↔ 비공개를 뒤집습니다. 지금 값은 이 훅이 알고 있어서 인자를 받지 않습니다. */
   togglePublic: () => void;
   isTogglePublicPending: boolean;
@@ -111,6 +119,7 @@ const useEventReport = (eventCode: string, eventStatus?: EventStatus): EventRepo
     isUnknown,
     isPublic,
     generate: () => generateMutation.mutate(),
+    isGenerateDisabled: eventStatus !== 'ENDED' || isUnknown || isGenerating,
     togglePublic: () => setPublicMutation.mutate(!isPublic),
     isTogglePublicPending: setPublicMutation.isPending,
     isGenerateError: generateMutation.isError,

--- a/hooks/useEventReport.ts
+++ b/hooks/useEventReport.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { showToast } from '@/hooks/useToast';
+import { fetchOwnReport, generateReport, setReportPublic } from '@/lib/api/endpoints';
+import type { EventStatus } from '@/lib/schemas/api';
+
+/**
+ * 이벤트 하나의 AI 요약 리포트입니다. 조회(폴링 포함)·생성·공개 전환을 함께 묶습니다.
+ *
+ * 셋을 한 훅에 두는 이유는 같은 캐시 한 칸을 두고 움직이기 때문입니다. 생성은 202로 받은
+ * 리포트를 그 칸에 꽂아 폴링을 시작시키고, 공개 전환은 같은 칸을 갈아끼웁니다. 나눠두면
+ * 캐시 키가 두 곳에 복사됩니다.
+ *
+ * 밖으로는 mutation 객체가 아니라 화면이 쓰는 값만 내보냅니다(`useModerationActions`와 같은
+ * 방식). 리포트 상태를 읽는 자리가 대시보드 헤더와 리포트 섹션 둘인데, 각자 `isPending`과
+ * `data.status`를 조합하면 "생성 중"의 정의가 두 벌이 됩니다.
+ */
+
+/**
+ * 리포트가 만들어지는 동안만 쓰는 간격입니다. 소감 폴링(5초)보다 짧은 이유는, 이쪽은 버튼을
+ * 누른 사람이 결과를 기다리며 보고 있는 화면이라서입니다. 끝나는 즉시 타이머를 멈춥니다.
+ */
+const REPORT_POLL_INTERVAL_MS = 1_500;
+
+interface EventReportControls {
+  /** `GENERATED`이고 본문이 실제로 있을 때만 채워집니다. */
+  summaryText: string | null;
+  /**
+   * 요청을 보낸 순간부터 켜집니다. 202가 돌아오기를 기다리는 동안에도 버튼은 이미 눌렸으므로,
+   * 서버 응답이 오기 전 빈 구간을 mutation의 대기 상태가 메웁니다.
+   */
+  isGenerating: boolean;
+  isGenerated: boolean;
+  /**
+   * 상태를 아직 모르는 동안입니다. 생성 버튼을 잠그는 데 씁니다 — 이미 리포트가 있는
+   * 이벤트에서 눌리면 REPORT_ALREADY_EXISTS만 받습니다.
+   */
+  isUnknown: boolean;
+  isPublic: boolean;
+  generate: () => void;
+  /** 공개 ↔ 비공개를 뒤집습니다. 지금 값은 이 훅이 알고 있어서 인자를 받지 않습니다. */
+  togglePublic: () => void;
+  isTogglePublicPending: boolean;
+  /** 실패 배너를 나눠 그리므로 둘을 합치지 않습니다. 안내 문구가 서로 다릅니다. */
+  isGenerateError: boolean;
+  isTogglePublicError: boolean;
+}
+
+const useEventReport = (eventCode: string, eventStatus?: EventStatus): EventReportControls => {
+  const queryClient = useQueryClient();
+
+  const reportQueryKey = ['report', eventCode];
+
+  /*
+   * 리포트 행이 없는 상태(개념상 NONE)는 404 REPORT_NOT_FOUND로 옵니다. 에러로 오지만 "아직
+   * 생성하지 않았다"는 정상 상태라, 화면은 이걸 실패가 아니라 생성 전으로 읽습니다.
+   * `QueryProvider`의 `retry`가 4xx를 이미 거르므로 없는 리포트를 두들기지도 않습니다.
+   *
+   * 생성이 비동기라 폴링이 필요합니다. `GENERATING` 동안에만 돌리고 나머지 상태에서는 멈춥니다.
+   * 완료된 리포트를 계속 다시 받아봐야 같은 답이고, 여기서 멈추지 않으면 이 화면을 열어둔 내내
+   * 1.5초마다 요청이 나갑니다.
+   */
+  const reportQuery = useQuery({
+    queryKey: reportQueryKey,
+    queryFn: () => fetchOwnReport(eventCode),
+    // 생성 자체가 `ENDED`에서만 가능해서, 그 전에는 물어볼 이유가 없습니다.
+    enabled: eventStatus === 'ENDED',
+    refetchInterval: ({ state }) =>
+      state.data?.status === 'GENERATING' ? REPORT_POLL_INTERVAL_MS : false,
+  });
+
+  const generateMutation = useMutation({
+    mutationFn: () => generateReport(eventCode),
+    /*
+     * 202 응답이 이미 `GENERATING` 상태의 리포트입니다. 캐시에 바로 꽂아야 위 폴링이 그 자리에서
+     * 시작합니다. `invalidateQueries`로도 되지만 방금 받은 답을 한 번 더 물어보게 됩니다.
+     */
+    onSuccess: (report) => {
+      queryClient.setQueryData(reportQueryKey, report);
+    },
+  });
+
+  /*
+   * 공개 여부만 뒤집습니다. 생성 직후 리포트는 비공개라(`isPublic: false`), 공개 페이지가 열리려면
+   * 주최자가 한 번 더 눌러야 합니다. 요약을 먼저 읽어보고 내보낼지 정하라는 순서입니다.
+   */
+  const setPublicMutation = useMutation({
+    mutationFn: (isPublic: boolean) => setReportPublic(eventCode, isPublic),
+    onSuccess: (report) => {
+      queryClient.setQueryData(reportQueryKey, report);
+      showToast(report.isPublic ? '리포트를 공개했어요' : '리포트를 비공개로 바꿨어요');
+    },
+  });
+
+  const report = reportQuery.data ?? null;
+  const isPublic = report?.isPublic ?? false;
+  const isGenerating = generateMutation.isPending || report?.status === 'GENERATING';
+  const isUnknown = eventStatus === 'ENDED' && reportQuery.isPending;
+
+  return {
+    /*
+     * 본문은 `GENERATED`에서만 채워집니다. 다만 `reportSchema`가 `status`와 `summaryText`를 묶지
+     * 않아서 `GENERATED`인데 본문이 비어 오는 응답도 검증을 통과합니다. 그 경우는 화면이
+     * 안내문으로 갈라 받습니다.
+     */
+    summaryText: report?.status === 'GENERATED' ? report.summaryText : null,
+    isGenerating,
+    isGenerated: report?.status === 'GENERATED',
+    isUnknown,
+    isPublic,
+    generate: () => generateMutation.mutate(),
+    togglePublic: () => setPublicMutation.mutate(!isPublic),
+    isTogglePublicPending: setPublicMutation.isPending,
+    isGenerateError: generateMutation.isError,
+    isTogglePublicError: setPublicMutation.isError,
+  };
+};
+
+export { useEventReport, type EventReportControls };

--- a/hooks/useSessionControls.ts
+++ b/hooks/useSessionControls.ts
@@ -1,0 +1,71 @@
+'use client';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { showToast } from '@/hooks/useToast';
+import { updateSession } from '@/lib/api/endpoints';
+import type { SessionStatus } from '@/lib/schemas/api';
+
+/**
+ * 세션의 소감 수신을 켜고 끕니다. 세션은 생성 시 `CLOSED`라, 발표가 시작될 때 주최자가 열어야
+ * 소감이 들어옵니다(2026-08-07 명세).
+ *
+ * 뒤집는 일과 "이 화면에서 멈춘 세션인가"를 한 훅에 둡니다. 둘은 혼자서는 의미가 없습니다 —
+ * 멈춘 목록은 이 뮤테이션의 성공 처리에서만 갱신되고, 그 목록을 읽는 곳은 판정 하나뿐입니다.
+ *
+ * 세션 목록 조회는 여기 들어오지 않습니다. 화면이 그 배열을 칩 말고도 세 군데(메타 문구의
+ * 세션 제목, 고른 세션 찾기, 로딩·에러 분기)에서 쓰기 때문에, 가져오면 "조작"이 아니라
+ * "세션에 관한 전부"가 됩니다.
+ *
+ * 이벤트 종료와 달리 확인 다이얼로그를 두지 않습니다. `ACTIVE ↔ CLOSED`는 되돌릴 수 있어서
+ * 잘못 눌러도 다시 누르면 그만입니다.
+ */
+
+/** 뒤집을 수 있는 상태입니다. `DELETED`는 여기로 오지 않습니다. */
+type ToggleableStatus = Extract<SessionStatus, 'ACTIVE' | 'CLOSED'>;
+
+interface SessionControls {
+  /**
+   * 이 화면에서 멈춘 세션인지 봅니다. 같은 `CLOSED`라도 "아직 안 열었다"와 "열었다가 멈췄다"는
+   * 버튼이 권하는 다음 행동이 달라서, 문구를 가르는 데 씁니다.
+   *
+   * `SessionView`에 열린 적이 있는지 알려주는 필드가 없어서 화면이 직접 기억합니다. 새로고침하면
+   * 잊고 다른 기기에서 멈춘 것도 모릅니다 — 정확히 하려면 서버에 흔적이 필요합니다(#143).
+   */
+  isPaused: (sessionId: number) => boolean;
+  toggle: (sessionId: number, status: ToggleableStatus) => void;
+  isPending: boolean;
+  isError: boolean;
+}
+
+const useSessionControls = (eventCode: string): SessionControls => {
+  const queryClient = useQueryClient();
+
+  const [pausedSessionIds, setPausedSessionIds] = useState<ReadonlySet<number>>(new Set());
+
+  const toggleMutation = useMutation({
+    mutationFn: ({ id, status }: { id: number; status: ToggleableStatus }) =>
+      updateSession(eventCode, id, { status }),
+    onSuccess: (session) => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      /* 다시 열면 지웁니다. 남겨두면 멈췄다 연 세션을 또 멈출 때가 아니라 처음 열 때부터 "다시"가 됩니다. */
+      setPausedSessionIds((previous) => {
+        const next = new Set(previous);
+        if (session.status === 'ACTIVE') next.delete(session.id);
+        else next.add(session.id);
+        return next;
+      });
+      showToast(session.status === 'ACTIVE' ? '이제 소감을 받아요' : '소감 받기를 멈췄어요');
+    },
+  });
+
+  return {
+    isPaused: (sessionId) => pausedSessionIds.has(sessionId),
+    toggle: (id, status) => toggleMutation.mutate({ id, status }),
+    isPending: toggleMutation.isPending,
+    isError: toggleMutation.isError,
+  };
+};
+
+export { useSessionControls, type SessionControls };


### PR DESCRIPTION
## 변경 사항

`components/dashboard/DashboardView.tsx` **846줄 → 384줄**. 화면 전체가 한 파일에 있어서 카드 하나를 고치려도 전부 열어야 했고, 서로 무관한 변경이 같은 파일에서 충돌했습니다(#170 · #187 · #195 · #203이 모두 이 파일을 고쳤습니다).

- 컴포넌트 8개 분리 — `DashboardHeader` · `SessionToggle` · `SessionFilterBar` · `SentimentTrendChart` · `SentimentTrendCard` · `ReportSection` · `LiveFeedCard` · `KeywordCard`
- 훅 2개 분리 — `useEventReport` (리포트 조회 폴링 + 생성 + 공개 전환) · `useSessionControls` (세션 토글 + 멈춤 기록)
- **중복 제거 2건**
  - 세션 토글 JSX가 데스크톱·모바일에 문구·분기까지 같은 27줄 두 벌 → `SessionToggle` 한 벌
  - 「요약 생성」 버튼 잠금 조건 3개가 헤더·리포트 카드 두 곳 → `report.isGenerateDisabled` 하나
- **동작 변경 없음.** 렌더 결과와 요청 횟수가 그대로입니다.

분리 기준은 세 가지입니다.

1. 시안에서 테두리로 묶인 한 덩어리(`CARD`가 붙은 `<section>`)를 파일 하나로
2. 자식은 쿼리하지 않고 `DashboardView`가 받아 props로 내림 — 자식이 각자 `useQuery`를 부르면 폴링이 카드 수만큼 돕니다
3. 훅으로 빼는 건 서버 상태 묶음만 (`useModerationActions` 전례)

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 3916f3f | refactor(dashboard): 리포트 상태를 useEventReport 훅으로 분리 | 쿼리·뮤테이션 2개가 `['report', eventCode]` 캐시 한 칸을 공유해서 흩어지면 키가 세 곳에 복사됨. mutation 객체 대신 좁은 인터페이스만 내보내 "생성 중"의 정의를 한 벌로 유지 |
| bf3751b | refactor(dashboard): 헤더와 세션 토글을 컴포넌트로 분리 | 헤더 135줄 분리. 세션 토글은 부모가 달라 CSS로 못 옮겨 생긴 27줄 중복 두 벌을 한 벌로 |
| ddcecc3 | refactor(dashboard): 감정 추이 차트를 컴포넌트로 분리 | recharts 74줄 분리. 차트가 `h-40`을 직접 들게 해서 `ResponsiveContainer`의 부모 높이 의존을 파일 안에 가둠 |
| ee09682 | refactor(dashboard): AI 요약 리포트 섹션을 컴포넌트로 분리 | 상태 4가지로 갈아입는 카드 65줄 분리. 버튼 잠금 판정을 훅으로 올려 두 곳의 중복 조건 제거 |
| 04ec431 | refactor(dashboard): 세션 칩 줄을 SessionFilterBar로 분리 | 열림 개수를 props로 받지 않고 안에서 셈 — 목록과 숫자를 따로 받으면 폴링 중 어긋남 |
| 6f5fa65 | refactor(dashboard): 실시간 소감 피드를 LiveFeedCard로 분리 | 짝인 ModerationQueue만 컴포넌트였음. props 이름을 맞춰 대칭을 드러냄 |
| 19355c1 | refactor(dashboard): 세션 조작을 useSessionControls 훅으로 분리 | 뮤테이션·state·판정 셋이 220줄 떨어져 있었음. 목록 쿼리는 화면에 남김 |
| 6da7009 | refactor(dashboard): 상위 키워드를 KeywordCard로 분리 | 마지막 인라인 section이라 혼자 남기면 호출과 원본 JSX가 섞임. `KeywordCount` 라벨 튜플 추가 |

## 관련 이슈

- Refs #205

## 검증 방법

```
$ npm run lint
(출력 없음 — 통과)

$ npm run test
Test Files  5 passed (5)
     Tests  102 passed (102)

$ npm run build
✓ Compiled successfully in 12.3s
✓ Generating static pages (9/9)
13개 라우트 정상 빌드
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음 (전부 이번에 새로 만든 내부 컴포넌트라 외부 사용처 없음)

## 트러블슈팅 및 참고 사항

**리뷰 시 봐주셔야 할 곳**

`publicUrl`의 `window.location.origin` 접근은 early return 뒤에 그대로 뒀습니다. 서버 렌더에서는 그 줄까지 오지 않는 게 안전 근거라, 자식으로 내릴 때 계산 위치는 유지하고 값만 props로 넘겼습니다.

보존해야 하는 나머지 규칙도 그대로입니다 — `toxicCount`는 `visible`이 아닌 전체 기준, `queueItems`는 `toxic || HIDDEN`(#170), `reportBadge`는 한 번 만들어 두 자리에 렌더, early return은 이벤트 → 세션 순서.

**수동 화면 확인은 안 했습니다**

동작 변경이 없는 리팩터링이라 위 세 명령으로 갈음했습니다. 카드 여섯 개가 자리를 옮겼으니, 리뷰하실 때 MSW 목 모드로 한 번 띄워보시면 좋겠습니다 — `LIVE` / `ENDED` / 리포트 생성 중·완료 / 모바일 폭 네 가지입니다.

**의도적으로 안 한 것**

- `DashboardStats` · `DashboardErrorBanners` · `SentimentDistributionCard` — 값보다 비용이 큽니다. `DashboardStats`는 지금 6줄인데 컴포넌트로 빼면 총 줄 수가 늘고, `DashboardErrorBanners`는 props가 7개인 데다 배너가 늘 때마다 하나씩 늘어납니다.
- `CARD` · `CARD_TITLE` 상수 통합 — 지금 `DashboardView` · `ModerationQueue` · `SentimentTrendCard` · `ReportSection` · `LiveFeedCard` · `KeywordCard` 여섯 곳에 사본이 있습니다. `components/ui/Card.tsx`를 만들면 없앨 수 있지만, 카드를 다 쪼개지 않기로 한 이상 지금 만들 이유가 약합니다. `app/e/[code]/report/page.tsx:34`는 `bg-background-default`가 붙은 다른 값이라 묶으면 안 됩니다.

이슈 #205의 체크리스트에 적힌 "`DashboardView.tsx` 200줄 이하"는 위의 "안 한 것"까지 전부 해야 나오는 숫자입니다. 384줄에서 멈춘 게 의도입니다.

**따로 이슈가 필요한 것**

`['sessions', eventCode]` 쿼리 키가 `DashboardView` · `EventForm`(4곳) · `LiveResult` · `app/dev/msw/page.tsx`에 하드코딩돼 있습니다. `useDashboardFeed`의 `DASHBOARD_FEED_KEY`처럼 상수로 빼는 게 맞는데, 이 PR 범위 밖이라 손대지 않았습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
