### PR TITLE
fix(feedback): 게스트 화면이 세션·이벤트·리포트 변화를 따라간다

### DIFF
--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,23 +1,27 @@
 import { notFound } from 'next/navigation';
 
-import { FeedbackForm } from '@/components/feedback/FeedbackForm';
-import { EmptyState } from '@/components/ui/EmptyState';
-import { buttonStyle } from '@/components/ui/Button';
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import Link from 'next/link';
+import { EventEntryView } from '@/components/feedback/EventEntryView';
 
 export const dynamic = 'force-dynamic';
 interface EventEntryPageProps {
   params: Promise<{ code: string }>;
 }
 
+/**
+ * 첫 데이터만 서버에서 받아 `EventEntryView`에 넘깁니다. 화면 분기는 그쪽이 폴링 결과로 다시
+ * 계산합니다(#237).
+ *
+ * fetch를 서버에 남겨두는 이유는 SSR HTML에 완성된 첫 화면을 실어 보내기 위해서입니다. 셋 다
+ * 클라이언트로 내리면 게스트가 빈 화면을 먼저 받고 나서 요청 세 개를 새로 쏘게 됩니다.
+ */
 const EventEntryPage = async ({ params }: EventEntryPageProps) => {
   const { code } = await params;
 
   // 서버에서 부릅니다. 두 요청이 서로를 안 기다리도록 병렬로 보냅니다.
-  // DRAFT·ENDED에서는 sessions를 안 쓰지만, 상태를 먼저 받고 결정하면
-  // 가장 흔한 LIVE 경로가 왕복 하나만큼 느려집니다. 응답 하나 버리는 게 낫습니다.
+  // DRAFT·ENDED에서는 sessions를 쓸 일이 없지만, 상태를 먼저 받고 결정하면
+  // 가장 흔한 LIVE 경로가 왕복 하나만큼 느려집니다. 안 쓰는 응답 하나가 낫습니다.
   const [event, sessions] = await Promise.all([
     fetchEventByCode(code),
     fetchSessionsByEventCode(code),
@@ -26,22 +30,12 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
     throw error;
   });
 
-  // 참가자는 DRAFT와 "세션이 아직 안 열림"을 구분할 수 없습니다. 둘 다 기다려야
-  // 하는 상태라 같은 화면을 보여줍니다. DRAFT는 세션이 미리 만들어져 있어도
-  // 막아야 합니다 — 폼이 뜨면 소감을 다 쓴 뒤에 EVENT_NOT_LIVE로 실패합니다.
-  //
-  // 세션 0개는 지금 API로는 나올 수 없습니다(DRAFT → LIVE 전환에 1개 이상 검사가
-  // 있고 삭제 API가 없음). 다만 그 검사가 목에만 있어서, 실제 서버가 빠뜨리면
-  // 칩 없는 폼이 뜨고 제출 버튼이 영원히 비활성이 됩니다. 조건 한 항목으로 막습니다.
-  const canSubmit = event.status === 'LIVE' && sessions.length > 0;
-  const isEnded = event.status === 'ENDED';
-
-  // 리포트는 ENDED일 때만 봅니다. 없거나 비공개면 똑같이 404가 오는데,
-  // 게스트에게 둘을 구분해 알리지 않기로 했습니다(#84).
-  // 404만 삼키고 나머지 오류는 그대로 던집니다 — 통신 실패까지 "리포트 없음"으로
-  // 읽으면 주최자가 공개해둔 리포트를 못 본 채로 화면이 멀쩡해 보입니다.
+  // ENDED가 아니면 리포트가 있을 수 없어 부르지 않습니다. 훅의 `enabled: isEnded`와 같은 판단입니다.
+  // 없거나 비공개면 똑같이 404가 오는데, 게스트에게 둘을 구분해 알리지 않기로 했습니다(#84).
+  // 404만 삼키고 나머지 오류는 그대로 던집니다 — 통신 실패까지 "리포트 없음"으로 읽으면
+  // 주최자가 공개해둔 리포트를 못 본 채로 화면이 멀쩡해 보입니다.
   const hasReport =
-    isEnded &&
+    event.status === 'ENDED' &&
     (await fetchPublicReport(code)
       .then(() => true)
       .catch((error: unknown) => {
@@ -50,41 +44,12 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
       }));
 
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
-      <section className="flex flex-col gap-1">
-        <p className="text-xs font-normal leading-4 text-text-tertiary">이벤트</p>
-        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
-        {canSubmit ? (
-          <p className="text-sm font-normal leading-5 text-text-secondary">
-            {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
-          </p>
-        ) : null}
-      </section>
-
-      {canSubmit ? (
-        <FeedbackForm eventCode={code} sessions={sessions} />
-      ) : isEnded ? (
-        <EmptyState
-          title="종료된 이벤트예요"
-          description={
-            hasReport
-              ? '소감 제출은 마감되었어요'
-              : '소감 제출은 마감되었어요\n주최자가 리포트를 준비하면 여기에 표시돼요'
-          }
-        >
-          {hasReport ? (
-            <Link href={`/e/${code}/report`} className={buttonStyle('primary', 'lg')}>
-              결과 리포트 보기
-            </Link>
-          ) : null}
-        </EmptyState>
-      ) : (
-        <EmptyState
-          title="지금은 소감을 받는 세션이 없어요"
-          description="세션이 열리면 여기서 남길 수 있어요"
-        />
-      )}
-    </main>
+    <EventEntryView
+      eventCode={code}
+      initialEvent={event}
+      initialSessions={sessions}
+      initialHasReport={hasReport}
+    />
   );
 };
 

