### PR TITLE
fix(event): 이벤트 카드에 행사 날짜를 쓴다

### DIFF
--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -41,7 +41,7 @@ const EventCard = ({ event }: EventCardProps) => {
   const { tone, label } = TONE_BY_STATUS[event.status];
 
   // TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가 추가되면 해당 날짜로 사용해야 함.
-  const datetime = formatEventDate(event.createdAt);
+  const datetime = formatEventDate(event.eventDate);
   const rightContent = RIGHT_CONTENT_BY_STATUS[event.status](event);
   const href = ROUTE_BY_STATUS[event.status](event);
 

--- a/lib/formatEventDate.ts
+++ b/lib/formatEventDate.ts
@@ -1,11 +1,10 @@
-const formatEventDate = (isoString: string) => {
-  const eventDate = new Date(isoString);
-
-  const year = eventDate.getFullYear();
-  const month = eventDate.getMonth() + 1;
-  const day = eventDate.getDate();
-
-  return `${year}. ${month.toString().padStart(2, '0')}. ${day.toString().padStart(2, '0')}`;
-};
+/**
+ * 이벤트 카드의 행사 날짜입니다. 입력은 시각이 없는 `YYYY-MM-DD`(API 명세의 `eventDate`)입니다.
+ *
+ * `Date`로 파싱하지 않습니다. 날짜만 있는 문자열은 UTC 자정으로 읽히는데, 그걸 다시 지역
+ * 시간으로 그리면 UTC보다 서쪽인 타임존에서 하루가 밀립니다. 브라우저 타임존은 사용자 것이라
+ * 서버를 한국으로 맞춰도 막을 수 없습니다.
+ */
+const formatEventDate = (eventDate: string) => eventDate.replaceAll('-', '. ');
 
 export default formatEventDate;


### PR DESCRIPTION
## 변경 사항

이벤트 카드가 **주최자가 이벤트를 등록한 날짜**를 보여주고 있었습니다.

```tsx
- const datetime = formatEventDate(event.createdAt);
+ const datetime = formatEventDate(event.eventDate);
```

일주일 전에 만들어둔 이벤트는 목록에서 일주일 전 날짜로 보입니다. **주최자가 자기 행사를 날짜로 찾을 수 없습니다.**

TODO로 남아 있던 조건이 충족됐습니다. `eventDate`가 2026-08-12 명세로 들어와 있는데 화면이 아직 안 쓰고 있었습니다.

```tsx
- /* TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가
-    추가되면 해당 날짜로 사용해야 함. */
```

## `formatEventDate`에서 `Date` 파싱을 걷어냈습니다

```ts
- const eventDate = new Date(isoString);
- const year = eventDate.getFullYear();
- const month = eventDate.getMonth() + 1;
- const day = eventDate.getDate();
- return `${year}. ${month.toString().padStart(2, '0')}. ${day.toString().padStart(2, '0')}`;
+ const formatEventDate = (eventDate: string) => eventDate.replaceAll('-', '. ');
```

`eventDate`는 **시각이 없는 `YYYY-MM-DD`** 입니다. `Date`로 읽으면 UTC 자정이 되고, 그걸 지역 시간으로 다시 그리면 **UTC보다 서쪽인 타임존에서 하루가 밀립니다.**

```
'2026-09-01' → UTC 2026-09-01 00:00
             → America/New_York(-4) 에서 getDate() → 8월 31일
```

브라우저 타임존은 사용자 것이라 **서버를 한국으로 맞춰도 막을 수 없습니다.** 구분자만 바꾸면 파싱 자체를 안 하므로 그 문제가 생길 자리가 없어집니다.

**출력 문구는 `2026. 09. 01` 그대로입니다.** 화면은 달라지지 않습니다.

입력 형식이 날짜 전용으로 좁아졌으므로 매개변수 이름과 주석도 그에 맞게 바꿨습니다.

## 관련 이슈

- Closes #198

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 7.0s / ✓ Finished TypeScript in 6.4s
npm run test    ✓ 5 files, 102 tests passed (1.05s)
```

이벤트 목록에서 시드 이벤트 3개의 날짜가 `eventDate`와 맞는지 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `formatEventDate`는 이제 **날짜 전용 문자열만** 받습니다. 쓰는 곳이 `EventCard` 하나뿐이라 다른 화면에 영향이 없습니다.

## 트러블슈팅 및 참고 사항

### 공개 리포트 화면에서 같은 건을 먼저 고쳤습니다

`app/e/[code]/report/page.tsx`도 `createdAt`을 쓰고 있었고, 같은 방식으로 처리했습니다. 그쪽은 `Intl.DateTimeFormat`을 `Asia/Seoul` 고정으로 써서 막고 있었는데, 파싱을 없애니 12줄이 한 줄이 됐습니다.

### 두 화면의 날짜 표기가 다릅니다

| 화면 | 표기 |
|---|---|
| 이벤트 목록 | `2026. 09. 01` |
| 공개 리포트 | `2026.09.01` |

같은 종류의 값인데 공백 유무가 다릅니다. 이번 PR에서는 **기존 표기를 유지**했습니다 — 시안을 다시 보고 정해야 하는 건이라 범위 밖으로 뒀습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
