### PR TITLE
feat(game): 주최자용 게임 목록 엔드포인트

### DIFF
--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -510,6 +510,8 @@ export const gameResultsRequestSchema = z.object({
     .refine((values) => new Set(values).size === values.length, '참가자가 중복될 수 없습니다.'),
 });
 
+export const gameListResponseSchema = listResponseSchema(gameViewSchema);
+
 export type GameStatus = z.infer<typeof gameStatusSchema>;
 export type GameType = z.infer<typeof gameTypeSchema>;
 export type Game = z.infer<typeof gameSchema>;

--- a/mocks/data/store.ts
+++ b/mocks/data/store.ts
@@ -195,6 +195,16 @@ export const findParticipantByClientId = (
   );
 
 /**
+ * 주최자용 게임 목록입니다. `findCurrentGame`과 달리 **`DRAFT`도 포함**합니다 —
+ * 만들어두고 아직 안 연 게임을 다시 찾는 게 이 목록의 존재 이유입니다.
+ *
+ * 최근에 만든 것이 위입니다. `createdAt`이 아니라 id로 고른 이유는 같은 시각에
+ * 만들어져도 순서가 안 흔들리기 때문이고, `findCurrentGame`과 기준을 맞췄습니다.
+ */
+export const listGamesOfEvent = (eventId: number): Game[] =>
+  db.games.filter((game) => game.eventId === eventId).sort((a, b) => b.id - a.id);
+
+/**
  * 참가자 화면 배너가 쓰는 "지금 열린 게임"입니다(`GET .../games/current`).
  *
  * `DRAFT`는 뺍니다. 배너가 뜨면 참가자가 눌러 들어갔다가 `GAME_NOT_OPEN`을 맞습니다.

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -260,6 +260,18 @@ describe('다른 계정의 자원 접근', () => {
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toMatchObject({ code: 'REPORT_NOT_FOUND' });
   });
+
+  /*
+   * 이 목록은 DRAFT 게임까지 내보내는 유일한 경로입니다. 주최자가 아직 안 연 게임의
+   * 제목이 남에게 보이면 안 됩니다.
+   */
+  it('남의 이벤트 게임 목록은 NOT_OWNER를 준다', async () => {
+    const other = createOtherAccount();
+    const response = await call(`/events/${LIVE_EVENT_CODE}/games`, { headers: other });
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toMatchObject({ code: 'NOT_OWNER' });
+  });
 });
 
 describe('이벤트 조회', () => {
@@ -950,8 +962,8 @@ describe('게임', () => {
   const FINISHED_GAME_ID = 1;
   const OPEN_GAME_ID = 2;
 
-  const createGame = (title: string) =>
-    call(`/events/${LIVE_EVENT_CODE}/games`, {
+  const createGame = (title: string, eventCode = LIVE_EVENT_CODE) =>
+    call(`/events/${eventCode}/games`, {
       method: 'POST',
       headers: { ...AUTH_HEADERS, 'Content-Type': 'application/json' },
       body: JSON.stringify({ title }),
@@ -1202,11 +1214,24 @@ describe('게임', () => {
     expect(items[0].status).toBe('DRAFT');
   });
 
+  /*
+   * 다른 이벤트에 게임을 하나 만들어두고 봅니다. 시드의 게임 둘이 전부 eventId 42라,
+   * 빈 목록만 확인하면 필터가 동작한 건지 애초에 없는 건지 구분되지 않습니다.
+   */
   it('다른 이벤트의 게임은 목록에 섞이지 않는다', async () => {
-    const response = await call(`/events/${DRAFT_EVENT_CODE}/games`, { headers: AUTH_HEADERS });
-    const { items } = gameListResponseSchema.parse(await response.json());
+    const other = gameViewSchema.parse(
+      await (await createGame('다른 이벤트 게임', DRAFT_EVENT_CODE)).json(),
+    );
 
-    expect(items).toEqual([]);
+    const live = gameListResponseSchema.parse(
+      await (await call(`/events/${LIVE_EVENT_CODE}/games`, { headers: AUTH_HEADERS })).json(),
+    );
+    expect(live.items.map((game) => game.id)).not.toContain(other.id);
+
+    const draft = gameListResponseSchema.parse(
+      await (await call(`/events/${DRAFT_EVENT_CODE}/games`, { headers: AUTH_HEADERS })).json(),
+    );
+    expect(draft.items.map((game) => game.id)).toEqual([other.id]);
   });
 
   it('목록은 인증이 필요하다', async () => {

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -4,6 +4,7 @@ import {
   eventViewSchema,
   feedbackListResponseSchema,
   feedbackSnapshotSchema,
+  gameListResponseSchema,
   gameParticipantSchema,
   gameViewSchema,
   listResponseSchema,
@@ -945,7 +946,7 @@ describe('리포트', () => {
 });
 
 describe('게임', () => {
-  /** 시드 게임(mock/data/seed.ts) */
+  /** 시드 게임(mocks/data/seed.ts) */
   const FINISHED_GAME_ID = 1;
   const OPEN_GAME_ID = 2;
 
@@ -1183,5 +1184,35 @@ describe('게임', () => {
     await expect(response.json()).resolves.toMatchObject({
       code: 'UNAUTHORIZED',
     });
+  });
+
+  /*
+   * `current`와 정반대입니다. 그쪽은 DRAFT를 빼는 게 목적이고, 이쪽은 DRAFT를 보여주는 게
+   * 목적입니다 — 만들어두고 아직 안 연 게임을 다시 찾을 방법이 이것뿐입니다(#255).
+   */
+  it('주최자 목록에는 DRAFT도 나오고 최근 것이 위다', async () => {
+    const created = gameViewSchema.parse(await (await createGame('새 게임')).json());
+
+    const response = await call(`/events/${LIVE_EVENT_CODE}/games`, { headers: AUTH_HEADERS });
+    expect(response.status).toBe(200);
+
+    const { items } = gameListResponseSchema.parse(await response.json());
+
+    expect(items.map((game) => game.id)).toEqual([created.id, OPEN_GAME_ID, FINISHED_GAME_ID]);
+    expect(items[0].status).toBe('DRAFT');
+  });
+
+  it('다른 이벤트의 게임은 목록에 섞이지 않는다', async () => {
+    const response = await call(`/events/${DRAFT_EVENT_CODE}/games`, { headers: AUTH_HEADERS });
+    const { items } = gameListResponseSchema.parse(await response.json());
+
+    expect(items).toEqual([]);
+  });
+
+  it('목록은 인증이 필요하다', async () => {
+    const response = await call(`/events/${LIVE_EVENT_CODE}/games`);
+
+    expect(response.status).toBe(401);
+    await expect(response.json()).resolves.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/mocks/handlers/game.ts
+++ b/mocks/handlers/game.ts
@@ -13,6 +13,7 @@ import {
   findEventByCode,
   findGameById,
   findParticipantByClientId,
+  listGamesOfEvent,
   listParticipantsOfGame,
   nextGameId,
   nextGameParticipantId,
@@ -109,6 +110,13 @@ export const gameHandlers = [
     db.games.push(game);
 
     return HttpResponse.json(toGameView(game), { status: 201 });
+  }),
+
+  http.get(`${API_BASE_URL}/events/:eventCode/games`, ({ request, params, cookies }) => {
+    const event = requireOwnedEvent(request, cookies, params.eventCode);
+    if (event instanceof Response) return event;
+
+    return HttpResponse.json({ items: listGamesOfEvent(event.id).map(toGameView) });
   }),
 
   /*


### PR DESCRIPTION
> ⚠️ **base가 `dev`가 아니라 `feature/249-game-mock-handlers`입니다.**
> 게임 스키마가 아직 #254에만 있어서 그 위에 쌓았습니다. #254가 머지되면 base를 `dev`로 바꾸겠습니다.

## 변경 사항

주최자용 게임 목록 엔드포인트 하나를 붙입니다.

```
GET /events/{eventCode}/games      주최자 인증 필요
```

**`DRAFT`를 포함합니다.** 이게 이 엔드포인트의 존재 이유입니다.

## 왜 필요한가

지금은 `gameId`를 생성 응답에서만 받습니다.

```
대시보드에서 "게임 만들기" → gameId 받음 → 새로고침 → gameId 사라짐
```

`GET .../games/current`가 있지만 **참가자용**이라 `DRAFT`를 뺍니다. 주최자가 게임을 미리 만들어두는 게 정상 흐름인데 그게 하나도 안 잡힙니다.

프로젝터 화면(`/events/[eventCode]/game`)이 열리려면 **어떤 게임을 띄울지 골라야** 하는데, 고를 목록이 없습니다.

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `53b04a0` | 목록 엔드포인트 + 스키마 + 조회 헬퍼 + 테스트 3개 |
| `81fd2ee` | 셀프 리뷰 반영 — 목록 테스트 보강, `NOT_OWNER` 케이스 추가 |

## 설계

**응답 항목은 `gameViewSchema` 그대로입니다.**

목록 전용 뷰를 따로 만들면 두 벌이 어긋날 자리가 생깁니다. 주최자 화면은 폴링이 아니라 진입 시 한 번 부르는 곳이라, 참가자 명단이 딸려오는 비용보다 그쪽이 큽니다. 실제로 무거워지면 그때 `participants`를 뺀 뷰를 만듭니다.

**봉투는 기존 `listResponseSchema`입니다.** `eventListResponseSchema`와 같은 형태고, FE는 `.items`로 언랩합니다.

**정렬은 id 내림차순으로 `findCurrentGame`과 기준을 맞췄습니다.** `createdAt`이 같아도 순서가 안 흔들립니다.

## 검증 방법

```
npm run lint    통과 (출력 없음)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 5 files, 123 tests passed
```

테스트 4개가 늘었습니다(119 → 123). 기준이 119인 것은 #254에 셀프 리뷰 반영으로 시드 정합성 테스트가 하나 더 붙었기 때문입니다.

| 테스트 | 확인하는 것 |
|---|---|
| 주최자 목록에는 DRAFT도 나오고 최근 것이 위다 | `DRAFT` 포함 · id 내림차순 · `.items` 봉투 |
| 다른 이벤트의 게임은 목록에 섞이지 않는다 | `eventId` 스코프 |
| 목록은 인증이 필요하다 | 401 |
| 남의 이벤트 게임 목록은 NOT_OWNER를 준다 | 403 |

첫 테스트는 `current`가 `DRAFT`를 빼는 기존 테스트와 **짝**입니다. 두 엔드포인트가 정반대 규칙을 지켜야 해서, 한쪽만 고치면 다른 쪽이 깨지도록 뒀습니다.

`NOT_OWNER`를 따로 보는 이유는 **이 목록이 `DRAFT` 게임까지 내보내는 유일한 경로**이기 때문입니다. 소유권이 새면 주최자가 아직 열지 않은 게임의 제목이 남에게 보입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **기존 엔드포인트 동작 변화 없음.** 새 경로 하나입니다
- **백엔드 계약이 하나 늘어납니다.** #255에서 확인 요청드렸습니다. 기존 `Game` 엔티티를 목록으로 내리는 것이라 새 난이도는 없다고 봅니다

## 트러블슈팅 및 참고 사항

`GET /games`와 `GET /games/current`는 경로 깊이가 달라 **순서가 상관없습니다.** `/games/current`와 `/games/:gameId`처럼 충돌하는 짝이 아닙니다. 읽기 좋으라고 생성 핸들러 바로 아래에 뒀습니다.

### 셀프 리뷰에서 고친 것

목록 테스트가 **이름값을 못 하고 있었습니다.** 「다른 이벤트의 게임은 목록에 섞이지 않는다」가 빈 배열만 확인했는데, `DRAFT_EVENT_CODE`에는 애초에 게임이 없어서 그 빈 배열이 `eventId` 필터 덕인지 원래 없어서인지 구분되지 않았습니다.

**섞이지 않는 걸 보려면 섞일 게 있어야 합니다.** 다른 이벤트에 게임을 하나 만들어두고 양쪽을 다 보도록 고쳤습니다. 그 과정에서 `createGame` 헬퍼에 이벤트 코드를 인자로 뺐고, 기본값을 둬서 기존 호출 다섯 곳은 그대로입니다.

### 범위 밖 수정 한 글자

`handlers.test.ts`의 주석 오타(`mock/data/seed.ts` → `mocks/data/seed.ts`)를 같이 고쳤습니다. #254에서 들어온 줄인데 이 PR이 어차피 그 파일을 건드려서 여기서 처리했습니다.

## 관련 이슈

- Closes #255
- Refs #243, #246, #249

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
