### PR TITLE
fix(dashboard): 세션 토글이 없을 때도 자리를 잡는다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -266,8 +266,23 @@ const DashboardView = () => {
    * 시작 전이나 끝난 뒤에 세션만 열어두면 화면은 "소감 받는 중"이라고 하고 참가자는
    * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다.
    */
-  const renderSessionToggle = (className: string) =>
-    event.status === 'LIVE' && selectedSession !== null ? (
+  const renderSessionToggle = (className: string) => {
+    if (event.status !== 'LIVE') return null;
+
+    /*
+     * "전체"에는 켜고 끌 대상이 없지만 자리는 남겨둡니다. 비워두면 칩을 오갈 때마다 토글
+     * 한 줄이 통째로 생겼다 사라지면서, 데스크톱은 헤더가 접혀 아래 카드가 전부 밀리고
+     * 모바일은 칩 줄 높이가 바뀝니다.
+     *
+     * `h-9`는 토글의 높이입니다 — 안에서 가장 큰 게 `size="sm"` 버튼이라 그 높이가 그대로
+     * 줄 높이가 됩니다. 배지(`h-6`)는 가운데 정렬돼서 높이를 정하지 않습니다.
+     *
+     * `LIVE`가 아닐 때는 위에서 이미 빠져나갔습니다. 그 상태에서는 토글이 영영 나오지
+     * 않으므로 자리를 잡아봐야 빈 공간만 남습니다.
+     */
+    if (selectedSession === null) return <div className={`h-9 ${className}`} aria-hidden />;
+
+    return (
       <SessionToggle
         session={selectedSession}
         isPaused={sessionControls.isPaused(selectedSession.id)}
@@ -275,7 +290,8 @@ const DashboardView = () => {
         onToggle={(status) => sessionControls.toggle(selectedSession.id, status)}
         className={className}
       />
-    ) : null;
+    );
+  };
 
   return (
     <div className="flex flex-col gap-4">


### PR DESCRIPTION
## 변경 사항

- `DashboardView`의 `renderSessionToggle`이 `LIVE`이면서 "전체" 칩을 고른 상태일 때, `null` 대신 같은 높이(`h-9`)의 빈 자리를 내보냅니다.
- `event.status !== 'LIVE'`는 그대로 `null`입니다. 그 상태에서는 토글이 영영 나오지 않으므로 자리를 잡으면 빈 공간만 남습니다.

`h-9`는 토글 안에서 가장 큰 `size="sm"` 버튼의 높이입니다. 배지(`h-6`)는 가운데 정렬돼서 줄 높이를 정하지 않습니다.

### 원인

"전체"(`selectedSession === null`)에는 켜고 끌 대상이 없어 토글이 통째로 빠졌습니다. 그래서 칩을 오갈 때마다 `h-9` 한 줄이 생겼다 사라지면서 데스크톱은 `DashboardHeader`의 `{sessionToggle}` 자리가 접혀 아래 카드가 전부 밀리고, 모바일은 `SessionFilterBar`의 칩 줄 높이가 바뀌었습니다.

## 관련 이슈

- Closes #234

## 검증 방법

### 명령

| 명령 | 결과 |
| --- | --- |
| `npm run lint` | 통과 (출력 없음) |
| `npm run test` | 통과 — 5 files / 102 tests |
| `npx tsc --noEmit` | 통과 (exit 0) |

### 수동 비교 (dev 서버, `LIVE` 이벤트 / 세션 3개)

같은 화면에서 이 커밋을 `git stash`로 뺐다 넣으며 앞뒤를 직접 비교했습니다.

| 상태 | 수정 전 | 수정 후 |
| --- | --- | --- |
| "전체" 선택 | 칩 줄이 헤더 버튼 줄에 붙어 올라감 | 칩 줄이 토글 자리만큼 내려온 위치에 고정 |
| 세션 칩 선택 | 토글 줄이 생기면서 칩 줄과 아래 통계 카드가 통째로 아래로 밀림 | 칩 줄·통계 카드 위치 그대로, 토글만 예약된 자리에 들어옴 |
| "전체"로 복귀 | 다시 위로 올라감 | 그대로 |

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**처음에는 "어느 세션이 소감을 받는 중인지 칩에서 알 수 없다"도 같이 다루려 했습니다.** `ACTIVE` 칩에 `positive` 색 점(`DotIcon`)을 붙이는 방식으로 구현했는데 — 칩의 색은 이미 "선택됨"에 쓰이고 있어서 칩 전체를 칠하면 선택하는 순간 표시가 사라지고, 점은 선택 상태와 겹치지 않아 둘 다 남는다는 판단이었습니다 — 실제 화면에서 보기 좋지 않아 되돌렸습니다. 표시 방법을 다시 정하면 별도 이슈로 다룹니다. 그래서 이 PR은 `ui/Chip.tsx`와 `ui/icons.tsx`를 건드리지 않습니다.

**검증에 쓴 로컬 dev 서버는 MSW 목이 아니라 실제 로컬 백엔드에 붙어 있었습니다.** 실제 데이터라 칩 전환과 화면 읽기만 했고, 세션 상태를 바꾸는 「멈추기」 버튼은 누르지 않았습니다. 토글의 **자리**만 검증 대상이라 버튼 동작까지 볼 필요는 없었습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
