### PR TITLE
fix(feedback): 이미 소감을 낸 세션에 다시 제출되지 않게 막는다

### DIFF
--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
 import { Banner } from '@/components/ui/Banner';
 import { Button } from '@/components/ui/Button';
 import { Chip } from '@/components/ui/Chip';
+import { CheckIcon } from '@/components/ui/icons';
 import { Textarea } from '@/components/ui/Textarea';
 
 import type { SessionView } from '@/lib/schemas/api';
 import { submitFeedback } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import { markSubmitted } from '@/lib/storage/submitted';
+import { listSubmitted, markSubmitted } from '@/lib/storage/submitted';
 
 import { toSubmitPayload } from '@/lib/tagger';
 import { useTagger } from '@/hooks/useTagger';
@@ -37,16 +38,64 @@ interface FeedbackFormProps {
 }
 
 const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
-  // CLOSED 세션은 목록에 남지만 고를 수 없습니다.
-  const openSessions = sessions.filter((session) => session.status === 'ACTIVE');
-
-  const [selectedId, setSelectedId] = useState<number | null>(
-    openSessions.length === 1 ? openSessions[0].id : null,
-  );
+  const [pickedId, setPickedId] = useState<number | null>(null);
   const [text, setText] = useState('');
 
   const router = useRouter();
   const { warmup, tag } = useTagger();
+
+  /*
+   * 제출 기록은 브라우저에만 있어서 서버 렌더에서는 항상 비어 있습니다. 렌더 중에 읽으면
+   * 서버와 클라이언트 결과가 어긋나므로 마운트 후에 읽습니다.
+   *
+   * `null`은 "아직 안 읽음"입니다. 그동안은 아무 세션도 고를 수 없습니다 — 기록을 모르는
+   * 채로 고르게 두면 이미 낸 세션이 그냥 선택되어 중복 제출이 열립니다(#232).
+   */
+  const [submitted, setSubmitted] = useState<Set<number> | null>(null);
+
+  useEffect(() => {
+    /*
+     * `react-hooks/set-state-in-effect`를 끕니다. 마운트 직후 한 번으로 끝나고, 룰이 권하는
+     * `useSyncExternalStore`로 바꾸면 구독하지 않는 스토어를 억지로 만들게 됩니다.
+     * `LiveResult`가 같은 기록을 같은 이유로 같은 모양으로 읽습니다.
+     */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSubmitted(listSubmitted(eventCode));
+  }, [eventCode]);
+
+  /*
+   * 고를 수 있는 세션입니다. CLOSED는 목록에 남지만 못 고르고, 이미 낸 세션은 고르는 대신
+   * 결과 화면으로 가는 길이 됩니다.
+   */
+  const selectableSessions =
+    submitted === null
+      ? []
+      : sessions.filter((session) => session.status === 'ACTIVE' && !submitted.has(session.id));
+
+  /*
+   * 고를 게 하나뿐이면 미리 골라둡니다. `useState` 초기값으로 두지 않는 이유는 그 값이
+   * 서버에서도 계산되기 때문입니다. 기록을 읽기 전에는 이미 낸 세션까지 후보에 들어가서,
+   * 세션이 하나뿐인 이벤트를 다시 열면 이미 낸 세션이 선택된 채로 폼이 뜹니다.
+   */
+  const selectedId =
+    pickedId ?? (selectableSessions.length === 1 ? selectableSessions[0].id : null);
+
+  const handleSelect = (sessionId: number) => {
+    /*
+     * 이미 남긴 세션은 다시 받지 않고 그 세션의 결과 화면으로 보냅니다(#232). 여기서 막지
+     * 않으면 결과 화면에서 뒤로가기로 돌아왔을 때 같은 세션에 또 낼 수 있고, 서버가 중복을
+     * 막지 않아서 그대로 등록됩니다(#92).
+     *
+     * `submitted=1`은 붙이지 않습니다. 방금 낸 사람에게만 띄우는 등록 안내라, 결과를 보러
+     * 다시 들어온 사람에게 뜨면 방금 낸 것처럼 읽힙니다.
+     */
+    if (submitted?.has(sessionId) === true) {
+      router.push(`/e/${eventCode}/live?sessionId=${sessionId}`);
+      return;
+    }
+
+    setPickedId(sessionId);
+  };
 
   const { mutate, isPending, error } = useMutation({
     // 제출 직전에 태깅합니다. 실패하거나 3초를 넘기면 tag가 null을 주고,
@@ -81,9 +130,18 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
             <Chip
               key={session.id}
               selected={session.id === selectedId}
-              disabled={session.status === 'CLOSED' || isPending}
-              onClick={() => setSelectedId(session.id)}
+              disabled={session.status === 'CLOSED' || isPending || submitted === null}
+              onClick={() => handleSelect(session.id)}
             >
+              {/* 아이콘은 prop이 아니라 children입니다(`components/ui/README.md`). ✓에
+                  `aria-hidden`이 붙어 있어 sr-only 문구가 없으면 스크린리더에는 일반 칩과
+                  똑같이 읽힙니다. */}
+              {submitted?.has(session.id) === true ? (
+                <>
+                  <CheckIcon />
+                  <span className="sr-only">소감을 남긴 세션, </span>
+                </>
+              ) : null}
               {session.title}
             </Chip>
           ))}
