### PR TITLE
fix: 키워드 빈 상태 문구와 제목을 화면끼리 통일한다

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -126,14 +126,16 @@ const ReportPage = async ({ params }: ReportPageProps) => {
         <Donut {...counts} className="py-2" />
       </section>
 
-      {/*
-        키워드가 하나도 없으면 제목만 남은 빈 칸이 되므로 섹션을 통째로 뺍니다. 생성이 끝난
-        리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
-      */}
-      {topKeywords.length > 0 && (
-        <section className="flex flex-col gap-3">
-          <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
-          {/* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */}
+      <section className="flex flex-col gap-3">
+        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+        {/*
+          생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
+          이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
+        */}
+        {topKeywords.length === 0 ? (
+          <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
+        ) : (
+          /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
           <ul className="flex flex-wrap gap-2">
             {topKeywords.map(({ keyword, count }) => (
               <li
@@ -145,8 +147,8 @@ const ReportPage = async ({ params }: ReportPageProps) => {
               </li>
             ))}
           </ul>
-        </section>
-      )}
+        )}
+      </section>
     </main>
   );
 };

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -193,13 +193,13 @@ const LiveResult = () => {
             <Thermometer positive={POS} neutral={NEU} negative={NEG} />
           </section>
 
-          {/*
-            키워드가 없으면 제목과 빈 상자만 남으므로 섹션을 통째로 뺍니다(#221). 폴링이라
-            소감이 쌓이면 다시 나타납니다.
-          */}
-          {keywords.length > 0 && (
-            <section className="flex flex-col gap-2">
-              <h3 className="text-xs text-text-tertiary">많이 나온 말</h3>
+          <section className="flex flex-col gap-2">
+            <h3 className="text-xs text-text-tertiary">주요 키워드</h3>
+            {keywords.length === 0 ? (
+              <p className="flex min-h-32 items-center justify-center rounded-xl border border-border-subtle p-4 text-sm text-text-tertiary">
+                아직 모인 키워드가 없어요
+              </p>
+            ) : (
               <ul className="flex min-h-32 flex-wrap items-center justify-center gap-x-6 gap-y-4 rounded-xl border border-border-subtle p-4">
                 {keywords.map(({ keyword, count }) => (
                   <li key={keyword}>
@@ -208,8 +208,8 @@ const LiveResult = () => {
                   </li>
                 ))}
               </ul>
-            </section>
-          )}
+            )}
+          </section>
 
           {refreshIntervalMs !== null && (
             <p className="text-center text-xs text-text-secondary">


### PR DESCRIPTION
## 변경 사항

- 라이브 결과(`/e/{code}/live`)와 공개 리포트(`/e/{code}/report`)의 키워드 섹션을 항상 렌더링하고, 키워드가 없으면 대시보드와 같은 `아직 모인 키워드가 없어요` 문구를 보여줍니다.
- 라이브 결과의 섹션 제목 `많이 나온 말`을 리포트와 같은 `주요 키워드`로 통일합니다.

이 변경은 PR #228의 마지막 커밋이었으나 push되지 않은 채 머지돼 dev에 반영되지 않았습니다. 자세한 경위는 아래 트러블슈팅 항목에 적었습니다.

## 개발 과정 로그

커밋이 1개라 표는 생략합니다 (위 "변경 사항"으로 충분).

## 관련 이슈

- Closes #221

## 검증 방법

- `npm run lint` → 통과 (에러·경고 출력 없음)
- `npm run test` → Test Files 5 passed (5), Tests 102 passed (102)
- `git diff origin/dev...HEAD`가 원본 커밋 `6ea9cce`의 diff와 바이트 단위로 동일한 것을 확인했습니다. 즉 이 PR은 누락된 커밋을 그대로 되살릴 뿐, 새로 추가한 변경은 없습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

PR #228이 머지될 때 브랜치 `feat/221-result-wordcloud`의 마지막 커밋 `6ea9cce`가 push되지 않은 상태였습니다.

- 머지 커밋 `c251deb`는 `9388f10`까지만 담고 있습니다. `app/e/[code]/report/page.tsx`와 `components/live/LiveResult.tsx` 두 파일의 blob 해시가 `9388f10` 시점과 동일한 것으로 확인했습니다.
- 빠진 `6ea9cce`는 `9388f10`의 "키워드가 없으면 섹션을 통째로 숨김"을 되돌리는 커밋이라, dev가 의도와 반대 상태로 남아 있었습니다. 대시보드만 빈 상태 문구를 노출하고 나머지 두 화면은 섹션이 통째로 사라져 화면끼리 처리가 갈렸습니다.
- 원격 브랜치는 머지와 함께 삭제돼 재push가 불가능하므로, dev에서 새 브랜치를 파 cherry-pick으로 복구했습니다. `6ea9cce`의 부모 트리가 dev의 해당 파일과 일치해 충돌은 없었습니다.
- 이미 `COMPLETED`로 닫혀 있던 이슈 #221을 재오픈하고 같은 경위를 코멘트로 남겼습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
