### PR TITLE
feat(feedback): 실시간 갱신 3종을 폴링에서 SSE로 전환한다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -111,7 +111,7 @@ const DashboardView = () => {
     feedbacks,
     isPending: isFeedPending,
     isError: isFeedError,
-    refreshIntervalMs,
+    isLive,
   } = useDashboardFeed({ eventCode, sessionId });
 
   const moderation = useModerationActions();
@@ -490,7 +490,7 @@ const DashboardView = () => {
               positive={positive}
               neutral={neutral}
               negative={negative}
-              refreshIntervalMs={refreshIntervalMs}
+              isLive={isLive}
             />
           </div>
 

--- a/components/dashboard/SentimentTrendCard.tsx
+++ b/components/dashboard/SentimentTrendCard.tsx
@@ -3,7 +3,7 @@ import { SentimentTrendChart } from '@/components/dashboard/SentimentTrendChart'
 import type { SentimentCounts } from '@/components/feedback/sentiment';
 
 /**
- * 시간대별 감정 추이 카드입니다. 제목·갱신 주기 표시·빈 상태를 맡고, 선을 그리는 일은
+ * 시간대별 감정 추이 카드입니다. 제목·갱신 상태 표시·빈 상태를 맡고, 선을 그리는 일은
  * `SentimentTrendChart`가 합니다.
  *
  * 빈 상태를 차트 안에 넣지 않는 이유는 높이를 카드가 잡기 때문입니다. 「아직 그릴 소감이
@@ -16,8 +16,11 @@ const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
 
 interface SentimentTrendCardProps extends SentimentCounts {
   trend: TrendPoint[];
-  /** 폴링 간격(ms)입니다. 영구 실패로 폴링이 멈추면 `null`이라 문구를 감춥니다. */
-  refreshIntervalMs: number | null;
+  /**
+   * 스트림으로 데이터가 흐르고 있는지입니다. 끊겨서 폴백 폴링으로 도는 동안에는 `false`라
+   * 문구를 감춥니다 — 그 사이에도 숫자는 갱신되지만 "실시간"은 아닙니다.
+   */
+  isLive: boolean;
 }
 
 const SentimentTrendCard = ({
@@ -25,15 +28,13 @@ const SentimentTrendCard = ({
   positive,
   neutral,
   negative,
-  refreshIntervalMs,
+  isLive,
 }: SentimentTrendCardProps) => (
   <section className={CARD}>
     <div className="flex items-center justify-between gap-2">
       <h2 className={CARD_TITLE}>시간대별 감정 추이</h2>
-      {refreshIntervalMs !== null && (
-        <span className="text-xs font-normal leading-4 text-text-tertiary">
-          {refreshIntervalMs / 1000}초마다 갱신
-        </span>
+      {isLive && (
+        <span className="text-xs font-normal leading-4 text-text-tertiary">실시간 갱신 중</span>
       )}
     </div>
 

--- a/components/live/LiveResult.tsx
+++ b/components/live/LiveResult.tsx
@@ -127,7 +127,7 @@ const LiveResult = () => {
     snapshot,
     isPending: isSnapshotPending,
     isError: isSnapshotError,
-    refreshIntervalMs,
+    isLive,
   } = useFeedbackSnapshot({ eventCode: code, sessionId: allowedSession?.id ?? null });
 
   const handleWriteAnother = () => {
@@ -211,10 +211,8 @@ const LiveResult = () => {
             )}
           </section>
 
-          {refreshIntervalMs !== null && (
-            <p className="text-center text-xs text-text-secondary">
-              {refreshIntervalMs / 1000}초마다 자동으로 갱신돼요
-            </p>
+          {isLive && (
+            <p className="text-center text-xs text-text-secondary">실시간으로 갱신되고 있어요</p>
           )}
         </>
       )}

--- a/hooks/useDashboardFeed.ts
+++ b/hooks/useDashboardFeed.ts
@@ -1,14 +1,17 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { fetchModerationQueue } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import { isClientError, type Feedback } from '@/lib/schemas/api';
+import { API_BASE_URL } from '@/lib/env';
+import { feedbackListResponseSchema, isClientError, type Feedback } from '@/lib/schemas/api';
 
 /**
- * 주최자 대시보드가 보는 소감 목록입니다. 지금은 폴링이고 나중에 SSE로 승급합니다.
+ * 주최자 대시보드가 보는 소감 목록입니다. 갱신은 `GET /admin/feedbacks/stream`(SSE)이
+ * 밀어줍니다(2026-08-21 명세).
  *
  * 참가자 화면의 `useFeedbackSnapshot`과 나란히 있지만 보는 엔드포인트가 다릅니다. 저쪽은
  * 서버가 집계해서 내려주는 공개 스냅샷이고, 이쪽은 `/admin/feedbacks`의 원본 목록입니다.
@@ -24,20 +27,59 @@ import { isClientError, type Feedback } from '@/lib/schemas/api';
  * 때문입니다. 집계와 피드에서 빼는 일은 화면이 `status`로 거릅니다.
  *
  * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을
- * 아는 코드는 이 파일에만 둡니다. `refetchInterval`을 밖으로 내보내지 않는 것도 같은 이유입니다.
+ * 아는 코드는 이 파일에만 둡니다. 화면은 `EventSource`도 폴백 간격도 모릅니다.
+ *
+ * 스트림 3종 중 유일하게 인증이 붙습니다. 자격증명은 다른 요청과 같은 `accessToken` 쿠키인데,
+ * `API_BASE_URL`이 `/api/proxy`라 동일 출처 요청이 되어서 브라우저가 알아서 싣습니다.
+ * `EventSource`는 헤더를 못 달아서, 쿠키 인증이 아니었으면 아예 불가능했을 자리입니다.
  */
 
-const REFRESH_INTERVAL_MS = 5_000;
+/** 서버가 스냅샷을 싣는 이벤트 이름입니다. 스트림 3종이 모두 이 이름을 씁니다(명세 고정값). */
+const SNAPSHOT_EVENT = 'snapshot';
+
+/**
+ * 스트림이 죽었을 때 되살리는 폴링 간격입니다. SSE 전환 전에 쓰던 값 그대로입니다.
+ *
+ * 스트림이 정상인 동안에는 꺼져 있습니다. `refetchInterval`은 staleness를 보지 않아서
+ * `staleTime: Infinity`와 함께 둬도 스위치처럼 동작합니다.
+ */
+const FALLBACK_INTERVAL_MS = 5_000;
+
+/**
+ * 연결한 뒤 첫 스냅샷을 이만큼 기다려보고, 안 오면 스트림이 죽은 것으로 봅니다.
+ *
+ * `onerror`로는 못 잡는 실패가 있어서 필요합니다. 압축 계층이 SSE를 막으면 응답이 200에
+ * `text/event-stream`이라 브라우저는 정상 연결로 보고 `open`까지 띄우는데, 본문만 안 옵니다
+ * (2026-08-21 실측, #261). 그때 관측할 수 있는 건 "아무 일도 안 일어난다"뿐이라 시간을 재는
+ * 수밖에 없습니다.
+ */
+const STREAM_TIMEOUT_MS = 5_000;
 
 /** 숨기기·삭제 뒤 목록을 다시 받을 때 쓰는 키 앞자리입니다. */
 const DASHBOARD_FEED_KEY = 'dashboardFeed';
 
 /**
  * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를 거르는
- * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴링도 하지 않습니다.
+ * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴백도 하지 않습니다.
  */
 const isPermanentFailure = (error: Error | null): boolean =>
   error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+/**
+ * 스트림으로 들어온 한 건을 계약 스키마로 검사합니다.
+ *
+ * `EventSource`는 `apiClient`를 거치지 않아서 `endpoints.ts`의 응답 검증이 통째로 우회됩니다.
+ * 여기서 다시 걸러주지 않으면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간
+ * 경로에서만 사라집니다. `JSON.parse`가 던지는 경우도 같이 받습니다.
+ */
+const parseQueue = (raw: string): Feedback[] | null => {
+  try {
+    const result = feedbackListResponseSchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data.items : null;
+  } catch {
+    return null;
+  }
+};
 
 interface UseDashboardFeedParams {
   eventCode: string;
@@ -50,10 +92,16 @@ interface UseDashboardFeedResult {
   isPending: boolean;
   isError: boolean;
   /**
-   * 화면이 "N초마다 갱신돼요"를 그릴 때 쓰는 값입니다. 주기 갱신이 돌고 있지 않으면 `null`입니다.
-   * 폴링을 멈춘 실패에서 그렇고, SSE로 바뀌면 항상 `null`이 됩니다.
+   * 스트림으로 데이터가 실제로 흐르고 있는지입니다. 화면은 이 값으로 "실시간" 안내를 그릴지
+   * 정합니다.
+   *
+   * 폴링 시절의 `refreshIntervalMs`를 대신합니다. 밀어주는 방식에는 간격이라는 개념이 없어서
+   * "N초마다"를 그릴 수 없고, 대신 붙었는지 끊겼는지가 사용자에게 의미 있는 정보가 됐습니다.
+   *
+   * "연결됐는지"가 아니라 "흐르는지"입니다. 둘은 다릅니다 — 압축 계층에 막힌 스트림은 연결까지는
+   * 멀쩡히 되고 데이터만 안 옵니다(#261). 그래서 `open`이 아니라 첫 스냅샷에서 켭니다.
    */
-  refreshIntervalMs: number | null;
+  isLive: boolean;
 }
 
 const useDashboardFeed = ({
@@ -61,13 +109,31 @@ const useDashboardFeed = ({
   sessionId,
 }: UseDashboardFeedParams): UseDashboardFeedResult => {
   /*
-   * 인증 여부를 화면에서 받지 않고 여기서 직접 봅니다. "로그인이 없으면 폴링하지 않는다"는
+   * 인증 여부를 화면에서 받지 않고 여기서 직접 봅니다. "로그인이 없으면 붙지 않는다"는
    * 화면이 정할 일이 아니라 이 훅의 불변조건입니다. `['auth','me']` 캐시를 공유하므로 요청은
    * 늘지 않습니다 — 대시보드에는 `HostHeader`가 이미 같은 쿼리를 띄워둡니다.
    */
   const { isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
+  const [isLive, setIsLive] = useState(false);
+  const [isStreamBroken, setIsStreamBroken] = useState(false);
+  /* 스트림을 다시 열려고 두는 세대 번호입니다. 올라갈 때마다 아래 effect가 다시 돕니다. */
+  const [reconnectToken, setReconnectToken] = useState(0);
+  /*
+   * 스트림이 죽은 시각입니다. 아래 재연결 effect가 "이 시각 이후에 성공한 폴백 조회가 있는가"를
+   * 판정하는 기준점이라, 끊긴 사실만이 아니라 언제 끊겼는지를 남겨야 합니다.
+   */
+  const brokenSinceRef = useRef<number | null>(null);
+  /*
+   * 재연결을 한 차례로 묶어 두는 빗장입니다. 스냅샷을 한 건이라도 받으면 다시 열립니다.
+   *
+   * 없으면 무한히 깜빡입니다. 인증과 무관한 고장 — 압축 계층에 막힌 스트림 같은 것 — 에서는
+   * 폴백 조회가 계속 성공하는데 스트림만 계속 죽어서, "열림 → 5초 뒤 워치독 → 폴백 성공 →
+   * 다시 열림"이 영원히 돕니다.
+   */
+  const canRetryRef = useRef(true);
 
-  const { data, isPending, isError, error } = useQuery({
+  const { data, isPending, isError, dataUpdatedAt } = useQuery({
     queryKey: [DASHBOARD_FEED_KEY, eventCode, sessionId],
     queryFn: () =>
       fetchModerationQueue({
@@ -77,7 +143,7 @@ const useDashboardFeed = ({
       }),
     /*
      * 로그인이 풀리면 요청 자체를 내보내지 않습니다. 아래 `isPermanentFailure`가 401을 받고
-     * 폴링을 멈추긴 하지만 멈추기 전 한 번은 나가는데, #247의 401 인터셉터가 붙으면 그 한 번이
+     * 폴백을 멈추긴 하지만 멈추기 전 한 번은 나가는데, `apiClient`의 401 인터셉터가 그 한 번으로
      * `/auth/refresh`까지 부릅니다. 방금 로그아웃한 사용자를 위해 재발급을 시도하다 다시 401을
      * 받고 로그아웃 처리가 한 번 더 도는 흐름이라, 요청을 아예 막는 편이 낫습니다.
      *
@@ -88,23 +154,128 @@ const useDashboardFeed = ({
      */
     enabled: isAuthenticated,
     /*
-     * 폴링 타이머는 에러 상태에서도 그대로 돕니다. `QueryObserver`가 간격을 다시 잴 때 보는 건
-     * `enabled`와 간격값뿐이라 실패 여부는 아예 안 봅니다. 그래서 로그인이 풀린 화면이 401을
-     * 5초마다 새로 받아냅니다. `retry`가 이미 4xx를 거르고 있어서 재시도로도 안 잡힙니다.
-     *
-     * 5xx·네트워크 끊김은 계속 돌립니다. 저쪽은 다음 번에 성공할 수 있는 실패라, 여기서 같이
-     * 멈추면 순간 장애 한 번에 진행 중인 이벤트의 대시보드가 영영 멈춥니다. `refetchOnWindowFocus`도
+     * 갱신은 스트림이 맡으므로 주기적인 재요청 트리거를 끕니다. 이 쿼리에 남은 역할은 셋입니다 —
+     * 스트림의 첫 스냅샷이 오기 전 화면을 채우는 것, 스트림이 죽었을 때의 폴백, 그리고
+     * `useModerationActions`가 숨기기·삭제 뒤 이 키를 무효화할 때의 재조회입니다.
+     * `invalidateQueries`는 staleness를 보지 않아서 `Infinity`와 함께 둬도 그 재조회는 돕니다.
+     */
+    staleTime: Infinity,
+    /*
+     * 5xx·끊김은 계속 돌립니다. 저쪽은 다음 번에 성공할 수 있는 실패라, 여기서 같이 멈추면
+     * 순간 장애 한 번에 진행 중인 이벤트의 대시보드가 영영 멈춥니다. `refetchOnWindowFocus`도
      * 꺼져 있어서 탭을 다시 봐도 살아나지 않고, 남는 복구 수단이 새로고침뿐입니다.
      */
-    refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
+    refetchInterval: ({ state }) =>
+      isStreamBroken && !isPermanentFailure(state.error) ? FALLBACK_INTERVAL_MS : false,
   });
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    /*
+     * `EventSource`는 Next도 React도 아닌 브라우저 API라 서버에는 없습니다. effect가 서버에서
+     * 실행되지 않아서 SSR이 터지지 않는 것이고, 이 생성을 effect 밖으로 끌어내면 그때 깨집니다.
+     *
+     * `eventCode`는 명세상 필수입니다(소유권 검증 대상). 나머지 쿼리는 위 `queryFn`과 맞춰야
+     * 스트림과 폴백이 같은 큐를 봅니다.
+     */
+    const query = new URLSearchParams({ eventCode, includeHidden: 'true' });
+    if (sessionId !== null) query.set('sessionId', String(sessionId));
+
+    /*
+     * 동일 출처(`/api/proxy`)라 `withCredentials` 없이도 쿠키가 실립니다. 그래도 켜두는 건
+     * `NEXT_PUBLIC_API_BASE_URL`을 백엔드 절대주소로 바꾸는 순간 필수가 되기 때문입니다.
+     * 그때는 백엔드 CORS에 `Access-Control-Allow-Credentials`도 함께 필요합니다.
+     */
+    const source = new EventSource(`${API_BASE_URL}/admin/feedbacks/stream?${query.toString()}`, {
+      withCredentials: true,
+    });
+
+    /* 끊긴 시각을 남깁니다. 이미 끊겨 있으면 처음 끊긴 시각을 유지합니다. */
+    const markBroken = () => {
+      brokenSinceRef.current ??= Date.now();
+      setIsStreamBroken(true);
+    };
+
+    /*
+     * 첫 스냅샷을 기다리는 타이머입니다. 연결할 때마다 새로 걸고 스냅샷이 오면 지웁니다.
+     *
+     * 스냅샷마다 다시 걸지 않는 게 중요합니다. 다시 걸면 소감이 한동안 안 들어오는 조용한
+     * 구간을 고장으로 잘못 읽습니다. 서버가 밀어줄 게 없어서 조용한 것과 스트림이 죽어서
+     * 조용한 것은 다르고, 구분점은 "연결 직후 1건"이라는 명세의 보장입니다.
+     */
+    let watchdog: ReturnType<typeof setTimeout>;
+    const armWatchdog = () => {
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => {
+        setIsLive(false);
+        markBroken();
+      }, STREAM_TIMEOUT_MS);
+    };
+
+    // 연결이 아예 안 뜨는 경우까지 덮으려고 여기서 한 번, 재연결마다 `open`에서 다시 겁니다.
+    armWatchdog();
+    source.addEventListener('open', armWatchdog);
+
+    source.addEventListener(SNAPSHOT_EVENT, (message: MessageEvent<string>) => {
+      const feedbacks = parseQueue(message.data);
+      if (feedbacks === null) {
+        markBroken();
+        return;
+      }
+
+      clearTimeout(watchdog);
+      brokenSinceRef.current = null;
+      canRetryRef.current = true;
+      setIsLive(true);
+      setIsStreamBroken(false);
+      queryClient.setQueryData([DASHBOARD_FEED_KEY, eventCode, sessionId], feedbacks);
+    });
+
+    /*
+     * 끊겨서 다시 붙는 중(`CONNECTING`)이면 곧 돌아오므로 실패로 치지 않습니다. `CLOSED`는
+     * 다릅니다 — 응답이 200이 아니거나 `text/event-stream`이 아니면 브라우저가 재연결을
+     * 포기하고 여기로 옵니다. 스스로 살아나지 않으니 이때만 폴백을 켭니다.
+     */
+    source.onerror = () => {
+      setIsLive(false);
+      if (source.readyState === EventSource.CLOSED) markBroken();
+    };
+
+    return () => {
+      clearTimeout(watchdog);
+      source.close();
+      setIsLive(false);
+    };
+  }, [eventCode, sessionId, isAuthenticated, queryClient, reconnectToken]);
+
+  /*
+   * 끊긴 스트림을 다시 엽니다. 방아쇠는 "끊긴 뒤에 성공한 폴백 조회"입니다.
+   *
+   * 재발급을 여기서 직접 하지 않는 이유입니다. 이 스트림은 인증이 붙어서 accessToken(1시간)이
+   * 만료되면 `CLOSED`로 죽는데, `EventSource`는 상태 코드를 안 알려줘서 401인지 403인지 서버가
+   * 재시작한 건지 구분할 수 없습니다. 반면 폴백 폴링은 `apiClient`를 타므로 401이면 그쪽
+   * 인터셉터가 제 조건으로 재발급하고 재시도까지 끝냅니다. 그러니 "폴백이 성공했다"는 사실
+   * 자체가 곧 "인증이 필요했다면 이미 되살아났다"는 신호입니다. 재발급 조건을 이 파일로
+   * 복사해 오면 규칙이 두 군데로 갈라집니다.
+   *
+   * 이게 없으면 만료 한 번에 대시보드가 언마운트할 때까지 폴링으로 남습니다. 쿠키는 멀쩡하고
+   * 화면도 갱신되니 눈치채기 어려운 종류의 퇴화입니다.
+   */
+  useEffect(() => {
+    const brokenSince = brokenSinceRef.current;
+    if (brokenSince === null || !canRetryRef.current) return;
+    if (dataUpdatedAt <= brokenSince) return;
+
+    brokenSinceRef.current = null;
+    canRetryRef.current = false;
+    setReconnectToken((token) => token + 1);
+  }, [dataUpdatedAt]);
 
   return {
     feedbacks: data,
     isPending,
     isError,
-    /* 폴링이 멈춘 뒤에도 "5초마다 갱신"을 그리면 거짓말이 됩니다. 화면은 `null`이면 라벨을 감춥니다. */
-    refreshIntervalMs: isPermanentFailure(error) ? null : REFRESH_INTERVAL_MS,
+    isLive,
   };
 };
 

--- a/hooks/useEventEntryFeed.ts
+++ b/hooks/useEventEntryFeed.ts
@@ -1,30 +1,59 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import { isClientError, type EventView, type SessionView } from '@/lib/schemas/api';
+import {
+  isClientError,
+  listResponseSchema,
+  sessionViewSchema,
+  type EventView,
+  type SessionView,
+} from '@/lib/schemas/api';
+import { useEffect, useState } from 'react';
+import { API_BASE_URL } from '@/lib/env';
 
 /**
- * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트입니다. 지금은 폴링이고 나중에 SSE로
- * 승급합니다.
+ * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트입니다.
  *
  * 셋을 한 훅에 두는 이유는 서로 배타적으로 켜졌다 꺼지는 하나의 상태 머신이기 때문입니다.
- * 이벤트가 `ENDED`를 잡는 순간 세션 폴링을 끄고 리포트 폴링을 켜는 그 조율이 이 훅의 알맹이라,
+ * 이벤트가 `ENDED`를 잡는 순간 세션 구독을 끊고 리포트 폴링을 켜는 그 조율이 이 훅의 알맹이라,
  * 나눠두면 조율이 화면으로 흘러나갑니다(`useEventReport`가 조회·생성·공개를 묶은 것과 같은 이유).
  *
+ * 갱신 수단이 둘로 갈립니다. 세션만 SSE(`.../sessions/stream`)로 받고, 이벤트 상태와 리포트는
+ * 폴링입니다. 명세에 스트림이 셋뿐이라 이벤트 상태에는 아예 없고, 리포트는 "실시간 push(SSE)는
+ * 도입하지 않고 폴링으로 확정"이라고 명시적으로 배제됐습니다(2026-08-21).
+ *
  * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을 아는
- * 코드는 이 파일에만 둡니다. `refetchInterval`을 밖으로 내보내지 않는 것도 같은 이유입니다.
+ * 코드는 이 파일에만 둡니다. 화면은 `EventSource`도 폴링 간격도 모릅니다.
  */
 
+/** 서버가 스냅샷을 싣는 이벤트 이름입니다. 스트림 3종이 모두 이 이름을 씁니다(명세 고정값). */
+const SNAPSHOT_EVENT = 'snapshot';
+
 /**
- * 세션이 열리고 닫히는 것을 따라가는 간격입니다.
+ * 이벤트 상태(`DRAFT` → `LIVE` → `ENDED`)를 따라가는 간격이자, 세션 스트림이 죽었을 때
+ * 되살리는 폴링 간격입니다. SSE 전환 전 둘 다 이 값이었어서 그대로 씁니다.
  *
- * "세션 시작"은 초 단위 정확도가 필요한 값이 아니고, 게스트 요청은 참가자 수만큼 곱해집니다.
- * 그래서 주최자 화면보다 촘촘하게 갈 이유가 없습니다(#237).
+ * 이벤트 상태에는 스트림이 없어서 그쪽은 늘 폴링입니다. "행사가 시작됐다"는 초 단위 정확도가
+ * 필요한 값이 아니고 게스트 요청은 참가자 수만큼 곱해지므로, 촘촘하게 갈 이유가 없습니다.
+ * 이 간격이 곧 게스트가 시작·종료를 알아차리기까지의 최대 지연입니다.
  */
 const REFRESH_INTERVAL_MS = 5_000;
+
+/**
+ * 연결한 뒤 첫 스냅샷을 이만큼 기다려보고, 안 오면 스트림이 죽은 것으로 봅니다.
+ *
+ * `onerror`로는 못 잡는 실패가 있어서 필요합니다. 압축 계층이 SSE를 막으면 응답이 200에
+ * `text/event-stream`이라 브라우저는 정상 연결로 보고 `open`까지 띄우는데, 본문만 안 옵니다
+ * (2026-08-21 실측, #261). 그때 관측할 수 있는 건 "아무 일도 안 일어난다"뿐이라 시간을 재는
+ * 수밖에 없습니다.
+ *
+ * 명세가 연결 즉시 스냅샷 1건을 보장하고 목에서는 43ms에 왔습니다. 5초면 느린 회선에서도
+ * 오탐이 나지 않을 여유입니다.
+ */
+const STREAM_TIMEOUT_MS = 5_000;
 
 /**
  * 리포트가 공개되기를 기다리는 간격입니다. 위보다 훨씬 성긴 이유는 시간 척도가 달라서입니다 —
@@ -44,6 +73,27 @@ const REPORT_REFRESH_INTERVAL_MS = 15_000;
  */
 const isPermanentFailure = (error: Error | null): boolean =>
   error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+/**
+ * 스트림으로 들어온 한 건을 계약 스키마로 검사하고 봉투를 벗깁니다.
+ *
+ * `EventSource`는 `apiClient`를 거치지 않아서 `endpoints.ts`의 응답 검증이 통째로 우회됩니다.
+ * 여기서 다시 걸러주지 않으면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간
+ * 경로에서만 사라집니다. `JSON.parse`가 던지는 경우도 같이 받습니다.
+ *
+ * 모듈 스코프에 두는 이유는 아래 effect가 이 함수를 쓰기 때문입니다. 훅 안에 두면 렌더마다 새
+ * 함수가 되고, 그걸 deps에 넣는 순간 렌더마다 구독을 끊었다 다시 엽니다.
+ *
+ * `feedbacks/stream`과 달리 `{ items }` 봉투로 옵니다(`SessionListResponse`).
+ */
+const parseSessions = (raw: string): SessionView[] | null => {
+  try {
+    const result = listResponseSchema(sessionViewSchema).safeParse(JSON.parse(raw));
+    return result.success ? result.data.items : null;
+  } catch {
+    return null;
+  }
+};
 
 /**
  * 리포트가 공개됐는지만 봅니다. 본문은 받지 않습니다 — 이 화면이 정하는 건 "결과 리포트 보기"를
@@ -68,8 +118,8 @@ interface UseEventEntryFeedParams {
   eventCode: string;
   /**
    * 서버 컴포넌트가 이미 받아둔 값입니다. `initialData`로 넣어야 SSR HTML에 실려 나간 첫 화면이
-   * 그대로 유지되고, 그 뒤부터 폴링이 갱신을 맡습니다. 넘기지 않으면 게스트가 완성된 화면을
-   * 받아놓고도 마운트 직후 빈 상태를 한 번 지나갑니다.
+   * 그대로 유지되고, 그 뒤부터 스트림·폴링이 갱신을 맡습니다. 넘기지 않으면 게스트가 완성된
+   * 화면을 받아놓고도 마운트 직후 빈 상태를 한 번 지나갑니다.
    */
   initialEvent: EventView;
   initialSessions: SessionView[];
@@ -92,6 +142,10 @@ const useEventEntryFeed = ({
   initialSessions,
   initialHasReport,
 }: UseEventEntryFeedParams): UseEventEntryFeedResult => {
+  const queryClient = useQueryClient();
+  /** 세션 스트림이 죽었는지입니다. 참이면 아래 쿼리가 폴링으로 되돌아갑니다. */
+  const [isStreamBroken, setIsStreamBroken] = useState(false);
+
   const eventQuery = useQuery({
     queryKey: ['event', eventCode],
     queryFn: () => fetchEventByCode(eventCode),
@@ -114,17 +168,80 @@ const useEventEntryFeed = ({
     queryFn: () => fetchSessionsByEventCode(eventCode),
     initialData: initialSessions,
     /*
-     * 정지 조건에 세션 상태를 넣지 않습니다. "하나라도 열렸으면 그만 물어봐도 된다"가 그럴듯해
-     * 보이지만, 그러면 닫히는 쪽을 못 잡습니다 — 주최자가 A를 닫고 B를 여는 사이 게스트는 A만
-     * 열린 화면에 소감을 다 쓰고 제출에서야 `SESSION_CLOSED`를 받습니다.
+     * 갱신은 아래 스트림이 맡으므로 재요청 트리거를 끕니다.
      *
-     * `ENDED`에서 멈추는 건 다릅니다. 그 뒤에 세션이 열려도 `canSubmit`이 `LIVE`를 요구해서
-     * 화면이 바뀌지 않습니다. 목이 세션 토글에 이벤트 상태를 검사하지 않아 실제로 열릴 수는
-     * 있지만, 열려봐야 게스트는 `EVENT_NOT_LIVE`로 막힙니다.
+     * 폴링 시절에는 여기에 "정지 조건에 세션 상태를 넣지 않는다"는 설명이 있었습니다. 하나라도
+     * 열렸다고 그만 물어보면 닫히는 쪽을 놓쳐서, 주최자가 A를 닫고 B를 여는 사이 게스트가 A만
+     * 열린 화면에 소감을 다 쓰고 제출에서야 `SESSION_CLOSED`를 받는 문제였습니다. 밀어주는
+     * 방식에서는 "그만 물어봐도 되나"를 따질 일이 없어서 그 고민 자체가 사라졌습니다.
+     *
+     * `initialData`가 있는 상태의 `staleTime: Infinity`라 평소에는 `queryFn`이 아예 실행되지
+     * 않습니다. SSR이 첫 값을 채우고 그 뒤는 스트림이 덮어씁니다.
      */
-    refetchInterval: ({ state }) =>
-      isEnded || isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS,
+    staleTime: Infinity,
+    /*
+     * 스트림이 죽은 동안만 예전 폴링을 되살립니다. `refetchInterval`은 staleness를 보지 않아서
+     * 위의 `staleTime: Infinity`와 함께 둬도 스위치처럼 동작합니다.
+     *
+     * 이게 없으면 스트림이 조용히 죽었을 때 세션 목록이 SSR 시점 값에 영영 굳습니다. 칩도 폼도
+     * 멀쩡히 떠 있어서 아무도 눈치채지 못한 채 #237이 그대로 재현됩니다.
+     */
+    refetchInterval: isStreamBroken ? REFRESH_INTERVAL_MS : false,
   });
+
+  /*
+   * 세션 목록 구독입니다(#261). `ENDED` 뒤에는 열지 않습니다 — 폴링을 멈추던 조건과 같은
+   * 판단이고, 그 뒤에 세션이 열려도 `canSubmit`이 `LIVE`를 요구해서 화면이 바뀌지 않습니다.
+   *
+   * `EventSource`는 Next도 React도 아닌 브라우저 API라 서버에는 없습니다. effect가 서버에서
+   * 실행되지 않아서 SSR이 터지지 않는 것이고, 이 생성을 effect 밖으로 끌어내면 그때 깨집니다.
+   *
+   * 연결 상태를 화면에 보여주지는 않습니다(그릴 자리가 없습니다). 대신 죽은 걸 감지해서 위
+   * 쿼리의 폴링을 되살리는 데만 씁니다.
+   */
+  useEffect(() => {
+    if (isEnded) return;
+    const source = new EventSource(`${API_BASE_URL}/events/${eventCode}/sessions/stream`);
+
+    /*
+     * 첫 스냅샷을 기다리는 타이머입니다. 연결할 때마다 새로 걸고 스냅샷이 오면 지웁니다.
+     *
+     * 스냅샷마다 다시 걸지 않는 게 중요합니다. 다시 걸면 세션이 한동안 안 바뀌는 조용한 구간을
+     * 고장으로 잘못 읽습니다. 서버가 밀어줄 게 없어서 조용한 것과 스트림이 죽어서 조용한 것은
+     * 다르고, 구분점은 "연결 직후 1건"이라는 명세의 보장입니다.
+     */
+    let watchdog: ReturnType<typeof setTimeout>;
+    const armWatchdog = () => {
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => setIsStreamBroken(true), STREAM_TIMEOUT_MS);
+    };
+
+    // 연결이 아예 안 뜨는 경우까지 덮으려고 여기서 한 번, 재연결마다 `open`에서 다시 겁니다.
+    armWatchdog();
+    source.addEventListener('open', armWatchdog);
+
+    source.addEventListener(SNAPSHOT_EVENT, (message: MessageEvent<string>) => {
+      const sessions = parseSessions(message.data);
+      if (sessions === null) return;
+
+      clearTimeout(watchdog);
+      setIsStreamBroken(false);
+      queryClient.setQueryData(['sessions', eventCode], sessions);
+    });
+
+    /*
+     * 끊겨서 다시 붙는 중(`CONNECTING`)이면 곧 돌아오므로 실패로 치지 않습니다. `CLOSED`는
+     * 브라우저가 재연결을 포기한 상태라 스스로 살아나지 않습니다. 이때만 폴백을 켭니다.
+     */
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) setIsStreamBroken(true);
+    };
+
+    return () => {
+      clearTimeout(watchdog);
+      source.close();
+    };
+  }, [eventCode, isEnded, queryClient]);
 
   const reportQuery = useQuery({
     queryKey: ['publicReportExists', eventCode],
@@ -133,7 +250,8 @@ const useEventEntryFeed = ({
     /*
      * 전역 기본값(`QueryProvider`의 10초)보다 길어야 의미가 있습니다. SSR로 받아둔 값을 마운트
      * 직후 한 번 더 물어보지 않게 하려는 것이고, 폴링 간격과 맞춰야 요청이 두 리듬으로 겹치지
-     * 않습니다. 이벤트·세션 쪽은 전역 10초가 이미 그 일을 해서 따로 두지 않았습니다.
+     * 않습니다. 이벤트 쪽은 전역 10초가 이미 그 일을 하고, 세션은 스트림이 맡아서 아예
+     * `staleTime: Infinity`입니다.
      */
     staleTime: REPORT_REFRESH_INTERVAL_MS,
     // 리포트 생성 자체가 `ENDED`에서만 가능해서(`useEventReport`), 그 전에는 물어볼 이유가 없습니다.
@@ -154,8 +272,8 @@ const useEventEntryFeed = ({
     event,
     sessions: sessionsQuery.data,
     /*
-     * 파생값까지 훅이 계산해서 내보냅니다. 화면이 다시 조합하게 두면 폴링으로 값이 움직일 때마다
-     * 판정이 두 벌로 갈리고, 한쪽만 고치는 실수가 열립니다.
+     * 파생값까지 훅이 계산해서 내보냅니다. 화면이 다시 조합하게 두면 값이 움직일 때마다 판정이
+     * 두 벌로 갈리고, 한쪽만 고치는 실수가 열립니다.
      *
      * `LIVE`를 요구하는 이유 — 참가자는 `DRAFT`와 "세션이 아직 안 열림"을 구분할 수 없습니다. 둘 다
      * 기다려야 하는 상태라 같은 화면을 보여줍니다. `DRAFT`는 세션이 미리 만들어져 있어도 막아야

--- a/hooks/useFeedbackSnapshot.ts
+++ b/hooks/useFeedbackSnapshot.ts
@@ -1,22 +1,42 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { fetchFeedbackSnapshot } from '@/lib/api/endpoints';
-import type { FeedbackSnapshot } from '@/lib/schemas/api';
+import { feedbackSnapshotSchema, type FeedbackSnapshot } from '@/lib/schemas/api';
+import { useEffect, useState } from 'react';
+import { API_BASE_URL } from '@/lib/env';
 
 /**
- * 집계 스냅샷 구독입니다. 지금은 폴링이고 나중에 SSE로 승급합니다.
+ * 집계 스냅샷 구독입니다. 갱신은 `GET /events/{eventCode}/feedbacks/stream`(SSE)이
+ * 밀어줍니다(2026-08-21 명세).
  *
- * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리해서 나중에 전환" 원칙에 따라,
- * 갱신 방식을 아는 코드를 이 파일 하나로 묶었습니다. 백엔드가 SSE 엔드포인트를 열면 이 파일의
- * 내부만 바꾸면 되고 화면은 손대지 않습니다.
+ * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리해서 나중에 전환" 원칙에 따라
+ * 갱신 방식을 아는 코드는 이 파일에만 둡니다. 화면은 `EventSource`도, 갱신 간격도 모릅니다.
  *
- * 그래서 `refetchInterval` 같은 TanStack Query 옵션도 밖으로 내보내지 않습니다. 화면이 폴링을
- * 전제한 코드를 갖게 되면 격리한 의미가 없어집니다.
+ * TanStack Query를 걷어내지 않고 캐시만 스트림이 채우게 뒀습니다. 이 훅만 보면 `useState`로도
+ * 충분하지만(이 키를 무효화하는 mutation이 없습니다), 같은 모양이 `useDashboardFeed`에서는
+ * 실제로 필요합니다 — 거기선 모더레이션 mutation이 `DASHBOARD_FEED_KEY`를 무효화합니다.
  */
 
-const REFRESH_INTERVAL_MS = 3_000;
+/** 서버가 스냅샷을 싣는 이벤트 이름입니다. 스트림 3종이 모두 이 이름을 씁니다(명세 고정값). */
+const SNAPSHOT_EVENT = 'snapshot';
+
+/**
+ * 스트림으로 들어온 한 건을 계약 스키마로 검사합니다.
+ *
+ * `EventSource`는 `apiClient`를 거치지 않아서 `endpoints.ts`의 응답 검증이 통째로 우회됩니다.
+ * 여기서 다시 걸러주지 않으면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간
+ * 경로에서만 사라집니다. `JSON.parse`가 던지는 경우도 같이 받습니다.
+ */
+const parseSnapshot = (raw: string): FeedbackSnapshot | null => {
+  try {
+    const result = feedbackSnapshotSchema.safeParse(JSON.parse(raw));
+    return result.success ? result.data : null;
+  } catch {
+    return null;
+  }
+};
 
 interface UseFeedbackSnapshotParams {
   eventCode: string;
@@ -29,29 +49,79 @@ interface UseFeedbackSnapshotResult {
   isPending: boolean;
   isError: boolean;
   /**
-   * 화면이 "N초마다 갱신돼요"를 그릴 때 쓰는 값입니다.
+   * 스트림이 붙어 있는지입니다. 화면은 이 값으로 "실시간" 안내를 그릴지 정합니다.
    *
-   * SSE로 바뀌면 `null`이 됩니다. 호출부는 값이 있으면 주기를 안내하고 없으면 그 문구를 빼면 되므로,
-   * 갱신 방식이 무엇인지는 몰라도 됩니다.
+   * 폴링 시절의 `refreshIntervalMs`를 대신합니다. 밀어주는 방식에는 간격이라는 개념이 없어서
+   * "N초마다"를 그릴 수 없고, 대신 붙었는지 끊겼는지가 사용자에게 의미 있는 정보가 됐습니다.
    */
-  refreshIntervalMs: number | null;
+  isLive: boolean;
 }
 
 export const useFeedbackSnapshot = ({
   eventCode,
   sessionId,
 }: UseFeedbackSnapshotParams): UseFeedbackSnapshotResult => {
+  const queryClient = useQueryClient();
+  const [isLive, setIsLive] = useState(false);
+  const [isStreamBroken, setIsStreamBroken] = useState(false);
   const { data, isPending, isError } = useQuery({
     queryKey: ['feedbackSnapshot', eventCode, sessionId],
     queryFn: () => fetchFeedbackSnapshot(eventCode, sessionId ?? undefined),
     enabled: sessionId !== null,
-    refetchInterval: REFRESH_INTERVAL_MS,
+    /*
+     * 갱신은 스트림이 맡으므로 재요청 트리거를 끕니다. 이 쿼리에 남은 역할은 둘입니다 —
+     * 스트림의 첫 스냅샷이 오기 전 화면을 채우는 것, 그리고 스트림이 못 뜬 경우의 폴백입니다.
+     *
+     * 폴백을 남겨둔 값이 실제로 있습니다. 압축 계층이 SSE를 막으면(#261) 스트림은 열리기만
+     * 하고 이벤트가 한 건도 안 오는데, 그때도 화면은 한 번 받아둔 집계를 보여줍니다. 대신
+     * 실시간이 죽은 걸 화면이 모르게 되므로 `isLive`로 그 사실을 따로 알립니다.
+     */
+    staleTime: Infinity,
   });
 
+  useEffect(() => {
+    if (sessionId === null) return;
+    /*
+     * effect가 서버에서 실행되지 않아서 SSR이 터지지 않는 것이고,
+     * `'use client'`만으로는 부족합니다 — 클라이언트
+     * 컴포넌트도 서버에서 한 번 렌더됩니다. 이 생성을 effect 밖으로 끌어내면 그때 깨집니다.
+     */
+    const query = new URLSearchParams({ sessionId: String(sessionId) });
+    const source = new EventSource(
+      `${API_BASE_URL}/events/${eventCode}/feedbacks/stream?${query.toString()}`,
+    );
+    source.addEventListener('open', () => {
+      setIsLive(true);
+      setIsStreamBroken(false);
+    });
+
+    source.addEventListener(SNAPSHOT_EVENT, (event: MessageEvent<string>) => {
+      const snapshot = parseSnapshot(event.data);
+      if (snapshot === null) {
+        setIsStreamBroken(true);
+        return;
+      }
+      queryClient.setQueryData(['feedbackSnapshot', eventCode, sessionId], snapshot);
+    });
+    /*
+     * `error`는 두 상황에서 옵니다. 끊겨서 브라우저가 다시 붙는 중(`CONNECTING`)이면 잠깐
+     * 실시간이 아닐 뿐 곧 돌아오므로 실패로 치지 않습니다. `CLOSED`는 다릅니다 — 응답이 200이
+     * 아니거나 `text/event-stream`이 아니면 브라우저가 재연결을 포기하고 여기로 옵니다.
+     * 스스로 살아나지 않으니 이때만 실패로 올립니다.
+     */
+    source.onerror = () => {
+      setIsLive(false);
+      if (source.readyState === EventSource.CLOSED) setIsStreamBroken(true);
+    };
+    return () => {
+      source.close();
+      setIsLive(false);
+    };
+  }, [eventCode, sessionId, queryClient]);
   return {
     snapshot: data,
     isPending,
-    isError,
-    refreshIntervalMs: REFRESH_INTERVAL_MS,
+    isError: isError || isStreamBroken,
+    isLive,
   };
 };

--- a/hooks/useFeedbackSnapshot.ts
+++ b/hooks/useFeedbackSnapshot.ts
@@ -23,6 +23,27 @@ import { API_BASE_URL } from '@/lib/env';
 const SNAPSHOT_EVENT = 'snapshot';
 
 /**
+ * 연결한 뒤 첫 스냅샷을 이만큼 기다려보고, 안 오면 스트림이 죽은 것으로 봅니다.
+ *
+ * `onerror`로는 못 잡는 실패가 있어서 필요합니다. 압축 계층이 SSE를 막으면 응답이 200에
+ * `text/event-stream`이라 브라우저는 정상 연결로 보고 `open`까지 띄우는데, 본문만 안 옵니다
+ * (2026-08-21 실측, #261). 그때 관측할 수 있는 건 "아무 일도 안 일어난다"뿐이라 시간을 재는
+ * 수밖에 없습니다.
+ *
+ * 명세가 연결 즉시 스냅샷 1건을 보장하고 목에서는 43ms에 왔습니다. 5초면 느린 회선에서도
+ * 오탐이 나지 않을 여유입니다.
+ */
+const STREAM_TIMEOUT_MS = 5_000;
+
+/**
+ * 스트림이 죽었을 때 되살리는 폴링 간격입니다. SSE 전환 전에 쓰던 값 그대로입니다.
+ *
+ * 스트림이 정상인 동안에는 꺼져 있습니다. `refetchInterval`은 staleness를 보지 않아서
+ * `staleTime: Infinity`와 함께 둬도 스위치처럼 동작합니다.
+ */
+const FALLBACK_INTERVAL_MS = 3_000;
+
+/**
  * 스트림으로 들어온 한 건을 계약 스키마로 검사합니다.
  *
  * `EventSource`는 `apiClient`를 거치지 않아서 `endpoints.ts`의 응답 검증이 통째로 우회됩니다.
@@ -49,10 +70,14 @@ interface UseFeedbackSnapshotResult {
   isPending: boolean;
   isError: boolean;
   /**
-   * 스트림이 붙어 있는지입니다. 화면은 이 값으로 "실시간" 안내를 그릴지 정합니다.
+   * 스트림으로 데이터가 실제로 흐르고 있는지입니다. 화면은 이 값으로 "실시간" 안내를 그릴지
+   * 정합니다.
    *
    * 폴링 시절의 `refreshIntervalMs`를 대신합니다. 밀어주는 방식에는 간격이라는 개념이 없어서
    * "N초마다"를 그릴 수 없고, 대신 붙었는지 끊겼는지가 사용자에게 의미 있는 정보가 됐습니다.
+   *
+   * "연결됐는지"가 아니라 "흐르는지"입니다. 둘은 다릅니다 — 압축 계층에 막힌 스트림은 연결까지는
+   * 멀쩡히 되고 데이터만 안 옵니다(#261). 그래서 `open`이 아니라 첫 스냅샷에서 켭니다.
    */
   isLive: boolean;
 }
@@ -69,14 +94,18 @@ export const useFeedbackSnapshot = ({
     queryFn: () => fetchFeedbackSnapshot(eventCode, sessionId ?? undefined),
     enabled: sessionId !== null,
     /*
-     * 갱신은 스트림이 맡으므로 재요청 트리거를 끕니다. 이 쿼리에 남은 역할은 둘입니다 —
-     * 스트림의 첫 스냅샷이 오기 전 화면을 채우는 것, 그리고 스트림이 못 뜬 경우의 폴백입니다.
-     *
-     * 폴백을 남겨둔 값이 실제로 있습니다. 압축 계층이 SSE를 막으면(#261) 스트림은 열리기만
-     * 하고 이벤트가 한 건도 안 오는데, 그때도 화면은 한 번 받아둔 집계를 보여줍니다. 대신
-     * 실시간이 죽은 걸 화면이 모르게 되므로 `isLive`로 그 사실을 따로 알립니다.
+     * 갱신은 스트림이 맡으므로 주기적인 재요청 트리거를 끕니다. 이 쿼리에 남은 역할은 둘입니다 —
+     * 스트림의 첫 스냅샷이 오기 전 화면을 채우는 것, 그리고 스트림이 죽었을 때의 폴백입니다.
      */
     staleTime: Infinity,
+    /*
+     * 스트림이 죽은 동안만 예전 폴링을 되살립니다. `refetchInterval`은 staleness를 보지 않아서
+     * 위의 `staleTime: Infinity`와 함께 둬도 스위치처럼 동작합니다.
+     *
+     * 이게 없으면 스트림이 조용히 죽었을 때 화면이 한 번 받아둔 집계에 영영 굳습니다. 게다가
+     * 멀쩡해 보여서 아무도 눈치채지 못합니다.
+     */
+    refetchInterval: isStreamBroken ? FALLBACK_INTERVAL_MS : false,
   });
 
   useEffect(() => {
@@ -90,19 +119,45 @@ export const useFeedbackSnapshot = ({
     const source = new EventSource(
       `${API_BASE_URL}/events/${eventCode}/feedbacks/stream?${query.toString()}`,
     );
-    source.addEventListener('open', () => {
-      setIsLive(true);
-      setIsStreamBroken(false);
-    });
 
-    source.addEventListener(SNAPSHOT_EVENT, (event: MessageEvent<string>) => {
-      const snapshot = parseSnapshot(event.data);
+    /*
+     * 첫 스냅샷을 기다리는 타이머입니다. 연결할 때마다 새로 걸고 스냅샷이 오면 지웁니다.
+     *
+     * 스냅샷마다 다시 걸지 않는 게 중요합니다. 다시 걸면 소감이 한동안 안 들어오는 조용한
+     * 구간을 고장으로 잘못 읽습니다. 서버가 밀어줄 게 없어서 조용한 것과 스트림이 죽어서
+     * 조용한 것은 다르고, 구분점은 "연결 직후 1건"이라는 명세의 보장입니다.
+     */
+    let watchdog: ReturnType<typeof setTimeout>;
+    const armWatchdog = () => {
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => {
+        setIsLive(false);
+        setIsStreamBroken(true);
+      }, STREAM_TIMEOUT_MS);
+    };
+
+    // 연결이 아예 안 뜨는 경우까지 덮으려고 여기서 한 번, 재연결마다 `open`에서 다시 겁니다.
+    armWatchdog();
+    source.addEventListener('open', armWatchdog);
+
+    /*
+     * `isLive`를 `open`이 아니라 첫 스냅샷에서 켭니다. 연결됐다는 것과 데이터가 흐른다는 것이
+     * 다르다는 게 이번 gzip 건의 교훈입니다(#261) — `open`으로 켜면 한 건도 못 받는 스트림을
+     * 두고 화면이 "실시간으로 갱신되고 있어요"라고 거짓말을 합니다.
+     */
+    source.addEventListener(SNAPSHOT_EVENT, (message: MessageEvent<string>) => {
+      const snapshot = parseSnapshot(message.data);
       if (snapshot === null) {
         setIsStreamBroken(true);
         return;
       }
+
+      clearTimeout(watchdog);
+      setIsLive(true);
+      setIsStreamBroken(false);
       queryClient.setQueryData(['feedbackSnapshot', eventCode, sessionId], snapshot);
     });
+
     /*
      * `error`는 두 상황에서 옵니다. 끊겨서 브라우저가 다시 붙는 중(`CONNECTING`)이면 잠깐
      * 실시간이 아닐 뿐 곧 돌아오므로 실패로 치지 않습니다. `CLOSED`는 다릅니다 — 응답이 200이
@@ -113,7 +168,9 @@ export const useFeedbackSnapshot = ({
       setIsLive(false);
       if (source.readyState === EventSource.CLOSED) setIsStreamBroken(true);
     };
+
     return () => {
+      clearTimeout(watchdog);
       source.close();
       setIsLive(false);
     };

--- a/mocks/browser.ts
+++ b/mocks/browser.ts
@@ -1,9 +1,14 @@
 import { setupWorker } from 'msw/browser';
+import { streamHandlers } from '@/mocks/handlers/stream';
 import { createHandlers } from './handlers';
 
 /**
  * Service Worker가 응답을 가로채는 환경이라 `httpOnly: true`로 두면 `accessToken`
  * 쿠키가 브라우저에 저장되지 않습니다(이슈 #128, `mocks/handlers/auth.ts`
  * `sessionCookies` 주석 참고). `httpOnly: false`로 이 제약을 우회합니다.
+ *
+ * SSE 핸들러는 `createHandlers`에 넣지 않고 여기서만 더합니다. `sse()`가 생성 시점에
+ * `EventSource` 전역을 요구해서, 같이 묶으면 `mocks/server.ts`(SSR 목·계약 테스트)가
+ * Node에서 모듈 로드 단계에 죽습니다(`mocks/handlers/stream.ts` 주석 참고).
  */
-export const worker = setupWorker(...createHandlers({ httpOnly: false }));
+export const worker = setupWorker(...createHandlers({ httpOnly: false }), ...streamHandlers);

--- a/mocks/handlers/stream.ts
+++ b/mocks/handlers/stream.ts
@@ -1,0 +1,87 @@
+import { sse } from 'msw';
+
+import type { FeedbackSnapshot, SessionView } from '@/lib/schemas/api';
+import {
+  buildSnapshot,
+  findEventByCode,
+  listSessionsOfEvent,
+  toSessionView,
+} from '@/mocks/data/store';
+import { API_BASE_URL, toNumericId } from '@/mocks/handlers/shared';
+
+/**
+ * SSE 스트림 목입니다. 계약 원본은 Notion API 명세서(2026-08-21 갱신본)입니다.
+ *
+ * ⚠️ 이 파일은 **브라우저에서만** 등록해야 합니다(`mocks/browser.ts`). `sse()`는 생성 시점에
+ * `EventSource` 전역을 요구하는데(msw `core/sse.mjs`의 invariant) Node에는 플래그 없이 그
+ * 전역이 없습니다. `mocks/handlers.ts`의 `createHandlers`에 넣으면 `mocks/server.ts`를 쓰는
+ * SSR 목과 `mocks/handlers.test.ts`가 SSE와 무관하게 모듈 로드 단계에서 통째로 죽습니다.
+ *
+ * 실제 서버는 소감 제출·모더레이션·세션 토글이 일어난 시점에 밀어줍니다. 목에는 그 변경을
+ * 알려줄 장치가 없어서(`mocks/data/store.ts`의 `db`가 그냥 배열입니다) 주기적으로 다시
+ * 만들어 보냅니다. 계약과 배선을 확인하는 데는 충분하지만, "변경 시점에 즉시 온다"까지
+ * 재현하지는 못합니다.
+ */
+
+/** 목이 스냅샷을 다시 밀어주는 간격입니다. */
+const PUSH_INTERVAL_MS = 2_000;
+
+/**
+ * 연결이 끊기면 타이머를 정리합니다. 안 걸어두면 탭을 옮기거나 세션을 바꿀 때마다 타이머가
+ * 쌓여서, 목이 죽은 커넥션에 계속 쓰다가 콘솔이 에러로 뒤덮입니다.
+ */
+const stopOnDisconnect = (request: Request, timer: ReturnType<typeof setInterval>): void => {
+  request.signal.addEventListener('abort', () => clearInterval(timer));
+};
+
+export const streamHandlers = [
+  /** 집계 스냅샷 구독. `data`는 `GET .../feedbacks`와 같은 `FeedbackSnapshot`입니다. */
+  sse<{ snapshot: FeedbackSnapshot }>(
+    `${API_BASE_URL}/events/:eventCode/feedbacks/stream`,
+    ({ client, params, request }) => {
+      const event = findEventByCode(String(params.eventCode));
+      if (!event) {
+        client.error();
+        return;
+      }
+
+      /*
+       * 폴링 핸들러와 달리 잘못된 `sessionId`를 에러로 돌려줄 방법이 없습니다. SSE는 이미 200으로
+       * 열린 스트림이라 상태 코드를 바꿀 수 없어서, 값이 이상하면 세션 필터 없이 이벤트 전체를
+       * 집계해 보냅니다.
+       */
+      const rawSessionId = new URL(request.url).searchParams.get('sessionId') ?? undefined;
+      const sessionId = toNumericId(rawSessionId) ?? undefined;
+
+      const push = () => {
+        client.send({ event: 'snapshot', data: buildSnapshot(event.id, sessionId) });
+      };
+
+      // 명세대로 연결 직후 현재 스냅샷을 1건 보냅니다.
+      push();
+      stopOnDisconnect(request, setInterval(push, PUSH_INTERVAL_MS));
+    },
+  ),
+
+  /** 세션 목록 구독. `data`는 `GET .../sessions`와 같은 `{ items }` 봉투입니다. */
+  sse<{ snapshot: { items: SessionView[] } }>(
+    `${API_BASE_URL}/events/:eventCode/sessions/stream`,
+    ({ client, params, request }) => {
+      const event = findEventByCode(String(params.eventCode));
+      if (!event) {
+        client.error();
+        return;
+      }
+
+      const push = () => {
+        client.send({
+          event: 'snapshot',
+          data: { items: listSessionsOfEvent(event.id).map(toSessionView) },
+        });
+      };
+
+      push();
+      stopOnDisconnect(request, setInterval(push, PUSH_INTERVAL_MS));
+    },
+  ),
+];


### PR DESCRIPTION
## 변경 사항

2026-08-21 API 명세 갱신으로 추가된 SSE 스트림 3종을 전부 붙이고, 대응하는 폴링을 걷어냈습니다.

| 스트림 | 훅 | 화면 |
| --- | --- | --- |
| `GET /events/{code}/feedbacks/stream` (공개) | `useFeedbackSnapshot` | 게스트 실시간 결과 |
| `GET /events/{code}/sessions/stream` (공개) | `useEventEntryFeed` | 게스트 진입 화면 |
| `GET /admin/feedbacks/stream` (소유자) | `useDashboardFeed` | 주최자 대시보드 |

세 훅 모두 같은 골격입니다.

- **갱신 방식을 훅 안에 가둡니다.** CLAUDE.md의 "폴링 → SSE 승급, 훅으로 격리" 원칙대로 화면은 `EventSource`도 간격도 모릅니다.
- **수신값을 계약 스키마로 다시 검증합니다.** `EventSource`는 `apiClient`를 거치지 않아 `endpoints.ts`의 응답 검증이 통째로 우회됩니다. 여기서 안 거르면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간 경로에서만 사라집니다.
- **연결이 아니라 흐름을 봅니다.** `open`이 아니라 첫 스냅샷 수신에서 `isLive`를 켭니다. 압축 계층에 막힌 스트림은 `open`까지 정상이고 본문만 안 오기 때문입니다(아래 트러블슈팅).
- **워치독 5초.** 연결 후 첫 스냅샷이 그 안에 안 오면 죽은 것으로 보고 예전 폴링을 폴백으로 되살립니다. 명세가 "연결 즉시 스냅샷 1건"을 보장해서 성립하는 판정입니다.
- **초기 조회 쿼리는 남깁니다.** 첫 스냅샷 전 화면을 채우고, 스트림이 죽었을 때의 폴백이 되고, 모더레이션 mutation의 캐시 무효화를 받습니다.

화면 계약은 `refreshIntervalMs: number | null` → `isLive: boolean`으로 바뀌었습니다. 밀어주는 방식에는 간격이라는 개념이 없어 "N초마다 갱신"을 그릴 수 없고, 붙었는지 끊겼는지가 대신 의미 있는 정보가 됐습니다.

폴링을 유지한 곳도 있습니다. **리포트**는 명세가 "실시간 push(SSE)는 도입하지 않고 폴링으로 확정"이라고 명시적으로 배제했고, **이벤트 상태**(`DRAFT`→`LIVE`→`ENDED`)는 명세에 스트림 자체가 없습니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| 694d431 | feat(feedback): 실시간 집계를 SSE 구독으로 바꾼다 | 공개 엔드포인트라 인증·재연결 복잡도가 없어서 스트림 배선 자체가 맞는지 먼저 확인. 반환 계약을 `refreshIntervalMs` → `isLive`로 바꾼 것도 여기서. |
| b8cb58e | feat(mocks): SSE 스트림 목 핸들러를 추가한다 | `msw` 2.15.0에 `sse()`가 이미 있어 새 의존성 없음. 실제 서버는 변경 시점에 밀어주지만 목에는 그 변경을 알려줄 장치가 없어(`db`가 그냥 배열) 2초마다 다시 만들어 보냄 — 계약·배선 확인용이고 "변경 즉시"까지는 재현 못 함. |
| be080ca | feat(feedback): 세션 목록을 SSE로 받고 실패 시 폴링으로 돌아간다 | 주최자가 세션을 열고 닫는 걸 게스트가 새로고침 없이 받게 함(#237의 원래 증상). `ENDED` 뒤에는 구독하지 않음 — 폴링을 멈추던 조건과 같고, 그 뒤 세션이 열려도 `canSubmit`이 `LIVE`를 요구해 화면이 안 바뀜. |
| 9210282 | feat(dashboard): 모더레이션 큐를 SSE 구독으로 바꾼다 | 스트림 3종 중 마지막이자 유일하게 인증이 붙는 것. 게스트 제출·주최자 숨기기/삭제가 주최자 대시보드에 즉시 반영됨. 토큰 만료 시 재연결 처리가 여기서만 추가로 필요(아래 트러블슈팅). |

## 관련 이슈

- Closes #261

## 검증 방법

**명령 (커밋 9210282 기준)**

```
npm run lint    0 errors, 1 warning
                (warning은 DashboardView.tsx:161 `items` useMemo 건으로, 이 PR에서 건드리지 않은 기존 경고)
npm run test    Test Files 5 passed (5) / Tests 139 passed (139)
npm run build   통과, 13개 라우트 생성
```

**수동 확인 (실제 백엔드 연동)**

로컬 백엔드(`pulse-backend` `test/sse-no-transform` 브랜치) + `NEXT_PUBLIC_API_MOCKING=disabled`로 띄워서 확인했습니다.

- 게스트 탭에서 소감 제출 → 주최자 대시보드 탭에 새로고침 없이 즉시 반영
- 게스트 실시간 결과 화면의 집계도 같은 제출에 함께 갱신 (백엔드가 게스트 집계 스트림과 주최자 큐 스트림에 같은 `feedbackChannel(eventCode)`를 쓰고, 구독자별 payload 함수만 다름)
- 주최자가 세션을 열고 닫으면 게스트 진입 화면 칩이 즉시 바뀜

**아직 실측하지 못한 경로**

- accessToken 1시간 만료 후의 재연결. 코드 경로는 아래 트러블슈팅대로 설계했지만 실제 만료를 기다려 확인하지는 못했습니다.
- Vercel 엣지에서의 SSE 동작. 로컬 Next dev·프로덕션 빌드까지만 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음 (`msw` 2.15.0의 `sse()`는 이미 설치돼 있던 기능)
- **로컬에서 추가로 해야 할 일: 있음.** 실제 백엔드에 붙여 SSE를 보려면 백엔드가 SSE 응답에 `Cache-Control: no-transform`을 붙이는 버전이어야 합니다. 현재는 `pulse-backend`의 `test/sse-no-transform` 브랜치에만 있습니다. 이게 없으면 스트림이 `open`까지만 되고 이벤트를 0건 받습니다. **목 모드(`npm run dev` 기본값)는 백엔드 없이 그대로 동작합니다.**
- **Breaking Change: 있음 (레포 내부 한정).** 훅 반환 계약과 컴포넌트 props가 바뀌었습니다. 이 PR 안에서 호출부를 모두 고쳤고 외부로 나가는 API는 아닙니다.
  - `useFeedbackSnapshot` / `useDashboardFeed`: `refreshIntervalMs: number | null` → `isLive: boolean`
  - `SentimentTrendCard`: prop `refreshIntervalMs` → `isLive`

## 트러블슈팅 및 참고 사항

**1. gzip이 SSE를 삼킵니다 (이번 작업에서 제일 오래 잡힌 것)**

Next가 `Accept-Encoding: gzip`을 보낸 클라이언트에게 `text/event-stream`을 gzip으로 압축하면, 압축기가 스트림을 물고 있어서 브라우저 `EventSource`가 **OPEN까지 정상이고 이벤트만 0건** 옵니다. 에러도 안 납니다. 백엔드가 SSE 응답에 `Cache-Control: no-transform`을 붙여 해결했습니다(백엔드 `test/sse-no-transform`).

`curl`은 기본적으로 압축을 요청하지 않아 이 증상이 안 보입니다. 검증은 반드시 `curl.exe --compressed` 또는 실제 브라우저 `EventSource`로 해야 합니다.

이 경험이 코드에 두 군데 남아 있습니다. `open`이 아니라 첫 스냅샷에서 `isLive`를 켜는 것, 그리고 `onerror`로는 못 잡는 실패를 시간으로 재는 워치독입니다.

**2. `sse()` 목 핸들러는 브라우저에서만 등록해야 합니다**

`msw`의 `sse()`는 **생성 시점에** `EventSource` 전역을 요구하는데(`core/sse.mjs`의 invariant) Node에는 플래그 없이 그 전역이 없습니다. `createHandlers`에 넣으면 `mocks/server.ts`를 쓰는 SSR 목과 `mocks/handlers.test.ts`가 SSE와 무관하게 **모듈 로드 단계에서** 통째로 죽습니다. 그래서 `mocks/browser.ts`에서만 더합니다.

**3. `/admin/feedbacks/stream`의 인증**

자격증명은 다른 요청과 같은 `accessToken` 쿠키입니다. `API_BASE_URL`이 `/api/proxy`라 동일 출처 요청이 되어 브라우저가 알아서 싣습니다. `EventSource`는 헤더를 못 달아서, 쿠키 인증이 아니었으면 아예 불가능했을 자리입니다. `withCredentials: true`는 `NEXT_PUBLIC_API_BASE_URL`을 백엔드 절대주소로 바꾸는 경우를 위한 보험입니다(그때는 백엔드 CORS에 `Access-Control-Allow-Credentials`도 필요).

CSRF는 해당 없습니다. GET이라 `apiClient`도 `X-XSRF-TOKEN`을 붙이지 않습니다.

**4. 토큰 만료 시 재연결 — `apiClient`를 건드리지 않은 이유 (리뷰 포인트)**

`EventSource`는 `apiClient`의 401 인터셉터(#257)를 우회합니다. accessToken은 1시간이고 SSE 연결은 그보다 오래 삽니다. 그대로 두면 만료 한 번에 스트림이 `CLOSED`로 죽고, 폴백 폴링이 켜지고, **그 폴링이 `apiClient`를 타서 쿠키는 되살아나는데 effect의 deps가 그대로라 스트림만 영영 안 열립니다.** 쿠키도 화면도 멀쩡해서 눈치채기 어려운 퇴화입니다.

처음에는 `refreshOnce`를 export해서 훅에서 직접 재발급하려고 했다가 되돌렸습니다. `apiClient`는 **401을 받았을 때만** 재발급하는데 훅은 **`CLOSED`가 되면** 부르게 되고, `CLOSED`의 원인은 401만이 아니기 때문입니다(403 `NOT_OWNER`, 404, 서버 재시작, gzip 차단 — `EventSource`는 상태 코드를 안 알려줘서 훅이 구분할 수 없습니다). 그러면 401이 아닌데도 `/auth/refresh`가 나가고, "언제 재발급하는가"라는 규칙이 두 파일로 갈라집니다.

최종안은 재발급을 아예 하지 않고 **"끊긴 뒤에 성공한 폴백 조회"를 재연결 방아쇠로 삼습니다.** 폴백 폴링은 `apiClient`를 타므로 401이면 #257 인터셉터가 제 자리에서 제 조건으로 재발급과 재시도까지 끝냅니다. 즉 폴백이 성공했다는 사실 자체가 "인증이 필요했다면 이미 되살아났다"는 신호입니다. 결과적으로 `lib/apiClient.ts` diff는 0입니다.

재연결은 스냅샷을 받기 전까지 한 번으로 제한합니다. 압축 계층 차단처럼 인증과 무관한 고장에서는 폴백 조회가 계속 성공하는데 스트림만 계속 죽어서, 빗장이 없으면 "열림 → 워치독 → 폴백 성공 → 다시 열림"이 영원히 돕니다.

**5. `/admin/feedbacks/stream` 목 핸들러는 넣지 않았습니다**

`sse()` 리졸버는 **반환값이 무시됩니다** — `ServerSentEventHandler`가 리졸버를 await한 뒤 무조건 200 `text/event-stream`을 돌려줍니다. 그래서 리졸버 안에서 401을 만들 수 없고, `client.error()`는 연결 중단(→ 브라우저가 `CONNECTING`으로 재연결)이라 실제 401(`CLOSED`, 재연결 포기)과 동작이 반대입니다. 제대로 하려면 같은 경로에 `http.get` 가드를 앞에 두고 미인증이면 401, 아니면 `undefined`를 반환해 `sse()`로 흘려보내야 합니다(`executeHandlers`가 응답 없는 핸들러는 건너뜁니다).

이번에는 실제 백엔드로 검증하는 쪽을 택해서 보류했습니다. **목 모드 대시보드는 스트림이 안 뜨면 폴백 폴링으로 돌기 때문에 전환 전과 똑같이 동작합니다**(콘솔에 MSW unhandled request 경고 1건). 별도 이슈로 올리는 게 맞다고 보면 알려주세요.

**6. 세션 필터와 채널 입도**

백엔드 broadcast 채널은 이벤트 단위(`feedbackChannel(eventCode)`)입니다. 대시보드가 1부를 보고 있는데 2부에 소감이 들어와도 push가 옵니다. 다만 payload는 구독 시 넘긴 `sessionId`로 재계산되니 내용은 그대로고 리렌더만 한 번 헛돕니다. 실질 문제는 아니라 두었습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
