### PR TITLE
fix(dashboard): 대시보드 좌우 여백을 헤더와 맞춘다

### DIFF
--- a/app/(host)/events/[eventCode]/dashboard/page.tsx
+++ b/app/(host)/events/[eventCode]/dashboard/page.tsx
@@ -16,7 +16,7 @@ import { DashboardView } from '@/components/dashboard/DashboardView';
  */
 const DashboardPage = () => {
   return (
-    <main className="flex flex-col gap-6 px-5 md:px-20">
+    <main className="flex flex-col gap-6 p-5 md:px-20">
       <DashboardView />
     </main>
   );

--- a/app/(host)/events/[eventCode]/dashboard/page.tsx
+++ b/app/(host)/events/[eventCode]/dashboard/page.tsx
@@ -16,7 +16,7 @@ import { DashboardView } from '@/components/dashboard/DashboardView';
  */
 const DashboardPage = () => {
   return (
-    <main className="flex flex-col gap-6 p-5 md:p-8">
+    <main className="flex flex-col gap-6 px-5 md:px-20">
       <DashboardView />
     </main>
   );


### PR DESCRIPTION
## 변경 사항

- 대시보드 페이지의 `main` 패딩을 `p-5 md:p-8` → `p-5 md:px-20`으로 바꿔 헤더와 좌우 정렬선을 맞췄습니다.
- 헤더(`components/layout/Header.tsx:16`)가 `px-5 md:px-20`을 쓰고 있어 좌우 값은 그대로 따랐습니다. `components/layout/README.md`에 적힌 레이아웃 기준(`px-5` / `md:px-20`)과도 일치합니다.
- 상하 여백은 `p-5`로 유지하고 md 이상에서 좌우만 `px-20`으로 덮습니다. `DashboardView` 루트가 `flex flex-col gap-4`라 자체 상하 여백이 없어, 좌우만 지정하면 헤더 아래로 첫 카드가 붙어버립니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 568187b | fix(dashboard): 대시보드 좌우 여백을 헤더와 맞춘다 | 헤더와 어긋난 좌우 정렬선을 `px-5 md:px-20`으로 맞춤 |
| bbf180a | fix(dashboard): 대시보드 상하 패딩을 되살린다 | 좌우만 지정하니 상하 여백이 사라져 `p-5 md:px-20`으로 정정 |

## 관련 이슈

- Closes #229

## 검증 방법

- `npm run test` → Test Files 5 passed (5) / Tests 102 passed (102)
- `npm run lint` → 통과 (출력 없음)
- `npm run build` → 통과, 라우트 13개 정상 생성

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

- 처음에는 `px-5 md:px-20`으로 좌우만 지정했는데, 그러면 기존 `p-5 md:p-8`이 주던 상하 여백까지 사라져 헤더 아래로 첫 카드가 붙고 페이지 하단도 여백 없이 끝났습니다. `p-5 md:px-20`으로 바꿔 상하 여백을 지키면서 좌우만 헤더 기준에 맞췄습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
