### PR TITLE
feat(auth): 액세스 토큰 만료 시 refresh로 세션 자동 복구

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -50,6 +50,7 @@ const LoginForm = () => {
     try {
       await login(loginInputs.email, loginInputs.password);
       router.push('/events');
+      router.refresh();
     } catch (error) {
       setLoginFailed(true);
 

--- a/components/providers/QueryProvider.tsx
+++ b/components/providers/QueryProvider.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 import { ApiError } from '@/lib/apiClient';
 import { isClientError } from '@/lib/schemas/api';
+import { useRouter } from 'next/navigation';
 
 interface QueryProviderProps {
   children: ReactNode;
@@ -19,28 +20,38 @@ interface QueryProviderProps {
  * 실시간 대시보드처럼 필요한 쿼리에서 개별로 지정합니다.
  */
 const QueryProvider = ({ children }: QueryProviderProps) => {
-  const [queryClient] = useState(
-    () =>
-      new QueryClient({
-        defaultOptions: {
-          queries: {
-            staleTime: 10_000,
-            // 다시 물어봐도 같은 답이 오는 실패는 재시도하지 않습니다.
-            retry: (failureCount, error) => {
-              if (error instanceof ApiError) {
-                // 응답이 계약과 다른 경우. 같은 요청에 같은 응답이 옵니다.
-                if (error.code === 'INVALID_RESPONSE') return false;
-                // 4xx.
-                if (isClientError(error.code)) return false;
-              }
+  const router = useRouter();
+  const [queryClient] = useState(() => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {
+          staleTime: 10_000,
+          // 다시 물어봐도 같은 답이 오는 실패는 재시도하지 않습니다.
+          retry: (failureCount, error) => {
+            if (error instanceof ApiError) {
+              // 응답이 계약과 다른 경우. 같은 요청에 같은 응답이 옵니다.
+              if (error.code === 'INVALID_RESPONSE') return false;
+              // 4xx.
+              if (isClientError(error.code)) return false;
+            }
 
-              return failureCount < 2;
-            },
-            refetchOnWindowFocus: false,
+            return failureCount < 2;
           },
+          refetchOnWindowFocus: false,
+        },
+      },
+      queryCache: new QueryCache({
+        onError: (error) => {
+          if (error instanceof ApiError && error.code === 'UNAUTHORIZED') {
+            client.setQueryData(['auth', 'me'], null);
+            router.push('/login');
+          }
         },
       }),
-  );
+    });
+
+    return client;
+  });
 
   return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
 };

--- a/lib/apiClient.ts
+++ b/lib/apiClient.ts
@@ -38,6 +38,16 @@ const readXsrfToken = (): string | null => {
   return match ? decodeURIComponent(match[1]) : null;
 };
 
+let refreshing: Promise<Response> | null = null;
+const refreshOnce = () => {
+  refreshing ??= fetch(`${API_BASE_URL}/auth/refresh`, {
+    method: 'POST',
+    credentials: 'include',
+  }).finally(() => (refreshing = null));
+
+  return refreshing;
+};
+
 async function parseJsonSafely(response: Response): Promise<unknown> {
   if (response.status === 204) return null;
   const text = await response.text();
@@ -59,12 +69,25 @@ export async function apiClient<T>(path: string, options: ApiClientOptions = {})
     mergedHeaders.set(XSRF_TOKEN_HEADER, xsrfToken);
   }
 
-  const response = await fetch(`${API_BASE_URL}${path}`, {
+  let response = await fetch(`${API_BASE_URL}${path}`, {
     ...rest,
     // 인증은 HttpOnly 쿠키라 FE가 헤더로 실어 보낼 수 없습니다. 브라우저가 붙이게 맡깁니다.
     credentials: skipAuth ? 'omit' : 'include',
     headers: mergedHeaders,
   });
+
+  const requiresRefresh = response.status === 401 && path !== '/auth/refresh' && !skipAuth;
+  if (requiresRefresh) {
+    const refreshResponse = await refreshOnce();
+
+    if (refreshResponse.ok) {
+      response = await fetch(`${API_BASE_URL}${path}`, {
+        ...rest,
+        credentials: skipAuth ? 'omit' : 'include',
+        headers: mergedHeaders,
+      });
+    }
+  }
 
   if (!response.ok) {
     let body: { code?: string; message?: string } | null;

--- a/mocks/handlers/auth.ts
+++ b/mocks/handlers/auth.ts
@@ -1,16 +1,19 @@
 import { http, HttpResponse } from 'msw';
 import type { AuthUser } from '@/lib/schemas/api';
 import { loginRequestSchema, signupRequestSchema } from '@/lib/schemas/api';
-import type { MockAccount } from '@/mocks/data/store';
+import { findAccountById, MockAccount } from '@/mocks/data/store';
 import { db, findAccountByEmail, nextAccountId } from '@/mocks/data/store';
 import {
   ACCESS_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE,
   API_BASE_URL,
   XSRF_TOKEN_COOKIE,
   authenticatedAccount,
   errorResponse,
   issueAccessToken,
   parseBody,
+  issueRefreshToken,
+  accountIdFromRefreshToken,
 } from '@/mocks/handlers/shared';
 
 /**
@@ -72,6 +75,10 @@ const sessionCookies = (
   ],
   // CSRF double-submit용이라 HttpOnly가 아닙니다. FE가 읽어서 X-XSRF-TOKEN 헤더로 되돌려 보냅니다.
   ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=${MOCK_XSRF_TOKEN}; Path=/; SameSite=Lax`],
+  [
+    'Set-Cookie',
+    `${REFRESH_TOKEN_COOKIE}=${issueRefreshToken(accountId)}; Path=/; SameSite=Lax${httpOnly ? '; HttpOnly' : ''}`,
+  ],
 ];
 
 const expiredCookies = ({ httpOnly }: { httpOnly: boolean }): [string, string][] => [
@@ -80,6 +87,10 @@ const expiredCookies = ({ httpOnly }: { httpOnly: boolean }): [string, string][]
     `${ACCESS_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0${httpOnly ? '; HttpOnly' : ''}`,
   ],
   ['Set-Cookie', `${XSRF_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0`],
+  [
+    'Set-Cookie',
+    `${REFRESH_TOKEN_COOKIE}=; Path=/; SameSite=Lax; Max-Age=0${httpOnly ? '; HttpOnly' : ''}`,
+  ],
 ];
 
 const toAuthUser = (account: MockAccount): AuthUser => ({
@@ -146,5 +157,23 @@ export const createAuthHandlers = ({ httpOnly }: { httpOnly: boolean }) => [
     if (!account) return errorResponse('UNAUTHORIZED');
 
     return HttpResponse.json(toAuthUser(account));
+  }),
+
+  http.post(`${API_BASE_URL}/auth/refresh`, ({ cookies }) => {
+    const accountId = accountIdFromRefreshToken(cookies[REFRESH_TOKEN_COOKIE]);
+
+    if (!accountId) {
+      return errorResponse('UNAUTHORIZED');
+    }
+
+    const account = findAccountById(accountId);
+
+    if (!account) {
+      return errorResponse('UNAUTHORIZED');
+    }
+
+    return HttpResponse.json(toAuthUser(account), {
+      headers: sessionCookies(account.id, { httpOnly }),
+    });
   }),
 ];

--- a/mocks/handlers/shared.ts
+++ b/mocks/handlers/shared.ts
@@ -46,6 +46,8 @@ export const errorResponse = (code: ApiErrorCode, message?: string) =>
 /** 인증 쿠키 이름입니다(2026-08-07 명세). 실제 BE가 `Set-Cookie`로 내려주는 이름과 같아야 합니다. */
 export const ACCESS_TOKEN_COOKIE = 'accessToken';
 
+export const REFRESH_TOKEN_COOKIE = 'refreshToken';
+
 /** CSRF double-submit용 쿠키. HttpOnly가 아니라서 FE가 읽어 `X-XSRF-TOKEN` 헤더로 되돌려 보냅니다. */
 export const XSRF_TOKEN_COOKIE = 'XSRF-TOKEN';
 
@@ -66,9 +68,20 @@ const ACCESS_TOKEN_PREFIX = 'mock-access-token-';
 
 export const issueAccessToken = (accountId: number): string => `${ACCESS_TOKEN_PREFIX}${accountId}`;
 
+const REFRESH_TOKEN_PREFIX = 'mock-refresh-token-';
+
+export const issueRefreshToken = (accountId: number): string =>
+  `${REFRESH_TOKEN_PREFIX}${accountId}`;
+
 const accountIdFromAccessToken = (token: string | undefined): number | null => {
   if (token === undefined || !token.startsWith(ACCESS_TOKEN_PREFIX)) return null;
   const parsed = Number(token.slice(ACCESS_TOKEN_PREFIX.length));
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+export const accountIdFromRefreshToken = (token: string | undefined): number | null => {
+  if (token === undefined || !token.startsWith(REFRESH_TOKEN_PREFIX)) return null;
+  const parsed = Number(token.slice(REFRESH_TOKEN_PREFIX.length));
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 };
 


### PR DESCRIPTION
## 변경 사항

액세스 토큰이 만료돼도 로그인 화면으로 튕기지 않고, 리프레시 토큰으로 조용히 세션을 복구합니다.

- AS-IS: 지금은 액세스 토큰이 만료되면(1시간) `hooks/useAuth.ts`의 `['auth','me']` 쿼리가 401을 받아 `null`이 되고, 이후 인증이 필요한 요청은 계속 401을 받습니다.
- TO-BE: 401을 받으면 `POST /auth/refresh`로 조용히 새 토큰을 받아 원 요청을 재시도합니다. 리프레시 토큰(14일)까지 만료됐을 때만 로그인 화면으로 이동합니다.

파일별 변경 내용입니다.

- **`lib/apiClient.ts`** — 서버로 나가는 모든 요청이 거치는 공통 함수입니다.  
  401 응답이면 `/auth/refresh`를 단일비행(single-flight, 여러 요청이 동시에 401을 받아도 실제 호출은 한 번만 나가는 방식)으로 호출하고, 성공하면 원 요청을 재시도하도록 고쳤습니다.
- **`components/providers/QueryProvider.tsx`** — TanStack Query의 `QueryClient`를 만드는 프로바이더입니다.  
  `QueryCache` 전역 `onError`를 추가해서, 어느 화면의 쿼리가 실패하든 그 에러가 `UNAUTHORIZED`이면 로그인 캐시(`['auth','me']`)를 비우고 `/login`으로 이동하도록 했습니다.
- **`components/auth/LoginForm.tsx`** — 로그인 폼입니다.  
  로그인 성공 후 `router.push('/events')` 다음에 `router.refresh()`를 추가했습니다.
- **`mocks/handlers/shared.ts`, `mocks/handlers/auth.ts`** — MSW 목 서버가 인증 요청에 응답하는 파일입니다.  
  `refreshToken` 쿠키의 발급·삭제·검증 로직과 `POST /auth/refresh` 핸들러를 실제 백엔드 계약(HANCOM-E/pulse-backend#34)에 맞춰 추가했습니다.

`lib/api/endpoints.ts`에 `refresh()` 함수는 추가하지 않았습니다.  
이유는 아래 "트러블슈팅 및 참고 사항"에 있습니다.

## 개발 과정 로그

커밋 1개뿐이라 생략합니다.

## 관련 이슈

- Refs #247

## 검증 방법

`npm run test` 102개 전부 통과, `npm run lint` 통과를 확인했습니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- 액세스 토큰이 만료된 뒤 로그인된 사용자가 API를 호출하면, 401을 받은 즉시 화면에 드러나지 않게 refresh를 시도합니다.  
  성공하면 원래 하려던 요청이 그대로 이어집니다.
- 대시보드처럼 여러 API 요청이 동시에 401을 받아도, `/auth/refresh` 호출은 한 번만 나갑니다.
- 로그인에 성공하면 `router.refresh()`로 라우터 캐시가 갱신됩니다.  
  로그인 안 된 상태로 접근했다가 `/login`으로 튕겼던 기록이 브라우저에 남아 있어도, 로그인 직후에는 다시 튕기지 않습니다.

### 실패하는 경우 (이 PR을 반영한 뒤 기준)

- 리프레시 토큰(14일)까지 만료됐거나 아예 없으면, `/auth/refresh` 요청도 `UNAUTHORIZED`로 실패합니다.  
  이 경우 로그인 정보(`['auth','me']`)를 비우고 `/login`으로 이동합니다.
- `/auth/refresh` 요청 자체가 401을 받아도 다시 refresh를 시도하지 않습니다.  
  `refreshOnce`(`lib/apiClient.ts`)가 `apiClient()`를 거치지 않고 `fetch()`를 직접 호출하는 구조라, 이 재귀 상황 자체가 애초에 발생하지 않습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

**`endpoints.ts`에 `refresh()`를 추가하면 `apiClient.ts` ↔ `endpoints.ts` 순환 참조(두 파일이 서로를 가져오는 상태)가 생기는 문제가 있습니다.**  
`endpoints.ts`는 이미 `apiClient.ts`를 가져다 쓰고 있어서, 반대로 `apiClient.ts`가 `endpoints.ts`의 `refresh()`를 가져다 쓰면 순환 참조가 생깁니다.  
`refreshOnce`가 이미 `/auth/refresh`를 자체적으로 완전하게 처리하고 있어서, `endpoints.ts`에 같은 기능의 함수를 추가하면 실제로 호출하는 곳이 없는 죽은 코드가 됩니다.  
그래서 `endpoints.ts`의 `refresh()`는 추가하지 않았습니다.

**`refreshToken` 쿠키의 `Path`가 리버스 프록시 구조와 안 맞아서 브라우저가 쿠키를 못 보내는 문제가 있었습니다.**  
백엔드가 `refreshToken` 쿠키를 `Path=/api/v1/auth/refresh`로 좁혀서 발급했는데, 브라우저는 항상 프론트 자신의 프록시 경로(`/api/proxy/**`, `next.config.ts`)로만 요청을 보냅니다.  
두 경로 문자열이 달라서 브라우저가 쿠키를 실어 보내지 못했습니다.  
백엔드에 `Path=/`로 넓히는 방안을 제안했고, HANCOM-E/pulse-backend#35(`Path=/`로 변경)로 반영·머지 완료된 것을 실제 코드로 확인했습니다.  
이 저장소의 MSW 목도 처음부터 `Path=/`로 만들어서 실제 배포 환경과 일치합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 해당 없음)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
