### PR TITLE
fix(feedback): 감정 태깅 모델을 화면 진입 시 미리 받는다

### DIFF
--- a/components/feedback/FeedbackForm.tsx
+++ b/components/feedback/FeedbackForm.tsx
@@ -45,6 +45,15 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
   const { warmup, tag } = useTagger();
 
   /*
+   * 모델이 13.9MB라 받는 데 시간이 걸립니다. 참가자가 입력창을 누른 뒤 시작하면
+   * 타이핑이 짧은 사람은 3초 타임아웃에 걸려 UNKNOWN으로 나갑니다.
+   * 화면이 뜨자마자 받기 시작하면 소감을 쓰는 동안 준비가 끝납니다.
+   */
+  useEffect(() => {
+    warmup();
+  }, [warmup]);
+
+  /*
    * 제출 기록은 브라우저에만 있어서 서버 렌더에서는 항상 비어 있습니다. 렌더 중에 읽으면
    * 서버와 클라이언트 결과가 어긋나므로 마운트 후에 읽습니다.
    *
@@ -176,7 +185,6 @@ const FeedbackForm = ({ eventCode, sessions }: FeedbackFormProps) => {
               maxLength={200}
               value={text}
               onChange={(event) => setText(event.target.value)}
-              onFocus={warmup}
             />
           </section>
 


### PR DESCRIPTION
## 변경 사항

감정 태깅 모델을 **화면이 뜨는 순간** 받기 시작합니다.

```tsx
- <Textarea … onFocus={warmup} />

+ useEffect(() => {
+   warmup();
+ }, [warmup]);
```

## 왜 필요한가

모델이 **13.9MB**입니다. 참가자가 입력창을 누른 뒤 받기 시작하면, **타이핑이 짧은 사람은 다 받기 전에 제출**합니다.

```ts
// hooks/useTagger.ts
const TAG_TIMEOUT_MS = 3000;
```

3초 안에 안 끝나면 `UNKNOWN`으로 나갑니다. 행사장 Wi-Fi에서 13.9MB가 3초 안에 도착하기는 어렵습니다.

**미분류가 늘어나는 만큼 대시보드 감정 분포의 분모가 깎입니다.** 지금 태거의 홀드아웃 macro F1이 `0.736`인데, 여기에 타임아웃 미분류까지 더해지면 주최자가 보는 숫자가 실제와 더 멀어집니다.

원래 `onFocus`에 걸어둔 것도 같은 이유였습니다. 제출 버튼을 누른 뒤 받으면 **모든 소감이 `UNKNOWN`**이 되니 한 단계 앞당긴 것이고, 이번에 한 단계 더 앞당겼습니다.

## `onFocus`를 지운 이유

마운트에서 이미 부르므로 남겨두면 같은 일을 두 자리에서 걸게 됩니다. 동작은 같지만 **왜 둘인지 다음 사람이 되짚어야** 합니다.

중복 호출 자체는 안전합니다 — 워커가 같은 로딩을 재사용합니다(`useTagger`의 `getWorker`).

## 마운트 때 한 번만 도는 근거

```ts
const getWorker = useCallback((): Worker | null => { … }, []);
const warmup   = useCallback(() => { … }, [getWorker]);
```

`getWorker`의 의존성이 빈 배열이라 참조가 안 바뀌고, `warmup`도 따라서 안 바뀝니다. `useEffect`가 재실행되지 않습니다.

## ⚠️ 감수하는 것

**소감을 남길 생각이 없던 사람도 13.9MB를 받습니다.** 페이지에 들어왔다가 바로 나가는 경우까지요.

행사장에서 동시 접속이 몰리면 트래픽이 늘어납니다. 그래도 이쪽을 택한 이유는 **미분류가 쌓이면 대시보드 숫자 자체를 못 믿게 되기 때문**입니다.

트래픽이 실제로 문제가 되면 **지연 warmup**으로 좁힐 수 있습니다.

```tsx
useEffect(() => {
  const timer = setTimeout(warmup, 1_500);
  return () => clearTimeout(timer);
}, [warmup]);
```

바로 나가는 사람은 건너뛰게 됩니다. 지금은 단순한 쪽으로 갑니다.

### 검토했지만 버린 것

`autoFocus`를 주면 포커스가 자동으로 가서 같은 효과가 납니다. 다만 **트래픽은 마운트 즉시와 같으면서** 모바일에서 키보드가 바로 올라와 화면이 좁아집니다. 이득 없이 손해만 있습니다.

## 관련 이슈

- Closes #240

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully in 5.5s / ✓ Finished TypeScript in 5.5s
npm run test    ✓ 5 files, 102 tests passed (805ms)
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **참가자 화면 진입 시 13.9MB 다운로드가 시작됩니다.** 위 「감수하는 것」 참고.
- 태깅이 실패해도 제출은 진행됩니다(#82). 이 변경은 성공률을 올릴 뿐 동작을 바꾸지 않습니다.

## 트러블슈팅 및 참고 사항

배포 환경에서 소감 몇 건 넣어보고 `UNKNOWN` 비율이 실제로 줄었는지 확인해야 합니다. 대시보드의 `미분류` 지표로 볼 수 있습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