--- a/components/feedback/EventEntryView.tsx
+++ b/components/feedback/EventEntryView.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import Link from 'next/link';
+
+import { FeedbackForm } from '@/components/feedback/FeedbackForm';
+import { buttonStyle } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useEventEntryFeed } from '@/hooks/useEventEntryFeed';
+import type { EventView, SessionView } from '@/lib/schemas/api';
+
+/**
+ * 게스트 진입 화면의 클라이언트 경계입니다.
+ *
+ * `app/e/[code]/page.tsx`가 서버에서 첫 데이터를 받아 넘기고, 그다음부터는 `useEventEntryFeed`의
+ * 폴링이 갱신을 맡습니다. 분기를 서버에 두면 주최자가 세션을 열거나 이벤트를 끝내도 게스트
+ * 화면이 새로고침 전까지 모릅니다 — 서버 컴포넌트는 요청이 올 때 한 번 그려지고 끝이라서입니다.
+ * `force-dynamic`은 그 한 번을 캐시하지 말라는 뜻일 뿐 다시 그려주지는 않습니다(#237).
+ *
+ * `main` 안쪽을 통째로 가져온 이유는 제목 아래 설명 문구까지 `canSubmit`에 걸려 있어서입니다.
+ * 세 분기 중 하나만 클라로 올리면 나머지가 서버에 남아 같은 문제를 그대로 반복합니다.
+ */
+
+interface EventEntryViewProps {
+  eventCode: string;
+  initialEvent: EventView;
+  initialSessions: SessionView[];
+  initialHasReport: boolean;
+}
+
+const EventEntryView = ({
+  eventCode,
+  initialEvent,
+  initialSessions,
+  initialHasReport,
+}: EventEntryViewProps) => {
+  const { event, sessions, canSubmit, isEnded, hasReport } = useEventEntryFeed({
+    eventCode,
+    initialEvent,
+    initialSessions,
+    initialHasReport,
+  });
+
+  return (
+    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+      <section className="flex flex-col gap-1">
+        <p className="text-xs font-normal leading-4 text-text-tertiary">이벤트</p>
+        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
+        {canSubmit ? (
+          <p className="text-sm font-normal leading-5 text-text-secondary">
+            {event.description ?? '오늘 들은 세션에 한줄 소감을 남겨주세요'}
+          </p>
+        ) : null}
+      </section>
+
+      {canSubmit ? (
+        <FeedbackForm eventCode={eventCode} sessions={sessions} />
+      ) : isEnded ? (
+        <EmptyState
+          title="종료된 이벤트예요"
+          description={
+            hasReport
+              ? '소감 제출은 마감되었어요'
+              : '소감 제출은 마감되었어요\n주최자가 리포트를 준비하면 여기에 표시돼요'
+          }
+        >
+          {hasReport ? (
+            <Link href={`/e/${eventCode}/report`} className={buttonStyle('primary', 'lg')}>
+              결과 리포트 보기
+            </Link>
+          ) : null}
+        </EmptyState>
+      ) : (
+        <EmptyState
+          title="지금은 소감을 받는 세션이 없어요"
+          description="세션이 열리면 여기서 남길 수 있어요"
+        />
+      )}
+    </main>
+  );
+};
+
+export { EventEntryView };

