### PR TITLE
fix(event): 이벤트 설정 화면 재진입 시 캐시된 값으로 폼이 안 채워지는 문제 수정

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -11,7 +11,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import ReportPanel from '@/components/report/ReportPanel';
 import { showToast } from '@/hooks/useToast';
 import { eventCreateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
-import type { SessionView } from '@/lib/schemas/api';
+import type { EventView, SessionView } from '@/lib/schemas/api';
 import {
   createEvent,
   createSession,
@@ -83,7 +83,11 @@ const EventForm = ({ eventCode }: EventFormProps) => {
 
   // 쿼리 데이터가 새로 도착했을 때만 폼 입력값을 덮어씁니다(렌더링 중 상태 조정 —
   // useEffect로 하면 렌더가 한 번 더 겹치고 react-hooks/set-state-in-effect에 걸립니다).
-  const [loadedEventData, setLoadedEventData] = useState(eventQuery.data);
+  //
+  // 초깃값을 undefined로 고정합니다. eventQuery.data로 초기화하면, TanStack Query 캐시가
+  // 이전 방문에서 이미 이 이벤트를 받아온 상태로 재마운트될 때 loadedEventData가 처음부터
+  // eventQuery.data와 같아져서 아래 비교가 한 번도 참이 되지 않고, 폼이 빈 값으로 남습니다.
+  const [loadedEventData, setLoadedEventData] = useState<EventView | undefined>(undefined);
   if (eventQuery.data && eventQuery.data !== loadedEventData) {
     setLoadedEventData(eventQuery.data);
     setEventFormInputs({


### PR DESCRIPTION
## 변경 사항

- `EventForm.tsx`의 `loadedEventData`(직전에 폼에 반영했던 이벤트 데이터를 기억하는 로컬 상태) 초깃값을 `useState(eventQuery.data)` 대신 `useState<EventView | undefined>(undefined)`로 고정했습니다.

## 관련 이슈

- Closes #208

## 검증 방법

- `npx tsc --noEmit`, `npm run lint` 모두 통과를 확인했습니다.
- 로컬(`npm run dev`)에서 미공개 이벤트 설정 화면에 들어갔다가 뒤로가기 후 같은 이벤트를 다시 클릭해도 제목·행사 날짜·설명이 정상적으로 채워지는 것을 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

원인을 좁히는 과정에서 `EventForm.tsx`에 임시로 렌더링 로그(`console.log`)를 추가해 실제 렌더 순서를 확인했습니다.
확인 후 로그는 모두 제거했고, 이번 PR에는 포함되지 않습니다.
전체 진단 과정과 근거는 이슈 #208 에 정리해 뒀습니다.
