### PR TITLE
fix(events): 이벤트 목록 화면의 참가자 링크를 실제 도메인 기준으로 표시한다

### DIFF
--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -11,7 +11,7 @@ export interface EventCardProps {
 
 const RIGHT_CONTENT_BY_STATUS = {
   LIVE: (event: PulseEvent) => ({
-    label: `pulse.app/e/${event.code}`,
+    label: `${window.location.origin}/e/${event.code}`,
     className: 'text-xs text-primary-darker',
   }),
   ENDED: () => ({


### PR DESCRIPTION
## 변경 사항

이벤트 목록 화면(`/events`)에서 진행 중(LIVE) 상태 이벤트의 참가자 링크 라벨이 
`pulse.app/e/...`로 고정 표시되던 문제를 고쳤습니다.
<img width="902" height="429" alt="shot-mszeuxp6" src="https://github.com/user-attachments/assets/5887ea54-c510-4dd5-8dac-10c2d7c67580" />

- **`components/events/EventCard.tsx`** 는 이벤트 목록 화면에서 이벤트 한 건을 카드 하나로 그리는 컴포넌트입니다.
  - AS-IS: 지금은 진행 중 상태일 때 참가자 링크 라벨을 `pulse.app/e/${event.code}`로 직접 문자열로 만들고 있습니다.
  - TO-BE: `${window.location.origin}/e/${event.code}`로 바꿔, 실제 접속 중인 도메인을 기준으로 링크를 표시합니다.

이벤트 설정 화면(`components/events/EventForm.tsx:264`)에는 이미 같은 방식(`window.location.origin` 기반)이 이슈 #178·PR #180 에서 적용되어 있었습니다.  
그 작업은 이벤트 설정 화면만 고쳤습니다.  
이벤트 목록 화면의 같은 하드코딩은 그때 놓쳐서, 이번 PR로 두 화면의 방식을 통일했습니다.

## 관련 이슈

- Closes #225

## 검증 방법

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

`localhost:3000/events`에서 진행 중 상태 카드 여러 개의 참가자 링크가 모두 `http://localhost:3000/e/{이벤트 코드}` 형식으로 표시되는 것을 로컬 브라우저로 직접 확인했습니다.

준비 중(DRAFT)·종료(ENDED) 상태 카드는 이번 변경과 무관한 분기라 기존과 동일하게 각각 빈 값·"리포트 공개됨"으로 표시됩니다.

### 실행한 명령과 결과

- `npx tsc --noEmit` — 통과했습니다.
- `npm run lint` — 통과했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