--- a/hooks/useEventEntryFeed.ts
+++ b/hooks/useEventEntryFeed.ts
@@ -1,0 +1,174 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import { isClientError, type EventView, type SessionView } from '@/lib/schemas/api';
+
+/**
+ * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트입니다. 지금은 폴링이고 나중에 SSE로
+ * 승급합니다.
+ *
+ * 셋을 한 훅에 두는 이유는 서로 배타적으로 켜졌다 꺼지는 하나의 상태 머신이기 때문입니다.
+ * 이벤트가 `ENDED`를 잡는 순간 세션 폴링을 끄고 리포트 폴링을 켜는 그 조율이 이 훅의 알맹이라,
+ * 나눠두면 조율이 화면으로 흘러나갑니다(`useEventReport`가 조회·생성·공개를 묶은 것과 같은 이유).
+ *
+ * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을 아는
+ * 코드는 이 파일에만 둡니다. `refetchInterval`을 밖으로 내보내지 않는 것도 같은 이유입니다.
+ */
+
+/**
+ * 세션이 열리고 닫히는 것을 따라가는 간격입니다.
+ *
+ * "세션 시작"은 초 단위 정확도가 필요한 값이 아니고, 게스트 요청은 참가자 수만큼 곱해집니다.
+ * 그래서 주최자 화면보다 촘촘하게 갈 이유가 없습니다(#237).
+ */
+const REFRESH_INTERVAL_MS = 5_000;
+
+/**
+ * 리포트가 공개되기를 기다리는 간격입니다. 위보다 훨씬 성긴 이유는 시간 척도가 달라서입니다 —
+ * 주최자가 종료하고, 생성하고, 읽어보고, 공개하기까지는 몇 분에서 며칠입니다.
+ *
+ * 탭이 백그라운드로 가면 `refetchIntervalInBackground`의 기본값(`false`)이 타이머를 멈춥니다.
+ * 그래서 리포트를 기다리며 열어둔 탭이 종일 서버를 두들기는 일은 생기지 않습니다.
+ */
+const REPORT_REFRESH_INTERVAL_MS = 15_000;
+
+/**
+ * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를 거르는
+ * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴링도 하지 않습니다.
+ *
+ * `useDashboardFeed`에 같은 함수가 있습니다. 아직 두 벌이라 옮기지 않았습니다 — 세 번째가
+ * 생기면 그때 공용으로 빼는 편이 맞아 보입니다.
+ */
+const isPermanentFailure = (error: Error | null): boolean =>
+  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+/**
+ * 리포트가 공개됐는지만 봅니다. 본문은 받지 않습니다 — 이 화면이 정하는 건 "결과 리포트 보기"를
+ * 열지 말지 하나뿐이고, 내용은 `/e/[code]/report`가 따로 받아갑니다.
+ *
+ * 404를 에러로 두지 않고 `false`로 삼킵니다. 서버는 없음·비공개·생성 중을 `REPORT_NOT_FOUND`
+ * 하나로 합쳐서 주는데(`app/e/[code]/report/page.tsx`), 이 화면에서 그건 실패가 아니라 "아직
+ * 안 나왔다"는 정상 상태입니다. 에러로 남기면 아래 `isPermanentFailure`가 4xx로 보고 폴링을
+ * 멈춰서, 주최자가 나중에 공개해도 화면이 영영 모릅니다.
+ */
+const fetchReportExists = async (eventCode: string): Promise<boolean> => {
+  try {
+    await fetchPublicReport(eventCode);
+    return true;
+  } catch (error) {
+    if (error instanceof ApiError && error.code === 'REPORT_NOT_FOUND') return false;
+    throw error;
+  }
+};
+
+interface UseEventEntryFeedParams {
+  eventCode: string;
+  /**
+   * 서버 컴포넌트가 이미 받아둔 값입니다. `initialData`로 넣어야 SSR HTML에 실려 나간 첫 화면이
+   * 그대로 유지되고, 그 뒤부터 폴링이 갱신을 맡습니다. 넘기지 않으면 게스트가 완성된 화면을
+   * 받아놓고도 마운트 직후 빈 상태를 한 번 지나갑니다.
+   */
+  initialEvent: EventView;
+  initialSessions: SessionView[];
+  initialHasReport: boolean;
+}
+
+interface UseEventEntryFeedResult {
+  event: EventView;
+  sessions: SessionView[];
+  /** 소감을 받을 수 있는 상태인지입니다. 폼을 그릴지 빈 상태를 그릴지 가릅니다. */
+  canSubmit: boolean;
+  isEnded: boolean;
+  /** 공개된 리포트가 있는지입니다. `ENDED`가 아니면 항상 `false`입니다. */
+  hasReport: boolean;
+}
+
+const useEventEntryFeed = ({
+  eventCode,
+  initialEvent,
+  initialSessions,
+  initialHasReport,
+}: UseEventEntryFeedParams): UseEventEntryFeedResult => {
+  const eventQuery = useQuery({
+    queryKey: ['event', eventCode],
+    queryFn: () => fetchEventByCode(eventCode),
+    initialData: initialEvent,
+    /*
+     * `ENDED`는 종착역입니다. 전이가 `DRAFT → LIVE → ENDED` 단방향이라
+     * (`mocks/handlers/event.ts`) 되돌아올 일이 없어서, 도착하면 자기 자신을 끕니다.
+     */
+    refetchInterval: ({ state }) =>
+      state.data?.status === 'ENDED' || isPermanentFailure(state.error)
+        ? false
+        : REFRESH_INTERVAL_MS,
+  });
+
+  const event = eventQuery.data;
+  const isEnded = event.status === 'ENDED';
+
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions', eventCode],
+    queryFn: () => fetchSessionsByEventCode(eventCode),
+    initialData: initialSessions,
+    /*
+     * 정지 조건에 세션 상태를 넣지 않습니다. "하나라도 열렸으면 그만 물어봐도 된다"가 그럴듯해
+     * 보이지만, 그러면 닫히는 쪽을 못 잡습니다 — 주최자가 A를 닫고 B를 여는 사이 게스트는 A만
+     * 열린 화면에 소감을 다 쓰고 제출에서야 `SESSION_CLOSED`를 받습니다.
+     *
+     * `ENDED`에서 멈추는 건 다릅니다. 그 뒤에 세션이 열려도 `canSubmit`이 `LIVE`를 요구해서
+     * 화면이 바뀌지 않습니다. 목이 세션 토글에 이벤트 상태를 검사하지 않아 실제로 열릴 수는
+     * 있지만, 열려봐야 게스트는 `EVENT_NOT_LIVE`로 막힙니다.
+     */
+    refetchInterval: ({ state }) =>
+      isEnded || isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS,
+  });
+
+  const reportQuery = useQuery({
+    queryKey: ['publicReportExists', eventCode],
+    queryFn: () => fetchReportExists(eventCode),
+    initialData: initialHasReport,
+    /*
+     * 전역 기본값(`QueryProvider`의 10초)보다 길어야 의미가 있습니다. SSR로 받아둔 값을 마운트
+     * 직후 한 번 더 물어보지 않게 하려는 것이고, 폴링 간격과 맞춰야 요청이 두 리듬으로 겹치지
+     * 않습니다. 이벤트·세션 쪽은 전역 10초가 이미 그 일을 해서 따로 두지 않았습니다.
+     */
+    staleTime: REPORT_REFRESH_INTERVAL_MS,
+    // 리포트 생성 자체가 `ENDED`에서만 가능해서(`useEventReport`), 그 전에는 물어볼 이유가 없습니다.
+    enabled: isEnded,
+    /*
+     * 공개된 뒤에도 멈추지 않습니다. `isPublic`은 주최자가 되돌릴 수 있는 값이라, 도달했다고
+     * 멈추면 공개 → 비공개 → 공개를 통째로 놓치고 화면이 실제와 어긋난 채로 굳습니다. 한 번
+     * 가면 끝인 `ENDED`나 `useEventReport`의 `GENERATED`와 다른 점이 여기입니다.
+     *
+     * 실패 정지만 남깁니다. 4xx는 다시 물어도 같은 답이지만 5xx·끊김은 다음번에 성공할 수 있어서,
+     * 거기서까지 멈추면 순간 장애 한 번에 화면이 영영 굳습니다.
+     */
+    refetchInterval: ({ state }) =>
+      isPermanentFailure(state.error) ? false : REPORT_REFRESH_INTERVAL_MS,
+  });
+
+  return {
+    event,
+    sessions: sessionsQuery.data,
+    /*
+     * 파생값까지 훅이 계산해서 내보냅니다. 화면이 다시 조합하게 두면 폴링으로 값이 움직일 때마다
+     * 판정이 두 벌로 갈리고, 한쪽만 고치는 실수가 열립니다.
+     *
+     * `LIVE`를 요구하는 이유 — 참가자는 `DRAFT`와 "세션이 아직 안 열림"을 구분할 수 없습니다. 둘 다
+     * 기다려야 하는 상태라 같은 화면을 보여줍니다. `DRAFT`는 세션이 미리 만들어져 있어도 막아야
+     * 합니다. 폼이 뜨면 소감을 다 쓴 뒤에 `EVENT_NOT_LIVE`로 실패합니다.
+     *
+     * 세션 0개 검사 — 지금 API로는 나올 수 없습니다(`DRAFT → LIVE` 전환에 1개 이상 검사가 있고
+     * 삭제 API가 없음). 다만 그 검사가 목에만 있어서, 실제 서버가 빠뜨리면 칩 없는 폼이 뜨고 제출
+     * 버튼이 영원히 비활성이 됩니다. 조건 한 항목으로 막습니다.
+     */
+    canSubmit: event.status === 'LIVE' && sessionsQuery.data.length > 0,
+    isEnded,
+    hasReport: isEnded && reportQuery.data === true,
+  };
+};
+
+export { useEventEntryFeed };


