### PR TITLE
fix(live): 집계 스냅샷 폴링 간격을 3초로 줄인다

### DIFF
--- a/hooks/useFeedbackSnapshot.ts
+++ b/hooks/useFeedbackSnapshot.ts
@@ -16,7 +16,7 @@ import type { FeedbackSnapshot } from '@/lib/schemas/api';
  * 전제한 코드를 갖게 되면 격리한 의미가 없어집니다.
  */
 
-const REFRESH_INTERVAL_MS = 5_000;
+const REFRESH_INTERVAL_MS = 3_000;
 
 interface UseFeedbackSnapshotParams {
   eventCode: string;


### PR DESCRIPTION
## 변경 사항

- `useFeedbackSnapshot`의 폴링 간격을 **5초 → 3초**로 줄입니다.

새 소감이 서버에 반영된 시점부터 화면에 뜨기까지는 `다음 tick까지 대기(0~N초 균등, 평균 N/2)` + `왕복시간`입니다. 이 변경은 앞쪽만 줄입니다.

| 폴링 간격 | 평균 대기 | 최악 대기 |
| --- | --- | --- |
| 5초 (기존) | 2.5초 | 5초 |
| 3초 | 1.5초 | 3초 |

평균 1초, 최악 2초 단축입니다. **원인을 확정하고 여는 PR이 아니라, 배포해서 체감을 보려고 여는 PR입니다.** 아래 "트러블슈팅"에 배포 후 확인할 것을 정리해뒀습니다.

## 관련 이슈

- Closes #218

## 검증 방법

```
npm run lint    # 커밋 훅(lint-staged)에서 eslint --fix, prettier --write 통과
npm run build   # 통과
```

상수 하나만 바뀌어 동작 검증은 배포 환경에서 체감으로 확인합니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

다만 **요청 수가 1.67배 늘어납니다.** 라이브 페이지는 참가자 전원이 보는 화면이라 1인당 분당 12회 → 20회가 되고 인원수만큼 곱해집니다. 50명 동시 접속이면 600 → 1000회/분입니다. 백엔드 부하가 문제가 되면 되돌리거나 다른 방법을 찾아야 합니다.

## 트러블슈팅 및 참고 사항

**배포 후 확인할 것 3가지**

**1. 왕복시간이 병목인지** — DevTools Network에서 `GET /events/{code}/feedbacks`의 응답 시간을 봅니다.

- 300ms 안쪽 → 폴링 간격이 병목이 맞고 이 변경으로 충분
- 1초 이상 → 병목은 서버 쪽. 간격을 더 줄여도 이득이 작습니다
- 3초 초과 → 타이머가 응답보다 빨라 실효 갱신 주기가 응답시간에 수렴합니다. 요청만 늘고 개선이 없어 되돌리는 편이 낫습니다

**2. 체감이 "지연"이 아니라 "뚝뚝 끊김"인지** — `Thermometer`에는 CSS transition이 없어 `flexGrow`에 값이 꽂히는 순간 즉시 점프합니다. 거슬리는 게 끊기는 느낌이라면 요청을 늘리지 않고 고칠 수 있습니다.

```tsx
<div className="bg-positive-default transition-[flex-grow] duration-500" style={{ flexGrow: positive }} />
```

**3. 탭 복귀 시 갱신** — `QueryProvider.tsx`의 전역 기본값이 `refetchOnWindowFocus: false`이고 `refetchIntervalInBackground`는 기본 `false`라, 백그라운드 탭에서는 폴링이 멈춥니다. "돌아왔더니 값이 옛날 것"이라는 체감이라면 이 화면에 한해 포커스 refetch를 켜는 편이 요청 수 증가 없이 효과적입니다.

**참고**

- `staleTime: 10_000`은 폴링을 막지 않습니다. TanStack Query 문서상 `refetchInterval`은 staleTime과 독립적으로 동작합니다 ("a query can be fresh and still refetch on its schedule").
- 근본 해결은 CLAUDE.md에 적힌 SSE 승급입니다. `useFeedbackSnapshot` 내부만 바꾸면 되도록 이미 격리돼 있어 화면 코드는 손대지 않아도 됩니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 1개라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
