### PR TITLE
chore(event): 이벤트 카드의 낡은 TODO 주석을 지운다

### DIFF
--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -32,7 +32,6 @@ const EventCard = ({ event }: EventCardProps) => {
 
   const { tone, label } = EVENT_STATUS_BADGE[event.status];
 
-  // TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가 추가되면 해당 날짜로 사용해야 함.
   const datetime = formatEventDate(event.eventDate);
   const rightContent = RIGHT_CONTENT_BY_STATUS[event.status](event);
   const href = ROUTE_BY_STATUS[event.status](event);


### PR DESCRIPTION
## 변경 사항

`components/events/EventCard.tsx`의 TODO 주석 한 줄을 지웁니다.

```diff
-  // TODO : 현재는 이벤트 생성 날짜(createdAt)으로 작업했으나, 백엔드 ERD에 '실제 이벤트 일자'가 추가되면 해당 날짜로 사용해야 함.
   const datetime = formatEventDate(event.eventDate);
```

주석은 "`createdAt`으로 작업했다"고 하는데 바로 아랫줄이 `event.eventDate`를 씁니다. **설명이 사실과 반대입니다.** 코드가 아니라 주석을 믿으면 이미 끝난 작업을 다시 하러 갑니다.

## 관련 이슈

- Refs #198

`#198`은 `#214`로 머지돼 이미 닫혔습니다. 기능(`createdAt` → `eventDate` 전환)은 그때 다 들어갔고, 그 전환 때문에 낡아버린 이 주석만 `git add`에서 빠졌습니다. 닫힌 이슈라 `Closes`를 걸어도 아무 일도 일어나지 않으므로 `Refs`로 답니다.

## 검증 방법

```
$ npm run lint     # 통과
$ npm run build    # 통과
$ npm run test     # 통과
```

주석만 지웠으므로 동작은 바뀌지 않습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

`#223` 작업 중 `git stash`를 정리하다 발견했습니다. 삭제가 워킹 트리에만 있고 커밋된 적이 없어서, `git log -S`로 dev 히스토리를 훑어도 이 주석을 지운 커밋이 나오지 않았습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