@@ -93,40 +151,57 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
             지금 소감을 받는 세션만 선택할 수 있어요
           </p>
         ) : null}
+        {sessions.some((session) => submitted?.has(session.id) === true) ? (
+          <p className="text-xs font-normal leading-4 text-text-tertiary">
+            ✓ 표시된 세션을 누르면 그 세션의 결과를 볼 수 있어요
+          </p>
+        ) : null}
       </section>
 
-      <section className="flex flex-col gap-1">
-        <div className="flex items-center justify-between">
-          <p className="text-xs font-normal leading-4 text-text-tertiary">한줄 소감</p>
-          <p className="text-xs font-normal leading-4 text-text-tertiary">{text.length}/200</p>
-        </div>
-        <Textarea
-          placeholder="이번 세션은 어떠셨나요?"
-          maxLength={200}
-          value={text}
-          onChange={(event) => setText(event.target.value)}
-          onFocus={warmup}
-        />
-      </section>
-      {error ? (
-        <Banner type="negative" className="w-full">
-          {error instanceof ApiError
-            ? (ERROR_MESSAGE[error.code] ?? FALLBACK_MESSAGE)
-            : FALLBACK_MESSAGE}
-        </Banner>
-      ) : null}
-      <Banner type="info" className="w-full">
-        제출하면 브라우저에서 감정을 자동 분석해요
-      </Banner>
+      {/* 세션을 고르기 전에는 입력란부터 버튼까지 내보내지 않습니다. 어느 세션에 남기는지
+          모르는 채로 소감을 다 쓰고 나서야 버튼이 안 눌리는 걸 알게 되는 순서였습니다.
 
-      <Button
-        size="lg"
-        className="w-full"
-        disabled={selectedId === null || text.trim() === '' || isPending}
-        onClick={() => mutate(selectedId!)}
-      >
-        {isPending ? '보내는 중...' : '소감 남기기'}
-      </Button>
+          기록을 읽기 전(`submitted === null`)에도 `selectedId`가 null이라 같이 가려집니다.
+          세션이 하나뿐인 이벤트에서는 자동 선택이 걸리면서 입력란이 한 박자 늦게 나타나는데,
+          기록을 안 읽고 그리면 이미 낸 세션에도 입력란이 열리므로 이쪽이 맞습니다. */}
+      {selectedId !== null && (
+        <>
+          <section className="flex flex-col gap-1">
+            <div className="flex items-center justify-between">
+              <p className="text-xs font-normal leading-4 text-text-tertiary">한줄 소감</p>
+              <p className="text-xs font-normal leading-4 text-text-tertiary">{text.length}/200</p>
+            </div>
+            <Textarea
+              placeholder="이번 세션은 어떠셨나요?"
+              maxLength={200}
+              value={text}
+              onChange={(event) => setText(event.target.value)}
+              onFocus={warmup}
+            />
+          </section>
+
+          {error ? (
+            <Banner type="negative" className="w-full">
+              {error instanceof ApiError
+                ? (ERROR_MESSAGE[error.code] ?? FALLBACK_MESSAGE)
+                : FALLBACK_MESSAGE}
+            </Banner>
+          ) : null}
+
+          <Banner type="info" className="w-full">
+            제출하면 브라우저에서 감정을 자동 분석해요
+          </Banner>
+
+          <Button
+            size="lg"
+            className="w-full"
+            disabled={text.trim() === '' || isPending}
+            onClick={() => mutate(selectedId)}
+          >
+            {isPending ? '보내는 중...' : '소감 남기기'}
+          </Button>
+        </>
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 변경 사항

- 제출 화면(`FeedbackForm`)이 마운트 후 `listSubmitted`로 제출 기록을 읽습니다. 이미 낸 세션 칩은 선택 대신 그 세션의 결과 화면(`/e/{code}/live?sessionId={id}`)으로 보냅니다. #92에서 읽는 쪽으로 이미 계획돼 있던 분기인데 구현이 빠져 있었습니다.
- 기록을 읽기 전(`submitted === null`)에는 칩을 비활성으로 둡니다. 그 사이에 눌러서 통과하는 경로를 막습니다.
- "세션이 하나면 자동 선택"을 `useState` 초기값에서 파생값으로 옮겼습니다. 초기값은 서버에서도 계산되는데 그때는 기록이 비어 있어서, 세션이 하나뿐인 이벤트를 다시 열면 이미 낸 세션이 선택된 채로 폼이 떴습니다.
- 이미 낸 세션 칩에 완료 표시(`CheckIcon`)를 붙였습니다. 시안에 "제출 완료" 상태가 없어서 색은 미선택 그대로 두고 아이콘만 넣었습니다 — Chip의 `icon=true` variant를 쓰는 방식이라 `components/ui/README.md`의 상태 표를 건드리지 않습니다. 아이콘에 `aria-hidden`이 붙어 있어 `sr-only` 문구를 같이 넣습니다.
- 세션을 고르기 전에는 입력란부터 제출 버튼까지 내보내지 않습니다. 어느 세션에 남기는지 모르는 채로 소감을 다 쓰고 나서야 버튼이 안 눌리는 걸 알게 되는 순서였습니다.

### 원인

제출 성공 시 `markSubmitted`로 남기는 로컬 기록을 읽는 곳이 결과 화면(`LiveResult`) 하나뿐이었습니다. 폼은 이미 낸 세션인지 모르는 채로 다시 열렸고, 서버는 중복 제출을 막지 않아(2026-08-07 명세, #92) 분당 3회 레이트리밋에 걸리기 전까지 그대로 등록됐습니다.

## 관련 이슈

- Closes #232
- Refs #92

## 검증 방법

### 명령

| 명령 | 결과 |
| --- | --- |
| `npm run lint` | 통과 (출력 없음) |
| `npm run test` | 통과 — 5 files / 102 tests |
| `npx tsc --noEmit` | 통과 (exit 0) |

### 수동 재현 (dev 서버 + MSW 목, 이벤트 `ab3f9x`)

사전 조건으로 `localStorage`의 `pulse:submitted:ab3f9x`를 지우고 시작했습니다.

| # | 절차 | 결과 |
| --- | --- | --- |
| 1 | `/e/ab3f9x` 진입 | 칩 3개만 보이고 입력란·배너·제출 버튼 없음 |
| 2 | `1부: 키노트` 선택 | 입력란·안내 배너·제출 버튼이 나타남 |
| 3 | 소감 입력 후 제출 | `/e/ab3f9x/live?sessionId=101`로 이동, "소감이 등록되었어요" 배너, 소감 9개 |
| 4 | **브라우저 뒤로가기** | `1부: 키노트` 칩에 ✓ 표시, 남은 미제출 세션 `2부: 패널 토론`이 자동 선택, "✓ 표시된 세션을 누르면…" 안내 노출 |
| 5 | ✓ 표시된 `1부: 키노트` 칩 클릭 | 선택되지 않고 `/e/ab3f9x/live?sessionId=101`로 이동. **등록 배너 안 뜸**(`submitted=1` 미부착), **소감 9개 그대로 — 중복 등록 없음** |
| 6 | `localStorage` 확인 | `pulse:submitted:ab3f9x = [101]` — 한 번만 기록됨 |

수정 전에는 4번에서 `1부: 키노트`가 아무 표시 없이 그대로 선택 가능했고, 5번에서 다시 제출하면 그대로 등록됐습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**이 방어는 완전하지 않습니다.** 근거가 `localStorage`라서 시크릿 모드·다른 기기·기록 삭제면 그대로 뚫립니다. 안내 수준이지 차단이 아닙니다. 실질적인 중복 방지는 서버가 `(sessionId, X-Client-Id)` 유니크로 막아야 하고, 그 키는 이미 레이트리밋에서 쓰고 있습니다(`mocks/data/store.ts`의 `isRateLimited`). API 스펙 변경이라 백엔드 담당자 확인이 먼저여서 이 PR 범위에서 뺐습니다.

**ACTIVE 세션을 전부 제출한 상태로 이 화면에 오면 입력란과 제출 버튼이 아예 안 나옵니다.** `LiveResult`의 "다른 세션 결과 보기" 버튼이 정확히 그 상태로 여기 보내고, 그때는 칩이 결과 화면으로 가는 길 역할을 하는 게 원래 설계라 그대로 뒀습니다. 별도 빈 화면을 붙이는 건 이슈 범위를 넘어서 하지 않았습니다.

**세션이 하나뿐인 이벤트에서는 입력란이 한 박자 늦게 나타납니다.** 기록을 읽어야 자동 선택 여부를 정할 수 있어서입니다. 기록을 안 읽고 먼저 그리면 이미 낸 세션에도 입력란이 열리므로 이쪽을 택했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
