### PR TITLE
fix(dashboard): 로그인이 풀리면 대시보드 폴링을 멈춘다

### DIFF
--- a/hooks/useDashboardFeed.ts
+++ b/hooks/useDashboardFeed.ts
@@ -2,6 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 
+import { useAuth } from '@/hooks/useAuth';
 import { fetchModerationQueue } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import { isClientError, type Feedback } from '@/lib/schemas/api';
@@ -59,6 +60,13 @@ const useDashboardFeed = ({
   eventCode,
   sessionId,
 }: UseDashboardFeedParams): UseDashboardFeedResult => {
+  /*
+   * 인증 여부를 화면에서 받지 않고 여기서 직접 봅니다. "로그인이 없으면 폴링하지 않는다"는
+   * 화면이 정할 일이 아니라 이 훅의 불변조건입니다. `['auth','me']` 캐시를 공유하므로 요청은
+   * 늘지 않습니다 — 대시보드에는 `HostHeader`가 이미 같은 쿼리를 띄워둡니다.
+   */
+  const { isAuthenticated } = useAuth();
+
   const { data, isPending, isError, error } = useQuery({
     queryKey: [DASHBOARD_FEED_KEY, eventCode, sessionId],
     queryFn: () =>
@@ -67,6 +75,18 @@ const useDashboardFeed = ({
         sessionId: sessionId ?? undefined,
         includeHidden: true,
       }),
+    /*
+     * 로그인이 풀리면 요청 자체를 내보내지 않습니다. 아래 `isPermanentFailure`가 401을 받고
+     * 폴링을 멈추긴 하지만 멈추기 전 한 번은 나가는데, #247의 401 인터셉터가 붙으면 그 한 번이
+     * `/auth/refresh`까지 부릅니다. 방금 로그아웃한 사용자를 위해 재발급을 시도하다 다시 401을
+     * 받고 로그아웃 처리가 한 번 더 도는 흐름이라, 요청을 아예 막는 편이 낫습니다.
+     *
+     * `isAuthenticated`는 `/auth/me` 응답 전에도 `false`라 진입 직후 한 박자 늦게 시작합니다.
+     * 미들웨어가 비로그인 진입을 이미 막으므로 그 지연은 첫 왕복뿐이고, 한 번이라도 받아둔
+     * 데이터가 있으면 `enabled`가 꺼져도 `isPending`으로 되돌아가지 않아 화면이 스켈레톤으로
+     * 깜빡이지 않습니다.
+     */
+    enabled: isAuthenticated,
     /*
      * 폴링 타이머는 에러 상태에서도 그대로 돕니다. `QueryObserver`가 간격을 다시 잴 때 보는 건
      * `enabled`와 간격값뿐이라 실패 여부는 아예 안 봅니다. 그래서 로그인이 풀린 화면이 401을

--- a/hooks/useEventReport.ts
+++ b/hooks/useEventReport.ts
@@ -2,6 +2,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { useAuth } from '@/hooks/useAuth';
 import { showToast } from '@/hooks/useToast';
 import { fetchOwnReport, generateReport, setReportPublic } from '@/lib/api/endpoints';
 import type { EventStatus } from '@/lib/schemas/api';
@@ -55,9 +56,14 @@ interface EventReportControls {
   isGenerateError: boolean;
   isTogglePublicError: boolean;
 }
-
 const useEventReport = (eventCode: string, eventStatus?: EventStatus): EventReportControls => {
   const queryClient = useQueryClient();
+
+  /*
+   * 인증 여부를 화면에서 받지 않고 여기서 직접 봅니다(`useDashboardFeed`와 같은 이유).
+   * `['auth','me']` 캐시를 공유하므로 요청은 늘지 않습니다.
+   */
+  const { isAuthenticated } = useAuth();
 
   const reportQueryKey = ['report', eventCode];
 
@@ -73,8 +79,15 @@ const useEventReport = (eventCode: string, eventStatus?: EventStatus): EventRepo
   const reportQuery = useQuery({
     queryKey: reportQueryKey,
     queryFn: () => fetchOwnReport(eventCode),
-    // 생성 자체가 `ENDED`에서만 가능해서, 그 전에는 물어볼 이유가 없습니다.
-    enabled: eventStatus === 'ENDED',
+    /*
+     * 생성 자체가 `ENDED`에서만 가능해서, 그 전에는 물어볼 이유가 없습니다.
+     *
+     * 로그인이 풀린 상태에서도 내보내지 않습니다. 이쪽은 `GENERATING` 동안에만 폴링해서 노출
+     * 창이 좁지만, 그 몇 초에 걸리면 `useDashboardFeed`와 똑같이 401 한 번이 #247의 인터셉터를
+     * 타고 `/auth/refresh`까지 부릅니다. 조건을 한쪽에만 걸어두면 왜 다른지 다음 사람이
+     * 되짚어야 해서 같이 맞춥니다.
+     */
+    enabled: eventStatus === 'ENDED' && isAuthenticated,
     refetchInterval: ({ state }) =>
       state.data?.status === 'GENERATING' ? REPORT_POLL_INTERVAL_MS : false,
   });


### PR DESCRIPTION
## 변경 사항

인증이 필요한 폴링 두 곳이 로그인 여부를 보고 요청을 멈춥니다.

- `hooks/useDashboardFeed.ts` — 소감 목록 (대시보드를 보는 내내 5초)
- `hooks/useEventReport.ts` — 리포트 조회 (`GENERATING` 동안 1.5초)

두 훅 모두 `useAuth()`의 `isAuthenticated`를 직접 봅니다. 호출부(`DashboardView`)는 건드리지 않았습니다.

지금도 `isPermanentFailure`가 4xx를 영구 실패로 걸러서 **401이 계속 나가지는 않습니다.** 이 PR이 막는 건 멈추기 전에 나가는 **첫 한 번**입니다. 지금은 그 한 번으로 끝나 실질 피해가 없지만, #247의 401 인터셉터가 `lib/apiClient.ts`에 붙으면 값이 달라집니다.

```
로그아웃 → 폴링이 401 → apiClient가 /auth/refresh 시도
        → 리프레시 쿠키도 지워졌으니 또 401 → 로그아웃 처리가 한 번 더
```

인터셉터가 오기 전에 요청을 막아둡니다.

### 인증 여부를 훅이 직접 봅니다

파라미터로 받아 화면이 넘기는 방법도 있지만, "로그인이 없으면 폴링하지 않는다"는 화면이 정할 일이 아니라 이 훅들의 불변조건입니다.

`['auth','me']` 캐시를 공유하므로 요청은 늘지 않습니다. 대시보드에는 `HostHeader`가 이미 같은 쿼리를 띄워둡니다.

### `useEventReport`는 조건을 합쳤습니다

`enabled: eventStatus === 'ENDED'`가 이미 있어서 덧붙이지 않고 `&&`로 합쳤습니다.

노출 창은 `useDashboardFeed`보다 훨씬 좁습니다(생성 중 몇 초 vs 대시보드를 보는 내내). 그래도 함께 넣은 이유는 판단 근거가 같아서입니다 — 조건을 한쪽에만 걸어두면 왜 다른지 다음 사람이 되짚어야 합니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| 0c8d190 | fix(dashboard): 로그인이 풀리면 소감 폴링을 멈춘다 | 노출 창이 가장 넓은 곳부터. `enabled`가 없던 자리라 새로 추가 |
| 04c18e0 | fix(dashboard): 리포트 조회도 로그인이 풀리면 멈춘다 | 같은 근거를 같은 화면의 다른 훅에도 적용. 기존 `enabled`와 `&&`로 합침 |

## 관련 이슈

Closes #250
Refs #247

## 검증 방법

실행한 명령 (두 커밋 모두에서):

- `npm run lint` — 통과 (출력 없음)
- `npm run test` — 5 files / 102 tests 통과
- `npm run build` — 통과

작업 중 `useAuth()`를 모듈 최상단에서 부른 실수가 있었는데, `react-hooks/rules-of-hooks`가 잡아서 훅 안으로 옮겼습니다. 아래 참고 사항에 적었습니다.

수동 확인은 하지 않았습니다. 목 모드에서 로그아웃 후 대시보드에 머무는 상태를 재현하려면 쿠키를 직접 지워야 하는데, 그 경로가 실제 사용 흐름(로그아웃하면 `/login`으로 이동)과 달라 확인 값이 낮다고 봤습니다. 리뷰 때 필요하다고 판단되면 알려주세요.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### `useAuth()` 호출 위치

처음에 `useEventReport.ts`의 모듈 최상단(훅 함수 밖)에서 `useAuth()`를 불렀습니다. 린트가 바로 잡았습니다.

```
error  React Hook "useAuth" cannot be called at the top level.  react-hooks/rules-of-hooks
```

그 자리는 React 렌더 컨텍스트 밖이라 훅이 동작할 수 없고, 통과한다 해도 모듈 로드 시점 값 하나가 고정돼서 로그인 상태 변화를 따라가지 못합니다. `useQueryClient()` 아래로 옮겼습니다.

### 진입 직후 폴링이 한 박자 늦습니다

`isAuthenticated`는 `user !== null`이라 `/auth/me` 응답이 오기 전에도 `false`입니다. 그래서 화면에 들어온 직후 첫 `/auth/me` 왕복만큼 폴링 시작이 밀립니다.

미들웨어(`proxy.ts`)가 비로그인 진입을 이미 막고 있어서 실제 지연은 그 한 번뿐이고, `DashboardView`는 `isEventPending`·`isSessionsPending`에서도 스켈레톤을 그리므로(`DashboardView.tsx:165`, `:196`) 사용자에게 새로 보이는 구간은 없습니다.

로그아웃 시점에는 이미 받아둔 데이터가 있어서 `enabled`가 꺼져도 쿼리 상태가 `pending`으로 되돌아가지 않습니다. 화면이 스켈레톤으로 깜빡이지 않습니다.

`useEventReport` 쪽은 다릅니다. `enabled`가 `false`인 동안 `isPending`이 유지되고, 그게 `isUnknown`을 거쳐 `isGenerateDisabled`로 이어져 **리포트 생성 버튼이 잠깁니다.** 인증을 확인하기 전에 눌러봐야 401이라 잠기는 쪽이 맞다고 봤습니다.

### 게스트 화면은 대상이 아닙니다

`useFeedbackSnapshot`, `useEventEntryFeed`(#248에서 추가)는 인증 없이 도는 공개 화면용이라 같은 조건을 걸면 안 됩니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
