### PR TITLE
fix(events): 이벤트 목록 캐시 키를 대시보드와 통일한다

### DIFF
--- a/app/(host)/events/page.tsx
+++ b/app/(host)/events/page.tsx
@@ -19,7 +19,7 @@ const EventsListPage = () => {
 
   // API: GET/POST /events. "새 이벤트 만들기" 버튼은 /events/new로 이동합니다.
   const myEvents = useQuery({
-    queryKey: ['events', 'my'],
+    queryKey: ['myEvents'],
     queryFn: fetchMyEvents,
   });
 


### PR DESCRIPTION
## 변경 사항

- `EventsListPage`(`app/(host)/events/page.tsx`)의 `queryKey`를 `['events', 'my']`에서 `['myEvents']`로 변경했습니다.
- `DashboardView`(`components/dashboard/DashboardView.tsx`)가 이미 쓰고 있는 `['myEvents']` 키에 맞춰, 두 화면이 같은 `fetchMyEvents` 데이터를 같은 캐시 키로 관리하도록 통일했습니다.
- 이슈 #193에 정리된 두 처방(단기/근본) 중 근본 처방을 선택했습니다. `DashboardView`는 `'myEvents'` 키를 두 곳(쿼리, `invalidateQueries`)에서 참조하고 있어 변경 범위가 더 작고, 코드베이스의 다른 쿼리 키들(`['event', eventCode]`, `['sessions', eventCode]`, `['auth', 'me']` 등)이 두 번째 배열 요소로 파라미터를 쓰는 패턴과도 `['myEvents']` 쪽이 더 맞아 `EventsListPage` 쪽을 바꿨습니다.

## 관련 이슈

- Fixes #193

## 검증 방법

- `npm run lint` 통과를 확인했습니다.
- `npx tsc --noEmit` 통과를 확인했습니다.
- 검증 시나리오
  - [x] 다른 이벤트의 대시보드를 먼저 한 번 방문해 `['myEvents']` 캐시를 채워둡니다.
  - [x] 세션이 1개 이상 등록된 `DRAFT` 상태 이벤트의 설정 화면(`/events/{code}`)에서 "이벤트 시작" 버튼을 누릅니다.
  - [x] 대시보드 화면(`/events/{code}/dashboard`)으로 이동하는 순간 "이 이벤트를 볼 수 없어요" 배너가 더 이상 뜨지 않는지 확인합니다.
  - [x] `/events`(EventsListPage)에서 이벤트 생성/삭제 후 목록이 정상적으로 갱신되는지 확인합니다(회귀 확인).

<img width="941" height="954" alt="2026-08-19 PR#222 첨부용" src="https://github.com/user-attachments/assets/5edf395c-c911-4b1f-96c8-21dda25f02a5" />



## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- 이 버그의 전제 조건이었던 대시보드 자동 이동(#177, PR #179)은 이미 dev에 머지된 상태라, 이 PR을 머지하지 않으면 dev에서도 재현되는 버그입니다.
- 이슈 #193 본문의 "결정 사항" 섹션에 이번 결정 근거를 갱신해뒀습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
