### PR TITLE
feat(event): 게스트 화면 로고를 눌러 이벤트 홈으로 돌아간다

### DIFF
--- a/app/e/[code]/layout.tsx
+++ b/app/e/[code]/layout.tsx
@@ -1,8 +1,6 @@
-import { Logo } from '@/components/brand/Logo';
+import Link from 'next/link';
 
-interface EventLayoutProps {
-  children: React.ReactNode;
-}
+import { Logo } from '@/components/brand/Logo';
 
 /**
  * 참가자 공개 화면(`/e/[code]`, `/live`, `/report`)의 공통 레이아웃입니다.
@@ -11,19 +9,37 @@ interface EventLayoutProps {
  * 호스트 전용이고, README도 참가자 화면에는 쓰지 말라고 명시하고 있습니다. 참가자는 로그인하지
  * 않아서 넘길 값 자체가 없습니다.
  *
- * 호스트 Header의 반응형 값(`md:h-16`·`md:px-20`)은 따라가지 않습니다. 현재 참가자 화면은 QR로 들어오는
+ * `h-14`는 그 Header의 모바일 높이에서 가져온 값입니다(`components/layout/README.md` 스펙 표).
+ * 반대로 반응형 단계(`md:h-16`·`md:px-20`)는 따라가지 않습니다. 현재 참가자 화면은 QR로 들어오는
  * 모바일 전용이라 넓은 화면을 위한 단계가 필요 없습니다. 대신 로고를 각 페이지 본문과 같은
  * `max-w-md`·`px-5` 열에 맞췄습니다.
  *
  * 여백은 바깥(`header`), 테두리는 안쪽(`div`)에 겁니다. 이래야 선이 화면 끝이 아니라 로고 왼쪽
  * 끝에서 시작해서 본문 오른쪽 끝에서 멈춥니다. 둘을 한 요소에 몰면 선이 `px-5`까지 덮습니다.
+ *
+ * `aria-label`에 `Pulse`를 남깁니다. 로고의 `Pulse`는 진짜 텍스트라 그냥 두면 접근 이름이 되는데
+ * (`components/brand/README.md`), `aria-label`은 자식 텍스트를 덮어써서 빼면 사라집니다. 그러면
+ * 음성 입력 사용자가 화면에 보이는 이름으로 이 링크를 지목할 수 없습니다. 뒷부분이 호스트 Header의
+ * "Pulse 홈으로"와 다른 이유는 목적지가 서비스 홈이 아니라 그 이벤트의 홈이기 때문입니다.
+ *
+ * `not-found.tsx`도 이 레이아웃 안에서 그려집니다. 그때 로고는 방금 404를 낸 주소를 가리키지만
+ * 그대로 뒀습니다. 참가자에게는 돌아갈 다른 홈이 없고, 막으려면 레이아웃이 자식이 `not-found`인지
+ * 알아야 해서 장치가 더 붙습니다(#239).
  */
-const EventLayout = ({ children }: EventLayoutProps) => {
+const EventLayout = async ({ children, params }: LayoutProps<'/e/[code]'>) => {
+  const { code } = await params;
+
   return (
     <div className="flex flex-1 flex-col">
       <header className="mx-auto w-full max-w-md px-5">
         <div className="flex h-14 items-center border-b border-border-subtle">
-          <Logo />
+          <Link
+            href={`/e/${code}`}
+            aria-label="Pulse 이벤트 홈으로"
+            className="rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
+          >
+            <Logo />
+          </Link>
         </div>
       </header>
       {children}


### PR DESCRIPTION
## 변경 사항

게스트 공개 화면(`/e/[code]`·`/live`·`/report`) 공통 레이아웃의 로고를 이벤트 홈(`/e/[code]`)으로 가는 링크로 감쌌습니다.

- 기존에는 `<Logo />`를 그대로 놓아서 `<span>`이었습니다. 클릭 대상도 포커스 대상도 아니라, 결과·리포트에서 이벤트 홈으로 돌아가는 길이 브라우저 뒤로가기뿐이었습니다.
- 호스트 `Header`는 재사용하지 않았습니다. `href`가 `/events`로 고정돼 있고 `email`·`onLogout`이 필수 prop이라, 로그인하지 않는 참가자에게는 넘길 값 자체가 없습니다. `components/layout/README.md`도 참가자 화면에는 쓰지 말라고 명시하고 있습니다.
- `code`를 얻으려고 `params`를 받으면서 props 타입을 `LayoutProps<'/e/[code]'>`로 바꿨습니다. 이슈 구현 메모대로이고, 형제 파일 `app/e/[code]/live/page.tsx`가 `PageProps<'/e/[code]/live'>`를 쓰는 것과 같은 방식입니다.
- 포커스 링은 `Header.tsx:20`과 같은 규격을 씁니다.

## 이슈의 "확인 필요" 두 가지

**`aria-label`은 "Pulse 이벤트 홈으로"로 정했습니다.** 로고의 `Pulse`는 진짜 텍스트라 그냥 두면 접근 이름이 되는데(`components/brand/README.md`), `aria-label`은 자식 텍스트를 덮어씁니다. "이벤트 홈으로"만 쓰면 화면에 보이는 `Pulse`가 접근 이름에서 빠져, 음성 입력 사용자가 보이는 이름으로 이 링크를 지목할 수 없습니다(WCAG 2.5.3 Label in Name). 호스트의 "Pulse 홈으로"와 뒷부분이 다른 이유는 목적지가 서비스 홈이 아니라 그 이벤트의 홈이기 때문입니다.

**`not-found` 화면에서는 그대로 두기로 했습니다.** `app/e/[code]/not-found.tsx`도 이 레이아웃 안에서 그려지므로, 그때 로고는 방금 404를 낸 주소를 가리킵니다. 무의미한 이동이지만 참가자에게는 돌아갈 다른 홈이 없고, 막으려면 레이아웃이 자식이 `not-found`인지 알아야 해서 장치가 더 붙습니다. 판단 근거는 코드 주석에도 남겼습니다.

## 관련 이슈

- Closes #239

## 검증 방법

| 명령 | 결과 |
| --- | --- |
| `npm run lint` | 통과 (출력 없음) |
| `npm run test` | 5 files / 102 tests passed |
| `npm run build` | Compiled successfully, TypeScript 통과 |

`npm run build`가 통과한다는 것은 `LayoutProps<'/e/[code]'>`가 실제로 해석된다는 확인도 됩니다. 이 타입은 `.next/types/routes.d.ts`에 생성되는 전역이라 import가 없고, 라우트 문자열이 틀리면 여기서 걸립니다.


## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