### PR DESCRIPTION
## 변경 사항

- 게스트 진입 화면(`/e/[code]`)의 분기를 `EventEntryView`(클라이언트)로 올리고, 이벤트·세션·리포트 세 값을 폴링으로 갱신합니다. 주최자가 세션을 열거나 이벤트를 끝내거나 리포트를 공개해도 게스트가 새로고침하지 않아도 됩니다.
- 갱신 방식을 아는 코드는 `hooks/useEventEntryFeed.ts` 한 파일로 격리했습니다. SSE 승급 때 이 파일 내부만 바꾸면 화면은 손대지 않습니다(CLAUDE.md의 "폴링 → SSE 승급, 훅으로 격리").
- `app/e/[code]/page.tsx`에는 첫 데이터 fetch와 `notFound()`만 남습니다. 받은 값을 `initialData`로 넘겨서 SSR HTML의 첫 화면은 지금과 동일합니다.

| 전이 | 화면 | 간격 |
| --- | --- | --- |
| 세션 `CLOSED` ↔ `ACTIVE` | 칩 활성/비활성 | 5초 |
| 이벤트 `LIVE` → `ENDED` | 폼 → 종료 안내 | 5초 |
| 리포트 공개 ↔ 비공개 | "결과 리포트 보기" 버튼 | 15초 |

