### PR TITLE
fix: 결과 화면의 키워드 빈 상태를 대시보드와 통일한다

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -126,21 +126,27 @@ const ReportPage = async ({ params }: ReportPageProps) => {
         <Donut {...counts} className="py-2" />
       </section>
 
-      <section className="flex flex-col gap-3">
-        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
-        {/* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */}
-        <ul className="flex flex-wrap gap-2">
-          {topKeywords.map(({ keyword, count }) => (
-            <li
-              key={keyword}
-              className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
-            >
-              {keyword}
-              <span className="text-text-tertiary">{count}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
+      {/*
+        키워드가 하나도 없으면 제목만 남은 빈 칸이 되므로 섹션을 통째로 뺍니다. 생성이 끝난
+        리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
+      */}
+      {topKeywords.length > 0 && (
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+          {/* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */}
+          <ul className="flex flex-wrap gap-2">
+            {topKeywords.map(({ keyword, count }) => (
+              <li
+                key={keyword}
+                className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
+              >
+                {keyword}
+                <span className="text-text-tertiary">{count}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
     </main>
   );
 };

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -193,13 +193,13 @@ const LiveResult = () => {
             <Thermometer positive={POS} neutral={NEU} negative={NEG} />
           </section>
 
-          <section className="flex flex-col gap-2">
-            <h3 className="text-xs text-text-tertiary">많이 나온 말</h3>
-            {keywords.length === 0 ? (
-              <p className="flex min-h-32 items-center justify-center rounded-xl border border-border-subtle p-4 text-sm text-text-tertiary">
-                아직 모인 키워드가 없어요
-              </p>
-            ) : (
+          {/*
+            키워드가 없으면 제목과 빈 상자만 남으므로 섹션을 통째로 뺍니다(#221). 폴링이라
+            소감이 쌓이면 다시 나타납니다.
+          */}
+          {keywords.length > 0 && (
+            <section className="flex flex-col gap-2">
+              <h3 className="text-xs text-text-tertiary">많이 나온 말</h3>
               <ul className="flex min-h-32 flex-wrap items-center justify-center gap-x-6 gap-y-4 rounded-xl border border-border-subtle p-4">
                 {keywords.map(({ keyword, count }) => (
                   <li key={keyword}>
@@ -208,8 +208,8 @@ const LiveResult = () => {
                   </li>
                 ))}
               </ul>
-            )}
-          </section>
+            </section>
+          )}
 
           {refreshIntervalMs !== null && (
             <p className="text-center text-xs text-text-secondary">


### PR DESCRIPTION
## 변경 사항

- 실시간 결과 화면(`/e/{code}/live`)과 공개 리포트(`/e/{code}/report`)의 키워드 섹션을 항상 렌더링하고, 키워드가 비어 있으면 `아직 모인 키워드가 없어요`를 보여줍니다. 대시보드의 상위 키워드 카드(`components/dashboard/KeywordCard.tsx`)가 이미 쓰던 문구라, 이제 세 화면의 빈 상태가 같은 문구로 통일됩니다.
- 라이브 결과의 섹션 제목 `많이 나온 말`을 리포트와 같은 `주요 키워드`로 바꿨습니다. (대시보드는 백오피스라 `상위 키워드`를 그대로 둡니다.)
- 처음에는 두 화면 모두 키워드가 없으면 섹션을 통째로 숨겼는데, 대시보드만 빈 상태 문구를 노출해 화면마다 동작이 갈렸습니다. 숨기는 대신 문구를 맞추는 쪽으로 방향을 바꿨습니다.
- 리포트는 생성이 끝났더라도 소감이 적으면 뽑힐 키워드가 없을 수 있어(`publicReportSchema`) 같은 빈 상태를 씁니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 9388f10 | fix: 키워드가 없으면 결과 화면의 키워드 섹션을 숨긴다 | 제목과 빈 상자만 남아 자리만 차지하는 문제를 먼저 섹션 숨김으로 처리 |
| 6ea9cce | fix: 키워드 빈 상태 문구와 제목을 화면끼리 통일한다 | 대시보드는 빈 상태 문구를 노출해 화면 간 동작이 갈려, 숨김을 되돌리고 문구·제목을 통일 |

## 관련 이슈

- Closes #221

> 워드클라우드 도입은 득보다 실이 많은것 같아서 재논의 할 예정입니다

## 검증 방법

- `npm run test` → Test Files 5 passed (5) / Tests 102 passed (102)
- `npm run lint` → 통과 (출력 없음)
- `npm run build` → 통과, 라우트 13개 정상 생성

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
