### PR TITLE
feat(dashboard): 감정·독성 급변을 주최자 화면에 알린다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -2,15 +2,18 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useParams } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import { KeywordCard } from '@/components/dashboard/KeywordCard';
 import { LiveFeedCard } from '@/components/dashboard/LiveFeedCard';
 import {
+  MODERATION_ALERT_MIN_COUNT,
   buildTrend,
   countKeywords,
+  isNegativeAlerting,
+  isPositiveSurging,
   summarizeSentiments,
   toRelativeTime,
 } from '@/components/dashboard/metrics';
@@ -49,6 +52,16 @@ import type { Feedback } from '@/lib/schemas/api';
 
 const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
 const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+/**
+ * 급증 배너를 다시 판정하는 주기입니다.
+ *
+ * 세 알림 중 급증만 시간이 답을 바꿉니다. 소감이 들어오지 않아도 최근 2분 창이 지나면 거짓이
+ * 되어야 하는데, 새 소감이 없으면 폴링이 같은 배열을 돌려주고 화면은 다시 그려지지 않습니다.
+ * 그러면 반응이 뚝 끊긴 상황 — 배너가 가장 내려가야 할 때 — 에 오히려 그대로 남습니다.
+ * 창(2분)보다 훨씬 짧게 잡아서, 늦어도 이 간격 안에 내려가게 합니다.
+ */
+const POSITIVE_SURGE_RECHECK_MS = 10_000;
 
 const DashboardView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