폴링 정지 조건은 **단방향 전이에만** 걸었습니다. 세션 상태에 걸면 주최자가 A를 닫고 B를 여는 사이 닫히는 쪽을 놓치고(게스트가 소감을 다 쓰고 나서 `SESSION_CLOSED`를 받습니다), 리포트 `isPublic`에 걸면 공개 → 비공개 → 공개를 통째로 놓칩니다. 실패 정지는 `useDashboardFeed`와 같은 기준(4xx + `INVALID_RESPONSE`)을 씁니다.

`force-dynamic`이 붙어 있어도 이 문제는 그대로였습니다. 그건 "그 한 번을 캐시하지 말라"는 뜻일 뿐 다시 그려주지 않습니다.

## 관련 이슈

Closes #237

이슈 본문의 "확인 필요"에 남아 있던 판단(이벤트 상태 전환까지 다룰지)을 **다루는 쪽으로 확정**했고, 이슈에는 없던 리포트 공개 반영까지 함께 넣었습니다. 셋 다 같은 클라이언트 경계를 필요로 해서 나누면 같은 작업을 두 번 하게 됩니다.

## 검증 방법

실행한 명령:

- `npm run lint` — 통과 (출력 없음)
- `npm run test` — 5 files / 102 tests 통과
- `npm run build` — 통과. `/e/[code]`가 `ƒ`(dynamic)로 유지되는 것까지 확인

