### PR TITLE
fix(events): 이벤트 설정 화면 상하 여백을 목록 화면 기준으로 맞춘다

### DIFF
--- a/app/(host)/events/[eventCode]/page.tsx
+++ b/app/(host)/events/[eventCode]/page.tsx
@@ -10,7 +10,7 @@ const EventEditPage = async ({ params }: EventEditPageProps) => {
   const { eventCode } = await params;
 
   return (
-    <div className="min-h-dvh w-full flex flex-col justify-center items-center gap-6 p-14 bg-background-default">
+    <div className="w-full flex flex-col items-center gap-6 px-14 py-8 bg-background-default">
       <EventForm eventCode={eventCode} />
     </div>
   );

--- a/app/(host)/events/new/page.tsx
+++ b/app/(host)/events/new/page.tsx
@@ -3,7 +3,7 @@ import EventForm from '@/components/events/EventForm';
 const NewEventPage = () => {
   // API: POST /events. events/page.tsx의 "새 이벤트 만들기" 버튼이 이 페이지로 이동합니다.
   return (
-    <div className="min-h-dvh w-full flex flex-col justify-center items-center gap-6 p-14 bg-background-default">
+    <div className="w-full flex flex-col items-center gap-6 px-14 py-8 bg-background-default">
       <EventForm />
     </div>
   );


### PR DESCRIPTION
## 변경 사항

이벤트 설정 화면(등록/수정 공용, `/events/new`·`/events/[eventCode]`)의 상하 여백을 
이벤트 목록 화면(`/events`) 기준으로 맞췄습니다.

- AS-IS: 지금은 이벤트 설정 화면 최상위 div가 `min-h-dvh`(뷰포트 전체 높이)와 `justify-center`(세로 중앙 정렬)를 같이 가지고 있어서, 폼이 화면 세로 정중앙에 배치되고 위쪽 여백이 화면 높이에 따라 달라집니다.
- TO-BE: 이벤트 목록 화면과 동일하게 "위에서부터 고정 간격" 방식으로 바꿔서, `min-h-dvh`·`justify-center`를 제거하고 세로 padding을 목록 화면과 같은 `py-8`로 맞췄습니다. 가로 padding은 이번 작업 범위가 아니라 기존 `p-14` 값을 그대로 유지해 `px-14`로만 분리했습니다.

## 관련 이슈

- Closes #244

## 검증 방법

- `npm run lint`, `npx tsc --noEmit` 모두 통과했습니다.
- `/events`(목록)와 `/events/[eventCode]`(수정 화면)를 나란히 띄운 캡처로 콘텐츠 시작 지점을 비교했습니다.
  헤더 바로 다음에 오는 첫 요소(목록의 "내 이벤트" 텍스트, 설정 화면의 뒤로가기 아이콘)가 거의 같은 높이에서 시작하는 것을 확인했습니다.
  설정 화면의 "이벤트 설정" 제목 자체는 그 위 뒤로가기 버튼과 `gap-6` 간격 때문에 목록 화면의 "내 이벤트" 제목보다 조금 더 아래에 있는데, 이건 컨테이너 여백이 아니라 뒤로가기 버튼이라는 요소가 하나 더 있는 화면 구조 차이입니다.

<!-- 스크린샷: 여기에 첨부 -->
<img width="1792" height="1120" alt="shot-mt11chsa" src="https://github.com/user-attachments/assets/2d1294ca-39a7-40ca-9461-49dc27fca138" />


## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음