@@ -141,6 +154,117 @@ const DashboardView = () => {
   /* 뒤집기와 「이 화면에서 멈춘 세션인가」 판정이 한 덩어리라 훅으로 묶여 있습니다. */
   const sessionControls = useSessionControls(eventCode);
 
+  /*
+   * 소감에서 뽑는 값들입니다. 정작 그리는 자리는 한참 아래지만 계산은 여기서 합니다.
+   * 바로 아래 알림 훅이 이 값을 봐야 하는데, 훅은 early return 뒤로 내려갈 수 없습니다.
+   */
+  const items = feedbacks ?? [];
+
+  /*
+   * 숨긴 건은 집계와 피드에서 뺍니다. 목록을 `includeHidden=true`로 받는 건 모더레이션
+   * 큐가 이미 숨긴 건도 보여줘야 해서지, 숫자에 넣으려는 게 아닙니다.
+   * 독성 건수만 예외입니다(아래 참고).
+   */
+  const visible = items.filter((feedback) => feedback.status === 'VISIBLE');
+
+  const { positive, neutral, negative, unclassified, classified, positiveRate, negativeRate } =
+    summarizeSentiments(visible);
+
+  /*
+   * 독성 건수만 `visible`이 아니라 전체를 셉니다. 독성 소감은 제출 시점에
+   * 이미 HIDDEN으로 저장되므로 `visible`에는 한 건도 남지 않습니다.
+   * 이건 감정 집계가 아니라 모더레이션 지표라서, 숨겼어도 몇 건 들어왔는지는
+   * 주최자에게 보여야 합니다. `visible` 기준으로 되돌리지 마세요.
+   */
+  const toxicCount = items.filter((feedback) => feedback.toxic).length;
+
+  /*
+   * 여기부터 주최자 실시간 알림입니다(#253). 무엇이 알림감인지는 `metrics.ts`가 정하고,
+   * 화면은 그 판정을 그리기만 합니다.
+   *
+   * 셋 다 조건이 참인 동안 떠 있는 배너입니다. 처음에는 급증과 독성을 지나가는 사건으로 보고
+   * 토스트로 띄웠는데, 4초 만에 사라져서 화면을 보고 있는 사람도 놓쳤습니다. 배너로 옮기니
+   * 알림을 언제 한 번만 띄울지 정할 일이 없어져서, 발화 시각과 이미 알린 단계를 들고 있던
+   * 상태도 함께 사라졌습니다.
+   *
+   * 셋 중 부정 비율만 여기에 상태로 남습니다. 켜지는 선과 꺼지는 선이 달라서 지금 떠 있는지를
+   * 알아야 다음 판정을 할 수 있기 때문입니다. 나머지 둘은 지금 목록만 보면 답이 나옵니다.
+   */
+  const [isNegativeHeavy, setIsNegativeHeavy] = useState(false);
+
+  /**
+   * 긍정 급증입니다. 지금 목록만 보면 답이 나오는데도 상태로 두는 이유는 위
+   * `POSITIVE_SURGE_RECHECK_MS` 주석에 적어뒀습니다. 시각이 답을 바꾸는 유일한 판정이라
+   * 렌더에서 바로 부르면 소감이 끊긴 순간부터 영영 갱신되지 않습니다.
+   */
+  const [isPositiveSurge, setIsPositiveSurge] = useState(false);
+
+  /** 지금 잡아둔 판정이 어느 세션 것인지입니다. 필터가 바뀌면 여기서 알아챕니다. */
+  const alertScopeRef = useRef(sessionId);
+
+  /*
+   * 부정 비율 판정입니다. 켜지는 선과 꺼지는 선이 달라서 직전 상태를 판정에 넘깁니다.
+   * updater로 넘기면 그 값을 deps에 넣지 않아도 됩니다. 넣으면 자기가 자기를 다시 부릅니다.
+   *
+   * 세션 전환을 여기서 같이 봅니다. 전환을 따로 훅으로 빼면 세션이 하나뿐인 이벤트에서
+   * "전체"와 그 세션을 오갈 때 구멍이 납니다. 두 목록이 같은 내용이라 아래 deps가 그대로여서
+   * 이 훅이 돌지 않는데, 리셋만 먼저 적용돼 배너가 사라진 채 돌아오지 않습니다. `sessionId`를
+   * deps에 넣고 전환 여부를 직접 보면 그 경우에도 반드시 다시 판정합니다.
+   */
+  useEffect(() => {
+    const isScopeChanged = alertScopeRef.current !== sessionId;
+    if (isScopeChanged) alertScopeRef.current = sessionId;
+
+    if (eventStatus !== 'LIVE') {
+      /*
+       * `react-hooks/set-state-in-effect`를 끕니다. 룰이 막으려는 건 렌더가 꼬리를 무는
+       * 상황인데, 여기서는 이벤트가 `LIVE`를 벗어나는 한 번뿐이고 그 뒤로는 조건이 계속
+       * 거짓이라 다시 돌지 않습니다. 렌더로 옮길 수도 없습니다 — 아래 판정이 직전 상태를
+       * 봐야 해서 렌더에서 읽으면 자기가 만든 값을 다시 읽게 됩니다.
+       */
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsNegativeHeavy(false);
+      return;
+    }
+
+    setIsNegativeHeavy((wasAlerting) =>
+      isNegativeAlerting({
+        negativeRate,
+        classified,
+        /* 다른 세션에서 켜둔 것을 물려받으면 안 됩니다. 새 모집단에서 처음부터 판정합니다. */
+        wasAlerting: isScopeChanged ? false : wasAlerting,
+      }),
+    );
+  }, [negativeRate, classified, eventStatus, sessionId]);
+
+  /*
+   * 급증 판정입니다. 목록이 바뀔 때 한 번 보고, 그 뒤로는 타이머가 같은 판정을 반복합니다.
+   *
+   * `visible`을 deps에 넣지 않고 여기서 다시 거릅니다. 저쪽은 렌더마다 새로 만들어지는
+   * 배열이라 넣으면 데이터가 그대로여도 이 훅이 매번 다시 돌고 타이머도 매번 새로 섭니다.
+   *
+   * 타이머는 목록이 바뀌면 정리되고 다시 섭니다. 소감이 계속 들어오는 동안에는 폴링이
+   * 판정을 갱신해주므로 타이머가 발동할 일이 없고, 끊긴 뒤에야 제 몫을 합니다.
+   */
+  useEffect(() => {
+    if (eventStatus !== 'LIVE') {
+      // 위 부정 배너와 같은 이유입니다. `LIVE`를 벗어나는 한 번으로 끝납니다.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsPositiveSurge(false);
+      return;
+    }
+
+    const judge = () => {
+      const visibleNow = items.filter((feedback) => feedback.status === 'VISIBLE');
+      setIsPositiveSurge(isPositiveSurging(visibleNow, Date.now()));
+    };
+
+    judge();
+
+    const timer = setInterval(judge, POSITIVE_SURGE_RECHECK_MS);
+    return () => clearInterval(timer);
+  }, [items, eventStatus]);
+
   const handleSelectSession = (nextSessionId: number | null) => {
     setSessionId(nextSessionId);
   };
@@ -212,25 +336,6 @@ const DashboardView = () => {
     if (await copyLink(publicUrl)) showToast('링크가 복사되었어요');
   };
 
-  const items = feedbacks ?? [];
-
-  /*
-   * 숨긴 건은 집계와 피드에서 뺍니다. 목록을 `includeHidden=true`로 받는 건 모더레이션
-   * 큐가 이미 숨긴 건도 보여줘야 해서지, 숫자에 넣으려는 게 아닙니다.
-   * 독성 건수만 예외입니다(아래 참고).
-   */
-  const visible = items.filter((feedback) => feedback.status === 'VISIBLE');
-
-  const { positive, neutral, negative, unclassified, positiveRate } = summarizeSentiments(visible);
-
-  /*
-   * 독성 건수만 `visible`이 아니라 전체를 셉니다. 독성 소감은 제출 시점에
-   * 이미 HIDDEN으로 저장되므로 `visible`에는 한 건도 남지 않습니다.
-   * 이건 감정 집계가 아니라 모더레이션 지표라서, 숨겼어도 몇 건 들어왔는지는
-   * 주최자에게 보여야 합니다. `visible` 기준으로 되돌리지 마세요.
-   */
-  const toxicCount = items.filter((feedback) => feedback.toxic).length;
-
   /*
    * 모더레이션 큐가 받는 목록입니다. 자동 판정된 독성 소감에 더해, 주최자가 실시간 피드에서
    * 직접 숨긴 소감도 넣습니다(#170).
@@ -243,6 +348,16 @@ const DashboardView = () => {
    * 항상 빼고 내려줍니다.
    */
   const queueItems = items.filter((feedback) => feedback.toxic || feedback.status === 'HIDDEN');
+
+  /*
+   * 큐 알림입니다. 위 `queueItems`를 그대로 세기 때문에 배너 숫자와 큐 배지 숫자가 어긋나지
+   * 않고, 주최자가 큐를 비우면 배너도 함께 내려갑니다. 나머지 둘과 달리 시각도 이력도 보지
+   * 않아서 여기서 바로 판정합니다.
+   *
+   * `LIVE`에서만 내놓는 것은 세 알림이 같습니다. 끝난 이벤트에는 지금 대응할 일이 없고,
+   * 시작 전에는 소감이 들어오지 않습니다.
+   */
+  const isQueueHeavy = event.status === 'LIVE' && queueItems.length >= MODERATION_ALERT_MIN_COUNT;
 
   const trend = buildTrend(visible);
   const keywords = countKeywords(visible);
@@ -331,6 +446,21 @@ const DashboardView = () => {
         <DashboardSkeleton />
       ) : (
         <>
+          {/*
+           * 실패 배너들과 떨어뜨려 통계 바로 위에 둡니다. 이건 고장이 아니라 지금 화면이
+           * 보여주는 숫자에 대한 경고라, 그 숫자 옆에 있어야 읽힙니다.
+           *
+           * 손이 가야 하는 순서로 세웁니다. 분위기가 꺾인 것과 큐가 밀린 것은 지금 대응할
+           * 일이고, 긍정 급증은 알아두면 좋은 소식이라 `info`로 맨 아래 섭니다.
+           */}
+          {isNegativeHeavy && (
+            <Banner type="warning">부정 반응이 {negativeRate}%까지 올라갔어요</Banner>
+          )}
+          {isQueueHeavy && (
+            <Banner type="warning">처리할 소감이 {queueItems.length}건 쌓였어요</Banner>
+          )}
+          {isPositiveSurge && <Banner type="info">긍정 반응이 늘고 있어요</Banner>}
+
           <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
             <Stat label="총 소감" value={`${visible.length}`} />
             <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />

--- a/components/dashboard/metrics.test.ts
+++ b/components/dashboard/metrics.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildTrend, countKeywords, summarizeSentiments } from '@/components/dashboard/metrics';
+import {
+  buildTrend,
+  countKeywords,
+  isNegativeAlerting,
+  isPositiveSurging,
+  summarizeSentiments,
+} from '@/components/dashboard/metrics';
 import type { Feedback, Sentiment } from '@/lib/schemas/api';
 
 /**
@@ -125,5 +131,148 @@ describe('summarizeSentiments', () => {
   it('분류된 소감이 하나도 없으면 0%다', () => {
     expect(summarizeSentiments(withSentiments('UNKNOWN')).positiveRate).toBe(0);
     expect(summarizeSentiments([]).positiveRate).toBe(0);
+  });
+});
+
+/*
+ * 여기부터는 주최자 실시간 알림 판정입니다(#253).
+ *
+ * 임계값을 상수로 불러오지 않고 숫자를 그대로 적습니다. 상수를 쓰면 값을 잘못 바꿔도
+ * 테스트가 같이 따라가서 아무것도 잡지 못합니다. 여기 적힌 숫자가 어긋나면 그건
+ * 규칙이 바뀌었다는 뜻이고, 바꾼 사람이 이 파일도 같이 고쳐야 합니다.
+ */
+
+/** 급증 판정은 `now`로부터의 나이만 봅니다. 위 `at()`과 기준이 달라 따로 둡니다. */
+const NOW = Date.parse('2026-08-13T10:00:00.000Z');
+
+const minutesAgo = (minutes: number) => new Date(NOW - minutes * 60_000).toISOString();
+
+/** 지금으로부터 몇 분 전인지를 받아 긍정 소감을 만듭니다(`makeFeedback`의 기본이 POS입니다). */
+const positivesAgo = (minutes: number[]) =>
+  minutes.map((minute, index) => makeFeedback({ id: index + 1, createdAt: minutesAgo(minute) }));
+
+/**
+ * 최근 창(1분 30초) 안에 흩어진 긍정 4건입니다. 하한을 딱 채우는 수입니다.
+ */
+const RECENT_FOUR = [0.2, 0.5, 0.9, 1.3];
+
+/**
+ * 기준 구간(1분 30초~7분 30초) 밖의 아주 오래된 기록 한 건입니다.
+ *
+ * 판정이 기준 구간을 온전히 6분으로 잡게 만드는 표식입니다. 이게 없으면 목록이 이제 막
+ * 시작된 것으로 보여 관측 폭 보정이 걸리고, 배수를 확인하려던 케이스가 보류로 새어 나갑니다.
+ */
+const OLD_MARK = [20];
+
+/**
+ * 세션이 `elapsed`분 진행되는 동안 분당 `perMinute`건이 일정하게 들어온 경우입니다.
+ * 속도가 한 번도 변하지 않았으므로 어느 시점에 재도 급증이면 안 됩니다.
+ */
+const steadyAges = (elapsed: number, perMinute: number) =>
+  Array.from({ length: Math.round(elapsed * perMinute) }, (_, index) => index / perMinute);
+
+describe('isNegativeAlerting', () => {
+  it('표본이 모자라면 비율이 높아도 알리지 않는다', () => {
+    // 3건 중 2건이 부정이면 67%지만, 이벤트 초반의 우연을 경고로 올릴 수는 없습니다.
+    expect(isNegativeAlerting({ negativeRate: 67, classified: 3, wasAlerting: false })).toBe(false);
+  });
+
+  it('표본이 차고 켜지는 선에 닿으면 알린다', () => {
+    expect(isNegativeAlerting({ negativeRate: 50, classified: 20, wasAlerting: false })).toBe(true);
+  });
+
+  it('켜지는 선에 한 칸 못 미치면 알리지 않는다', () => {
+    expect(isNegativeAlerting({ negativeRate: 49, classified: 20, wasAlerting: false })).toBe(
+      false,
+    );
+  });
+
+  it('한 번 켜지면 켜지는 선 아래로 내려가도 유지된다', () => {
+    // 45%는 새로 켤 수 없는 값입니다. 이미 떠 있을 때만 유지됩니다 — 이게 히스테리시스입니다.
+    expect(isNegativeAlerting({ negativeRate: 45, classified: 20, wasAlerting: true })).toBe(true);
+    expect(isNegativeAlerting({ negativeRate: 45, classified: 20, wasAlerting: false })).toBe(
+      false,
+    );
+  });
+
+  it('꺼지는 선 아래로 내려가면 꺼진다', () => {
+    expect(isNegativeAlerting({ negativeRate: 41, classified: 20, wasAlerting: true })).toBe(false);
+  });
+
+  it('표본이 하한 아래로 줄면 떠 있던 것도 꺼진다', () => {
+    // 소감을 지우거나 세션 필터를 좁히면 분모가 줄어듭니다.
+    expect(isNegativeAlerting({ negativeRate: 90, classified: 19, wasAlerting: true })).toBe(false);
+  });
+});
+
+describe('isPositiveSurging', () => {
+  it('최근 긍정이 하한에 못 미치면 급증이 아니다', () => {
+    // 앞 구간이 통째로 비어 있어도 3건은 "늘었다"고 하지 않습니다.
+    expect(isPositiveSurging(positivesAgo([0.2, 0.5, 0.9, ...OLD_MARK]), NOW)).toBe(false);
+  });
+
+  it('앞 구간이 비었어도 하한을 채우면 급증이다', () => {
+    expect(isPositiveSurging(positivesAgo([...RECENT_FOUR, ...OLD_MARK]), NOW)).toBe(true);
+  });
+
+  it('앞 구간과 견줘 배수에 못 미치면 급증이 아니다', () => {
+    // 기준 6분에 24건이면 창(1분 30초)당 6건입니다. 최근 4건은 오히려 줄어든 것입니다.
+    const baseline = Array.from({ length: 24 }, (_, index) => 2 + index * 0.19);
+
+    expect(isPositiveSurging(positivesAgo([...RECENT_FOUR, ...baseline, ...OLD_MARK]), NOW)).toBe(
+      false,
+    );
+  });
+
+  it('앞 구간의 두 배 이상이면 급증이다', () => {
+    // 기준 6분에 4건이면 창당 1건. 최근 4건은 두 배를 넘습니다.
+    const baseline = [2, 3, 4, 5];
+
+    expect(isPositiveSurging(positivesAgo([...RECENT_FOUR, ...baseline, ...OLD_MARK]), NOW)).toBe(
+      true,
+    );
+  });
+
+  it('기준 구간보다 오래된 소감은 세지 않는다', () => {
+    // 8~12분 전에 50건이 몰렸어도 지금 판정에는 끼지 않습니다. 끼면 급증이 묻힙니다.
+    const old = Array.from({ length: 50 }, (_, index) => 8 + index * 0.08);
+
+    expect(isPositiveSurging(positivesAgo([...RECENT_FOUR, ...old]), NOW)).toBe(true);
+  });
+
+  it('긍정이 아닌 소감은 세지 않는다', () => {
+    const negatives = RECENT_FOUR.map((minute, index) =>
+      makeFeedback({ id: index + 1, createdAt: minutesAgo(minute), sentiment: 'NEG' }),
+    );
+
+    expect(isPositiveSurging(negatives, NOW)).toBe(false);
+  });
+
+  it('서버 시각이 조금 앞서도 최근 구간으로 센다', () => {
+    // 미래로 찍힌 소감은 방금 들어온 것입니다. 버리면 급증이 한 박자 늦게 잡힙니다.
+    expect(isPositiveSurging(positivesAgo([-0.1, 0.5, 0.9, 1.3, ...OLD_MARK]), NOW)).toBe(true);
+  });
+
+  it('시간이 지나 최근 구간을 벗어나면 저절로 거짓이 된다', () => {
+    // 같은 목록을 3분 뒤에 다시 판정한 것입니다. 배너가 알아서 내려가는 근거입니다.
+    const surged = positivesAgo([...RECENT_FOUR, ...OLD_MARK]);
+
+    expect(isPositiveSurging(surged, NOW)).toBe(true);
+    expect(isPositiveSurging(surged, NOW + 3 * 60_000)).toBe(false);
+  });
+
+  /*
+   * 아래 두 개가 관측 폭 보정입니다. 기준 구간이 아직 다 차지 않은 세션에서, 속도가 한 번도
+   * 변하지 않았는데 급증으로 잡히던 문제를 막습니다. 보정이 없으면 둘 다 참이 됩니다.
+   */
+
+  it('기준 구간이 덜 찬 세션에서 속도가 일정하면 급증이 아니다', () => {
+    // 시작 4분째, 분당 6건이 계속 들어오는 중입니다. 빨라진 적이 없습니다.
+    expect(isPositiveSurging(positivesAgo(steadyAges(4, 6)), NOW)).toBe(false);
+  });
+
+  it('견줄 앞 구간이 최근 구간보다 짧으면 판정을 미룬다', () => {
+    // 시작 2분째. 비교할 과거가 없는 것이지 반응이 몰린 게 아닙니다.
+    expect(isPositiveSurging(positivesAgo(steadyAges(2, 6)), NOW)).toBe(false);
   });
 });

--- a/components/dashboard/metrics.ts
+++ b/components/dashboard/metrics.ts
@@ -39,13 +39,19 @@ interface TrendPoint {
   NEG: number;
 }
 
-/** 감정별 건수와 긍정 비율입니다. */
+/** 감정별 건수와 비율입니다. */
 interface SentimentSummary {
   positive: number;
   neutral: number;
   negative: number;
   unclassified: number;
+  /**
+   * 비율의 분모입니다. 미분류를 뺀 수라 밖에서 다시 만들 수 없어서 같이 내보냅니다.
+   * 부정 알림이 "표본이 너무 적으면 알리지 않는다"를 판단할 때 이 값을 봅니다.
+   */
+  classified: number;
   positiveRate: number;
+  negativeRate: number;
 }
 
 /** 키워드 하나와 그 횟수입니다. `Map` 엔트리 모양 그대로라 라벨로 자리를 표시합니다. */
@@ -101,13 +107,13 @@ const countKeywords = (feedbacks: Feedback[]): KeywordCount[] => {
 };
 
 /**
- * 감정별로 세고 긍정 비율까지 냅니다.
+ * 감정별로 세고 비율까지 냅니다.
  *
  * 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅이 실패했다는 뜻이라 "중립"과 다릅니다.
  * 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다.
  *
  * 세는 일과 나누는 일을 한 함수에 둔 이유가 이것입니다. 떨어져 있으면 분모를 다시 만들 때
- * 미분류를 빼는 규칙이 따라오지 않습니다.
+ * 미분류를 빼는 규칙이 따라오지 않습니다. 부정 비율도 여기서 같이 내는 이유가 같습니다.
  */
 const summarizeSentiments = (feedbacks: Feedback[]): SentimentSummary => {
   const positive = feedbacks.filter((feedback) => feedback.sentiment === 'POS').length;
@@ -122,16 +128,158 @@ const summarizeSentiments = (feedbacks: Feedback[]): SentimentSummary => {
     neutral,
     negative,
     unclassified,
+    classified,
     positiveRate: classified === 0 ? 0 : Math.round((positive / classified) * 100),
+    negativeRate: classified === 0 ? 0 : Math.round((negative / classified) * 100),
   };
 };
 
+/*
+ * 여기부터는 주최자에게 띄울 알림을 판정하는 계산입니다(#253).
+ *
+ * 폴링은 5초마다 누적 목록을 통째로 다시 줍니다. 그래서 "직전에 받은 목록과 견줘 늘었으면
+ * 알린다"로 만들면 새로고침이나 세션 필터 변경 한 번에 가짜 급증이 잡힙니다. 아래 판정은
+ * 전부 서버가 찍어준 `createdAt`과 지금 목록만 보고, 몇 번을 다시 계산해도 같은 답이 나옵니다.
+ *
+ * 세 알림 모두 "조건이 참인 동안 떠 있는" 상태입니다. 처음에는 급증과 독성을 지나가는
+ * 사건으로 보고 토스트로 띄웠는데, 4초 만에 사라져서 화면을 보고 있어도 놓쳤습니다. 배너로
+ * 옮기면서 "언제 한 번만 띄울지"를 정할 일이 없어졌고, 발화 시각과 이미 알린 단계를 들고
+ * 있던 화면 쪽 상태도 같이 사라졌습니다. 조건이 풀리면 알아서 내려갑니다.
+ */
+
+/** 부정 알림이 켜지는 선입니다. */
+const NEGATIVE_ALERT_ON_RATE = 50;
+
+/**
+ * 부정 알림이 꺼지는 선입니다. 켜지는 선보다 낮은 이유는, 같은 값이면 49%와 50%를 오갈 때마다
+ * 배너가 5초 주기로 나타났다 사라지기 때문입니다. 한 번 켜지면 여유를 두고 내려가야 꺼집니다.
+ */
+const NEGATIVE_ALERT_OFF_RATE = 42;
+
+/**
+ * 비율을 믿을 수 있는 최소 표본입니다. 3건 중 2건이 부정이면 67%지만 알릴 일이 아닙니다.
+ * 이벤트 초반에 부정 한 건이 들어왔다고 경고가 뜨는 것을 막습니다.
+ */
+const NEGATIVE_ALERT_MIN_SAMPLE = 20;
+
+/**
+ * 급증 판정이 "지금"으로 보는 구간입니다.
+ *
+ * 세션이 짧게 쪼개지는 행사를 염두에 두고 짧게 잡았습니다. 여기를 늘리면 판정이 둔해지는 데다
+ * 배너도 그만큼 오래 남습니다 — 조건이 거짓이 되어야 내려가는데 그 조건이 이 구간이라서입니다.
+ */
+const SURGE_WINDOW_MS = 90_000;
+
+/** 비교 기준이 되는 직전 구간입니다. `SURGE_WINDOW_MS`가 끝나는 지점부터 셉니다. */
+const SURGE_BASELINE_MS = 6 * 60_000;
+
+/** 최근 구간이 기준 구간(같은 길이로 환산)의 몇 배여야 급증인지입니다. */
+const SURGE_RATIO = 2;
+
+/**
+ * 배수와 함께 봐야 하는 절대 하한입니다. 배수만 보면 앞 구간이 0건일 때 1건만 들어와도
+ * 급증이 됩니다. 사람이 "늘었다"고 느낄 만한 최소 건수를 같이 요구합니다.
+ */
+const SURGE_MIN_COUNT = 4;
+
+/**
+ * 모더레이션 큐가 이만큼 쌓이면 알립니다.
+ *
+ * 누적 제출 건수가 아니라 "아직 큐에 남아 있는 건수"를 셉니다. 독성은 "지금 분위기"가 아니라
+ * "처리할 것이 쌓였다"는 신호라, 10분 전에 들어온 악성 소감도 큐에 있으면 여전히 처리 대상입니다.
+ * 반대로 주최자가 큐를 비우면 알릴 이유도 없어집니다 — 누적으로 세면 다 처리한 뒤에도 배너가
+ * 영영 남습니다.
+ *
+ * 세는 대상이 화면의 모더레이션 큐와 같아서 배너 숫자와 큐 배지 숫자가 항상 맞습니다.
+ * 큐에는 자동 판정된 독성뿐 아니라 주최자가 직접 숨긴 소감도 들어가므로, 문구도 "독성"이 아니라
+ * "처리할 소감"이라고 씁니다.
+ */
+const MODERATION_ALERT_MIN_COUNT = 5;
+
+interface NegativeAlertInput {
+  negativeRate: number;
+  classified: number;
+  /** 지금 배너가 떠 있는지입니다. 켜지는 선과 꺼지는 선을 가르는 데 씁니다. */
+  wasAlerting: boolean;
+}
+
+/** 부정 비율 경고를 띄울 상태인지 봅니다. 조건이 참인 동안 계속 참입니다(레벨 조건). */
+const isNegativeAlerting = ({
+  negativeRate,
+  classified,
+  wasAlerting,
+}: NegativeAlertInput): boolean => {
+  if (classified < NEGATIVE_ALERT_MIN_SAMPLE) return false;
+
+  return negativeRate >= (wasAlerting ? NEGATIVE_ALERT_OFF_RATE : NEGATIVE_ALERT_ON_RATE);
+};
+
+/**
+ * 최근 긍정 반응이 직전 구간보다 눈에 띄게 늘었는지 봅니다.
+ *
+ * 최근 2분만 보기 때문에 반응이 잦아들면 저절로 거짓이 됩니다. 배너를 내리는 별도 장치가
+ * 필요 없는 것이 이 때문입니다.
+ *
+ * `now`를 인자로 받는 이유는 테스트 때문입니다. 안에서 `Date.now()`를 부르면 시각을 고정할
+ * 수 없어서 경계값을 확인할 수 없습니다.
+ *
+ * 서버 시각이 클라이언트보다 조금 앞서면 `age`가 음수가 되는데, 그대로 최근 구간에 넣습니다.
+ * 방금 들어온 소감이라는 뜻이라 다른 칸에 둘 이유가 없습니다.
+ */
+const isPositiveSurging = (feedbacks: Feedback[], now: number): boolean => {
+  let recent = 0;
+  let baseline = 0;
+  /* 목록이 언제부터의 기록인지입니다. 아래에서 기준 구간이 실제로 얼마나 채워졌는지 재는 데 씁니다. */
+  let oldestAge = 0;
+
+  feedbacks.forEach((feedback) => {
+    if (feedback.sentiment !== 'POS') return;
+
+    const age = now - Date.parse(feedback.createdAt);
+    if (age > oldestAge) oldestAge = age;
+
+    if (age < SURGE_WINDOW_MS) recent += 1;
+    else if (age < SURGE_WINDOW_MS + SURGE_BASELINE_MS) baseline += 1;
+  });
+
+  if (recent < SURGE_MIN_COUNT) return false;
+
+  /*
+   * 기준 구간에 기록이 실제로 얼마나 있는지 잽니다. `SURGE_BASELINE_MS`로 바로 나누면 안 됩니다.
+   *
+   * 시작한 지 얼마 안 된 세션에서는 그 구간이 아직 다 차지 않았습니다. 3분밖에 안 된 세션의
+   * 기준 구간에는 1분 남짓한 기록뿐인데 6분치로 치고 나누면 평소 속도가 실제의 몇 분의 일로
+   * 잡히고, 그러면 속도가 하나도 안 변했는데도 전부 급증으로 보입니다. 세션이 기준 구간보다
+   * 짧으면 세션 내내 그렇습니다.
+   *
+   * `oldestAge`에서 최근 구간을 빼는 이유는, 저 값이 "지금부터" 잰 나이라 최근 구간까지
+   * 포함하고 있기 때문입니다. 여기서 알고 싶은 건 최근 구간이 끝나는 지점부터의 폭입니다.
+   * 기록이 충분히 오래됐으면 원래대로 `SURGE_BASELINE_MS`를 씁니다.
+   */
+  const observed = Math.min(SURGE_BASELINE_MS, oldestAge - SURGE_WINDOW_MS);
+
+  /*
+   * 견줄 앞 구간이 최근 구간보다도 짧으면 판정을 미룹니다. 이제 막 시작해서 비교 대상이 없는
+   * 것이지 반응이 몰린 게 아닙니다. 시작 직후에 소감이 들어오는 건 급증이 아니라 당연한 일입니다.
+   */
+  if (observed < SURGE_WINDOW_MS) return false;
+
+  /* 기준 구간을 최근 구간과 같은 길이로 줄여야 두 수를 견줄 수 있습니다. */
+  const baselinePerWindow = (baseline * SURGE_WINDOW_MS) / observed;
+
+  return recent >= baselinePerWindow * SURGE_RATIO;
+};
+
 export {
+  MODERATION_ALERT_MIN_COUNT,
   TREND_BUCKET_MS,
   buildTrend,
   countKeywords,
+  isNegativeAlerting,
+  isPositiveSurging,
   summarizeSentiments,
   toRelativeTime,
   type KeywordCount,
+  type SentimentSummary,
   type TrendPoint,
 };


### PR DESCRIPTION
## 변경 사항

주최자가 대시보드를 계속 보고 있지 않아도 분위기 변화를 알아채도록, 세 가지 신호를 배너로 띄웁니다.

- **부정 비율** — 분류된 소감의 부정 비율이 50%에 닿으면 표시. 표본 20건 미만이면 알리지 않고, 한 번 켜지면 42% 아래로 내려가야 꺼집니다(히스테리시스).
- **긍정 급증** — 최근 1분 30초 유입이 직전 6분 평균의 2배 이상이고 4건 이상일 때 표시. 반응이 잦아들면 저절로 내려갑니다.
- **모더레이션 큐 적체** — 큐에 5건 이상 남으면 표시. 주최자가 큐를 비우면 함께 내려갑니다.

판정은 `components/dashboard/metrics.ts`에 순수 함수로 두고, 화면은 조건이 참인 동안 그리기만 합니다. 서버 추가 없이 `useDashboardFeed`가 이미 받아오는 `/admin/feedbacks` 원본으로 계산합니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| cb9abfe | feat(dashboard): 감정·독성 급변을 주최자 화면에 알린다 | 판정(metrics)과 표시(view)를 나누고, 세 알림을 모두 조건 기반 배너로 통일 |

## 관련 이슈

- Refs #253

## 검증 방법

### 자동

```
npm run test   →  5 files / 118 tests passed
npm run lint   →  0 errors
```

`metrics.test.ts`에 임계 경계 케이스를 넣었습니다. 임계값은 상수를 불러오지 않고 숫자를 직접 적었습니다 — 상수를 쓰면 값을 잘못 바꿔도 테스트가 따라가서 아무것도 잡지 못합니다.

### 수동 (MSW 목 + 대시보드)

`npm run dev` 후 `/events/ab3f9x/dashboard`에서 콘솔로 소감을 제출해 조건을 만들었습니다. 레이트 리밋이 `(sessionId, X-Client-Id)` 기준이라 클라이언트 ID를 바꿔가며 여러 참가자를 흉내 냈습니다.

| # | 확인한 것 | 조건 | 기대 | 결과 | 스크린샷 |
| --- | --- | --- | --- | --- | --- |
| 1 | 평상시 | 부정 40%, 큐 2건 | 배너 없음 | ✅ | <!-- pulse-v2-1 --> |
| 2 | 부정 배너 등장 | 부정 50% 도달 | 배너 1개 | ✅ | <!-- pulse-v2-2 --> |
| 3 | 큐 배너 등장 | 큐 5건 | 배너 2개, 큐 배지와 숫자 일치 | ✅ | <!-- pulse-v2-3 --> |
| 4 | 급증 배너 등장 + 히스테리시스 | POS 4건(하한), 부정 43%로 하락 | 배너 3개, 부정 배너는 유지 | ✅ | <!-- pulse-v2-4 --> |
| 5 | 급증 자동 소멸 | 1분 40초 대기, 신규 제출 없음 | 급증만 소멸, 나머지 유지 | ✅ | <!-- pulse-v2-5 --> |
| 6 | 짧은 세션 오발화 방지 | 새 세션에 3.65분간 분당 6건 일정 유입 | 배너 없음 | ✅ | <!-- pulse-v2-6 --> |
| 7 | 꾸준한 유입은 침묵 | 기준 구간이 찬 상태, 최근 4건 | 배너 없음 (환산 6건 → 12건 필요) | ✅ | <!-- pulse-v2-7 --> |
| 8 | 배수 경계 아래 | 최근 10건 | 배너 없음 | ✅ | <!-- pulse-v2-8 --> |
| 9 | 배수 경계 위 | 최근 13건 | 급증 배너 등장 | ✅ | <!-- pulse-v2-9 --> |

7~9는 배수 조건만으로 갈리는 구간입니다(세 경우 모두 하한 4건은 충족). 기준 구간이 채워져 있으면 그 두 배를 넘어야만 급증으로 봅니다.

6번은 `mocks/data/seed.ts`를 임시로 고쳐 "최근 8분간 분당 4건" 상태를 만든 뒤 확인하고 되돌렸습니다. 기본 시드가 70분에 31건(분당 0.4건)이라 기준 구간이 거의 비어서, 무엇을 넣든 급증으로 잡혀 배수 조건을 확인할 수 없었습니다.
<img width="958" height="902" alt="pulse-v2-1-평상시-배너없음" src="https://github.com/user-attachments/assets/f0e1a6c7-96e8-4feb-a61e-742dc3c93400" />
<img width="958" height="902" alt="pulse-v2-2-부정배너-50" src="https://github.com/user-attachments/assets/e89f8adf-ae0e-4f9f-bf86-b4f5e6481032" />
<img width="958" height="902" alt="pulse-v2-3-큐배너-추가" src="https://github.com/user-attachments/assets/5a219599-d056-431e-9517-1de8e9ebf2a3" />
<img width="958" height="902" alt="pulse-v2-4-배너3종-동시" src="https://github.com/user-attachments/assets/eb409341-a811-4e01-98e7-229d17efe772" />
<img width="958" height="902" alt="pulse-v2-5-급증만-자동소멸" src="https://github.com/user-attachments/assets/e42e2e6f-476f-41c8-9db2-9317ab25db13" />
<img width="958" height="902" alt="pulse-v2-6-짧은세션-오발화방지" src="https://github.com/user-attachments/assets/6f693186-dbe7-4ba1-be69-5d342686e940" />
<img width="958" height="902" alt="pulse-v2-7-꾸준한유입-침묵" src="https://github.com/user-attachments/assets/a72e03ba-9a3f-4cc7-b883-646f3568dc07" />
<img width="958" height="902" alt="pulse-v2-8-10건-경계아래-침묵" src="https://github.com/user-attachments/assets/4ed6e0d8-9787-4d7a-a5b8-f2b67bfc1523" />
<img width="958" height="902" alt="pulse-v2-9-13건-급증발화" src="https://github.com/user-attachments/assets/e628f6c5-48c2-42d0-897c-7c0ca89510f1" />

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**토스트로 만들었다가 배너로 바꿨습니다.** 처음에는 급증·독성을 지나가는 사건으로 보고 토스트로 띄웠는데, 4초 만에 사라져서 화면을 보고 있어도 놓쳤습니다(검증 중 스크린샷으로 두 번 놓쳐 콘솔 감시로 겨우 확인). 배너로 옮기면서 발화 제어 전체 — 쿨다운, 이미 알린 단계를 들고 있던 ref, 마운트 기준선, 토스트가 서로 덮어쓰지 않게 하던 우선순위 분기 — 가 통째로 사라졌습니다.

**급증만 시간에 의존해서 갱신 구멍이 있었습니다.** 렌더에서 `Date.now()`로 판정했더니, 새 소감이 없으면 TanStack Query가 같은 배열을 돌려주고 화면이 다시 그려지지 않아 판정이 멈췄습니다. 반응이 뚝 끊긴 순간 — 배너가 가장 내려가야 할 때 — 에 오히려 남는 구조였습니다. 10초 주기 재판정 타이머로 고쳤고, 브라우저에서 2분간 데이터를 넣지 않고 확인했습니다(5번).

**기준 구간을 상수로 나누면 짧은 세션에서 오발화합니다.** 시작 3분짜리 세션의 기준 구간에는 1분 남짓한 기록뿐인데 6분치로 치고 나누면 평소 속도가 실제의 몇 분의 일로 잡혀, 속도가 하나도 안 변했는데 전부 급증이 됩니다. 세션이 기준 구간보다 짧으면 세션 내내 그렇습니다. 실제 관측 폭으로 환산하도록 고쳤습니다(6번에서 환산 9.1건 vs 보정 없을 때 3.3건).

**`react-hooks/set-state-in-effect`는 이유를 적고 껐습니다.** `FeedbackForm.tsx`·`LiveResult.tsx`의 선례를 따랐습니다. 이벤트가 `LIVE`를 벗어날 때 배너를 내리는 두 줄인데, 렌더로 옮기면 판정에 필요한 `Date.now()` 때문에 `react-hooks/purity`에 걸립니다.

**임계값은 전부 제안값입니다.** 요구사항 명세서에 "감정 반응이 급격히 바뀌면"의 구체 기준이 없어 실제 행사에서 써본 뒤 조정해야 합니다. 조정 지점은 `metrics.ts`의 상수 6개(`NEGATIVE_ALERT_ON_RATE`, `NEGATIVE_ALERT_OFF_RATE`, `NEGATIVE_ALERT_MIN_SAMPLE`, `SURGE_WINDOW_MS`, `SURGE_BASELINE_MS`, `SURGE_RATIO`, `SURGE_MIN_COUNT`, `MODERATION_ALERT_MIN_COUNT`)에 모여 있습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