수동 확인 (목 모드, 주최자 대시보드와 게스트 화면을 나란히 띄움):

- 종료된 이벤트에서 **리포트 공개 → 비공개** 전환 시, 게스트 화면의 "결과 리포트 보기" 버튼이 사라지는 것을 확인했습니다. 네트워크 탭에서 같은 `report` 요청이 `200`에서 `404`로 바뀌는 지점이 보입니다.

리뷰어가 함께 봐주시면 좋은 절차:

- 세션 전부 `CLOSED`인 `LIVE` 이벤트를 게스트로 열어둔 채 세션 하나를 `ACTIVE`로 토글 → 5초 안에 칩 활성화
- 그 상태에서 세션을 다시 닫기 → 칩이 비활성으로 복귀
- 이벤트를 `ENDED`로 전환 → 게스트 화면이 종료 안내로 전환
- 비공개 리포트를 공개 → 15초 안에 버튼 등장

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 리포트가 비공개인 동안 콘솔·백엔드 로그에 404가 쌓입니다

`GET /events/{code}/report`는 리포트 없음·비공개·생성 중을 전부 `REPORT_NOT_FOUND`(404)로 합쳐서 줍니다(#84, 비공개 리포트의 존재 자체를 숨기려는 의도). `fetchReportExists`가 그 404를 `false`로 삼켜서 **코드 레벨에서는 에러가 아니지만**, 브라우저가 네트워크 계층에서 찍는 빨간 줄은 `try/catch`로 막을 수 없습니다.

폴링 정지 조건을 뺀 대가로 비공개 구간에서는 15초마다 404가 하나씩 쌓입니다. 요청은 `/api/proxy` rewrites를 거쳐 Render 백엔드까지 가므로 그쪽 액세스 로그에도 남습니다. 다만 404는 HTTP 규격상 정상 응답이고, 같은 경로로 나가는 세션·이벤트 폴링(5초 × 2)이 이미 그보다 6배 많습니다. 탭이 백그라운드로 가면 `refetchIntervalInBackground` 기본값(`false`)이 타이머를 멈추므로, 요청이 나가는 건 게스트가 그 화면을 보고 있는 동안뿐입니다.

**근본 해결은 API 쪽에 있습니다.** `EventView`에 `hasPublicReport: boolean`이 하나 있으면:

- 이벤트는 이미 폴링 중이라 요청이 늘지 않고, 오히려 리포트 쿼리가 사라져서 줄어듭니다
- 404가 원천적으로 안 생깁니다
- `false`는 "공개된 게 없다"이지 "리포트가 없다"가 아니라서 #84의 의도도 지켜집니다

백엔드 스펙 변경이라 담당자 확인이 먼저고 이 PR 범위를 넘어서, 여기서는 손대지 않았습니다. SSE로 승급하면 주기적 404는 어차피 사라지므로(진입 시 1회만 남음) 그때까지 두고 봐도 됩니다.

### `isPermanentFailure`가 `useDashboardFeed`와 중복입니다

같은 함수가 두 곳에 있습니다. 세 번째가 생기면 공용으로 빼는 게 맞아 보여서 지금은 주석만 남겼습니다.

관련해서 `useFeedbackSnapshot`은 `refetchInterval`이 상수라 **영구 실패에서도 폴링이 멈추지 않습니다.** `useDashboardFeed`가 이미 겪고 고친 문제(주석에 "로그인이 풀린 화면이 401을 5초마다 새로 받아냅니다")가 그쪽에는 반영되지 않았습니다. 성격이 달라 이 PR에 넣지 않았고, 별도 이슈로 올리면 그때 공용 추출까지 같이 처리하면 됩니다.

### 이벤트가 삭제되면 게스트 화면은 마지막 상태로 멈춥니다

`deleteEvent`가 있어서, 게스트가 열어둔 사이 이벤트가 지워지면 폴링이 404를 받고 영구 실패로 판정해 멈춥니다. 클라이언트에서는 `notFound()`가 불리지 않아 화면이 그대로 남습니다. 의도적으로 두었습니다 — `not-found.tsx`는 "링크가 올바른지 확인해 주세요"라고 안내하는데 링크는 멀쩡했으니 틀린 안내가 되고, 소감을 제출하면 서버가 제대로 막습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
