### PR TITLE
feat(game): 소감 화면에 게임 참가 배너를 띄운다

### DIFF
--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -1,6 +1,11 @@
 import { notFound } from 'next/navigation';
 
-import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import {
+  fetchCurrentGame,
+  fetchEventByCode,
+  fetchPublicReport,
+  fetchSessionsByEventCode,
+} from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import { EventEntryView } from '@/components/feedback/EventEntryView';
 
@@ -13,7 +18,7 @@ interface EventEntryPageProps {
  * 첫 데이터만 서버에서 받아 `EventEntryView`에 넘깁니다. 화면 분기는 그쪽이 폴링 결과로 다시
  * 계산합니다(#237).
  *
- * fetch를 서버에 남겨두는 이유는 SSR HTML에 완성된 첫 화면을 실어 보내기 위해서입니다. 셋 다
+ * fetch를 서버에 남겨두는 이유는 SSR HTML에 완성된 첫 화면을 실어 보내기 위해서입니다. 전부
  * 클라이언트로 내리면 게스트가 빈 화면을 먼저 받고 나서 요청 세 개를 새로 쏘게 됩니다.
  */
 const EventEntryPage = async ({ params }: EventEntryPageProps) => {
@@ -22,9 +27,13 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
   // 서버에서 부릅니다. 두 요청이 서로를 안 기다리도록 병렬로 보냅니다.
   // DRAFT·ENDED에서는 sessions를 쓸 일이 없지만, 상태를 먼저 받고 결정하면
   // 가장 흔한 LIVE 경로가 왕복 하나만큼 느려집니다. 안 쓰는 응답 하나가 낫습니다.
-  const [event, sessions] = await Promise.all([
+
+  // 게임은 열린 게 없으면 `fetchCurrentGame`이 404를 null로 삼켜서 옵니다. 여기 없으면
+  // 첫 화면에 배너가 빠졌다가 폴링 한 박자 뒤에 나타나 화면이 밀립니다.
+  const [event, sessions, currentGame] = await Promise.all([
     fetchEventByCode(code),
     fetchSessionsByEventCode(code),
+    fetchCurrentGame(code),
   ]).catch((error: unknown) => {
     if (error instanceof ApiError && error.code === 'EVENT_NOT_FOUND') notFound();
     throw error;
@@ -49,6 +58,7 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
       initialEvent={event}
       initialSessions={sessions}
       initialHasReport={hasReport}
+      initialCurrentGame={currentGame}
     />
   );
 };

--- a/components/feedback/EventEntryView.tsx
+++ b/components/feedback/EventEntryView.tsx
@@ -3,10 +3,11 @@
 import Link from 'next/link';
 
 import { FeedbackForm } from '@/components/feedback/FeedbackForm';
+import { GameBanner } from '../game/GameBanner';
 import { buttonStyle } from '@/components/ui/Button';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { useEventEntryFeed } from '@/hooks/useEventEntryFeed';
-import type { EventView, SessionView } from '@/lib/schemas/api';
+import type { EventView, GameView, SessionView } from '@/lib/schemas/api';
 
 /**
  * 게스트 진입 화면의 클라이언트 경계입니다.
@@ -25,6 +26,7 @@ interface EventEntryViewProps {
   initialEvent: EventView;
   initialSessions: SessionView[];
   initialHasReport: boolean;
+  initialCurrentGame: GameView | null;
 }
 
 const EventEntryView = ({
@@ -32,12 +34,14 @@ const EventEntryView = ({
   initialEvent,
   initialSessions,
   initialHasReport,
+  initialCurrentGame,
 }: EventEntryViewProps) => {
-  const { event, sessions, canSubmit, isEnded, hasReport } = useEventEntryFeed({
+  const { event, sessions, canSubmit, isEnded, hasReport, currentGame } = useEventEntryFeed({
     eventCode,
     initialEvent,
     initialSessions,
     initialHasReport,
+    initialCurrentGame,
   });
 
   return (
@@ -51,6 +55,12 @@ const EventEntryView = ({
           </p>
         ) : null}
       </section>
+
+      {/*
+        분기 밖에 둡니다. 아이스브레이킹은 행사 시작 직전이라 그때 이벤트가 `DRAFT`일 수 있는데,
+        `canSubmit`이 `LIVE`를 요구해서 안쪽에 넣으면 정작 필요한 순간에 안 뜹니다.
+      */}
+      {currentGame ? <GameBanner eventCode={eventCode} game={currentGame} /> : null}
 
       {canSubmit ? (
         <FeedbackForm eventCode={eventCode} sessions={sessions} />

--- a/components/game/GameBanner.tsx
+++ b/components/game/GameBanner.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+import { gameBannerMessage, isVisibleGame } from './gameBannerMessage';
+import { Banner } from '@/components/ui/Banner';
+import { ChevronRightIcon } from '@/components/ui/icons';
+import { GameView } from '@/lib/schemas/api';
+
+/**
+ * 소감 화면에서 게임으로 넘어가는 유일한 길입니다(#243).
+ *
+ * 배너 전체를 `Link`로 감쌉니다. 오른쪽 끝에 작은 버튼을 두는 것보다 터치 영역이 커서
+ * 모바일에서 낫고, `Banner`에 액션 슬롯을 새로 뚫지 않아도 됩니다.
+ *
+ * 닫기 버튼은 없습니다(#259). 닫으면 되돌릴 방법이 없는데 얻는 게 「한 줄 치우기」라
+ * 남는 장사가 아니라고 봤습니다. `info`는 원래 상시형입니다(`components/ui/README.md`).
+ */
+
+interface GameBannerProps {
+  eventCode: string;
+  game: GameView;
+}
+
+const GameBanner = ({ eventCode, game }: GameBannerProps) => {
+  if (!isVisibleGame(game)) return null;
+
+  return (
+    <Link href={`/e/${eventCode}/game`} className="block">
+      <Banner type="info" className="w-full">
+        <span className="min-w-0 flex-1">{gameBannerMessage(game)}</span>
+        <ChevronRightIcon className="shrink-0" />
+      </Banner>
+    </Link>
+  );
+};
+
+export { GameBanner };

--- a/components/game/gameBannerMessage.test.ts
+++ b/components/game/gameBannerMessage.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { gameBannerMessage, isVisibleGame, type VisibleGame } from './gameBannerMessage';
+import type { GameView } from '@/lib/schemas/api';
+
+const build = (overrides: Partial<GameView>): GameView => ({
+  id: 1,
+  title: '시작 전 몸 풀기',
+  gameType: 'PINBALL',
+  status: 'OPEN',
+  participantCount: 0,
+  participants: [],
+  results: null,
+  createdAt: '2026-08-05T04:00:00.000Z',
+  ...overrides,
+});
+
+describe('isVisibleGame', () => {
+  /*
+   * 서버가 `current`에서 DRAFT를 빼주지만 화면이 그걸 믿고만 있으면, 실제 서버가 빠뜨렸을 때
+   * "참가하기"가 뜨고 눌러보면 GAME_NOT_OPEN이 납니다.
+   */
+  it('DRAFT는 걸러낸다', () => {
+    expect(isVisibleGame(build({ status: 'DRAFT' }))).toBe(false);
+    expect(isVisibleGame(build({ status: 'OPEN' }))).toBe(true);
+  });
+});
+
+describe('gameBannerMessage', () => {
+  it('모집 중이면 인원을 같이 보여준다', () => {
+    const game = build({ status: 'OPEN', participantCount: 47 }) as VisibleGame;
+
+    expect(gameBannerMessage(game)).toBe('지금 게임이 열렸어요 · 47명 참가 중');
+  });
+
+  it('진행 중이면 참가가 마감됐다고 알린다', () => {
+    const game = build({ status: 'RUNNING' }) as VisibleGame;
+
+    expect(gameBannerMessage(game)).toBe('레이스 진행 중이에요 · 참가는 마감됐어요');
+  });
+
+  it('끝났으면 1등을 보여준다', () => {
+    const game = build({
+      status: 'FINISHED',
+      results: [{ rank: 1, participantId: 5, nickname: '커피' }],
+    }) as VisibleGame;
+
+    expect(gameBannerMessage(game)).toBe('결과가 나왔어요 · 1등 커피');
+  });
+
+  /*
+   * 계약상 FINISHED면 results가 채워집니다. 다만 그 검사는 목에만 있어서 실제 서버가
+   * 빠뜨릴 수 있고, 그때 배너가 통째로 터지면 안 됩니다.
+   */
+  it('끝났는데 결과가 비어있지도 터지지 않는다', () => {
+    expect(gameBannerMessage(build({ status: 'FINISHED', results: null }) as VisibleGame)).toBe(
+      '결과가 나왔어요',
+    );
+    expect(gameBannerMessage(build({ status: 'FINISHED', results: [] }) as VisibleGame)).toBe(
+      '결과가 나왔어요',
+    );
+  });
+});

--- a/components/game/gameBannerMessage.ts
+++ b/components/game/gameBannerMessage.ts
@@ -1,0 +1,31 @@
+import type { GameStatus, GameView } from '@/lib/schemas/api';
+
+/**
+ * 배너 문구를 만드는 순수 함수입니다. 컴포넌트에서 뺀 이유는 테스트하기 위해서입니다 —
+ * `vitest.config`가 `environment: 'node'`라 렌더링 테스트를 못 씁니다
+ * (`components/dashboard/metrics.ts`와 같은 방식).
+ */
+
+/**
+ * `DRAFT`는 서버가 `games/current`에서 이미 빼므로 화면에 닿지 않습니다. 타입에서도 빼서
+ * 아래 분기가 도달할 수 없는 경우를 다루지 않게 합니다(`eventStatusBadge`와 같은 방식).
+ */
+type VisibleGameStatus = Exclude<GameStatus, 'DRAFT'>;
+
+type VisibleGame = GameView & { status: VisibleGameStatus };
+
+const isVisibleGame = (game: GameView): game is VisibleGame => game.status !== 'DRAFT';
+
+const gameBannerMessage = (game: VisibleGame): string => {
+  if (game.status === 'OPEN') return `지금 게임이 열렸어요 · ${game.participantCount}명 참가 중`;
+  if (game.status === 'RUNNING') return '레이스 진행 중이에요 · 참가는 마감됐어요';
+
+  /*
+   * 계약상 `FINISHED`면 `results`가 채워지지만, 목이 아니라 실제 서버가 빠뜨리면 여기서
+   * 터집니다. 1등 이름은 거들 뿐이라 없으면 문구만 바꿉니다.
+   */
+  const winner = game.results?.[0]?.nickname;
+  return winner ? `결과가 나왔어요 · 1등 ${winner}` : '결과가 나왔어요';
+};
+
+export { gameBannerMessage, isVisibleGame, type VisibleGame };

--- a/hooks/useEventEntryFeed.ts
+++ b/hooks/useEventEntryFeed.ts
@@ -2,28 +2,36 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import { 
+  fetchCurrentGame,
+  fetchEventByCode,
+  fetchPublicReport,
+  fetchSessionsByEventCode
+} from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import {
   isClientError,
   listResponseSchema,
   sessionViewSchema,
   type EventView,
+  type GameView,
   type SessionView,
 } from '@/lib/schemas/api';
 import { useEffect, useState } from 'react';
 import { API_BASE_URL } from '@/lib/env';
 
 /**
- * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트입니다.
+ * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트·게임입니다.
  *
- * 셋을 한 훅에 두는 이유는 서로 배타적으로 켜졌다 꺼지는 하나의 상태 머신이기 때문입니다.
+ * 넷을 한 훅에 두는 이유는 서로 배타적으로 켜졌다 꺼지는 하나의 상태 머신이기 때문입니다.
  * 이벤트가 `ENDED`를 잡는 순간 세션 구독을 끊고 리포트 폴링을 켜는 그 조율이 이 훅의 알맹이라,
  * 나눠두면 조율이 화면으로 흘러나갑니다(`useEventReport`가 조회·생성·공개를 묶은 것과 같은 이유).
  *
  * 갱신 수단이 둘로 갈립니다. 세션만 SSE(`.../sessions/stream`)로 받고, 이벤트 상태와 리포트는
  * 폴링입니다. 명세에 스트림이 셋뿐이라 이벤트 상태에는 아예 없고, 리포트는 "실시간 push(SSE)는
  * 도입하지 않고 폴링으로 확정"이라고 명시적으로 배제됐습니다(2026-08-21).
+ * 
+ * 게임도 폴링입니다. 명세의 스트림 3종에 게임이 없어서 이벤트 상태와 같은 처지입니다.
  *
  * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을 아는
  * 코드는 이 파일에만 둡니다. 화면은 `EventSource`도 폴링 간격도 모릅니다.
@@ -124,6 +132,8 @@ interface UseEventEntryFeedParams {
   initialEvent: EventView;
   initialSessions: SessionView[];
   initialHasReport: boolean;
+  /** 열린 게임이 없으면 `null`입니다. 404가 정상 상태라 에러가 아닙니다. */
+  initialCurrentGame: GameView | null;
 }
 
 interface UseEventEntryFeedResult {
@@ -134,6 +144,8 @@ interface UseEventEntryFeedResult {
   isEnded: boolean;
   /** 공개된 리포트가 있는지입니다. `ENDED`가 아니면 항상 `false`입니다. */
   hasReport: boolean;
+  /** 지금 열린 게임입니다. 없거나 행사가 끝났으면 `null`입니다. */
+  currentGame: GameView | null;
 }
 
 const useEventEntryFeed = ({
@@ -141,6 +153,7 @@ const useEventEntryFeed = ({
   initialEvent,
   initialSessions,
   initialHasReport,
+  initialCurrentGame,
 }: UseEventEntryFeedParams): UseEventEntryFeedResult => {
   const queryClient = useQueryClient();
   /** 세션 스트림이 죽었는지입니다. 참이면 아래 쿼리가 폴링으로 되돌아갑니다. */
@@ -243,6 +256,28 @@ const useEventEntryFeed = ({
     };
   }, [eventCode, isEnded, queryClient]);
 
+  /*
+   * 소감 화면 배너가 쓰는 "지금 열린 게임"입니다(#243).
+   *
+   * 세션과 달리 스트림이 없습니다. 명세의 실시간 3종에 게임이 안 들어가 있어서, 이벤트
+   * 상태와 같이 폴링으로 남습니다. 간격을 맞춘 것도 그래서입니다 — 둘 다 "주최자가
+   * 스위치를 눌렀나"를 묻는 질문이고 반응 속도 요구가 같습니다.
+   *
+   * `isEnded`에서 멈추는 이유도 이벤트 상태와 같습니다. 행사가 끝나면 게임이 새로 열릴
+   * 일이 없습니다.
+   *
+   * 열린 게임이 없을 때는 `fetchCurrentGame`이 404를 `null`로 삼켜서 옵니다. 그대로
+   * 던지면 `isPermanentFailure`가 4xx로 보고 폴링을 멈춰서, 주최자가 나중에 열어도
+   * 화면이 모릅니다.
+   */
+  const gameQuery = useQuery({
+    queryKey: ['currentGame', eventCode],
+    queryFn: () => fetchCurrentGame(eventCode),
+    initialData: initialCurrentGame,
+    refetchInterval: ({ state }) =>
+      isEnded || isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS,
+  });
+
   const reportQuery = useQuery({
     queryKey: ['publicReportExists', eventCode],
     queryFn: () => fetchReportExists(eventCode),
@@ -286,6 +321,11 @@ const useEventEntryFeed = ({
     canSubmit: event.status === 'LIVE' && sessionsQuery.data.length > 0,
     isEnded,
     hasReport: isEnded && reportQuery.data === true,
+    /*
+     * `isEnded`면 폴링만 멈추는 게 아니라 값도 지웁니다. 멈추기만 하면 주최자가 결과를 안
+     * 올린 채 종료했을 때 배너가 「레이스 진행 중」에 굳습니다.
+     */
+    currentGame: isEnded ? null : gameQuery.data,
   };
 };
 

--- a/lib/api/endpoints.test.ts
+++ b/lib/api/endpoints.test.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import {
+  fetchCurrentGame,
   fetchEventByCode,
   fetchMyEvents,
   fetchOwnReport,
@@ -22,6 +23,7 @@ import { server } from '@/mocks/server';
  * 프로덕션에서 로그만 남기고 raw payload를 캐스팅해 반환하던 분기의 회귀 방지용입니다.
  */
 
+const DRAFT_EVENT_CODE = 'zq1v8t';
 const EVENT_CODE = 'ab3f9x';
 const ENDED_EVENT_CODE = 'kd7m2p';
 const SEED_CREDENTIALS = { email: 'host@example.com', password: 'pulse1234' };
@@ -115,5 +117,29 @@ describe('인증 쿠키', () => {
     });
 
     await logout();
+  });
+});
+
+describe('fetchCurrentGame', () => {
+  it('열린 게임이 있으면 계약대로 받는다', async () => {
+    const game = await fetchCurrentGame(EVENT_CODE);
+
+    expect(game?.status).toBe('OPEN');
+  });
+
+  /*
+   * "열린 게임 없음"은 실패가 아니라 정상 상태입니다. 에러로 두면 useEventEntryFeed의
+   * isPermanentFailure가 4xx로 보고 폴링을 멈춰서, 주최자가 나중에 열어도 화면이 모릅니다.
+   */
+  it('열린 게임이 없으면 null을 준다', async () => {
+    await expect(fetchCurrentGame(DRAFT_EVENT_CODE)).resolves.toBeNull();
+  });
+
+  /*
+   * 상태 코드가 아니라 에러 코드로 갈라야 합니다. 없는 이벤트도 404지만 이건 진짜 실패라
+   * 삼키면 안 됩니다 — 배너만 조용히 안 뜨고 원인을 알 수 없게 됩니다.
+   */
+  it('없는 이벤트의 404는 삼키지 않는다', async () => {
+    await expect(fetchCurrentGame('nope00')).rejects.toMatchObject({ code: 'EVENT_NOT_FOUND' });
   });
 });

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -9,6 +9,7 @@ import type {
   FeedbackSnapshot,
   FeedbackSubmitRequest,
   FeedbackView,
+  GameView,
   LoginRequest,
   PublicReport,
   PulseEvent,
@@ -26,6 +27,7 @@ import {
   feedbackSchema,
   feedbackSnapshotSchema,
   feedbackViewSchema,
+  gameViewSchema,
   listResponseSchema,
   publicReportSchema,
   pulseEventSchema,
@@ -303,4 +305,28 @@ export const setReportPublic = async (eventCode: string, isPublic: boolean): Pro
     body: JSON.stringify({ isPublic }),
   });
   return parseResponse(reportSchema, data, 'PATCH /events/{eventCode}/report');
+};
+
+/**
+ * 참가자 화면 배너가 쓰는 "지금 열린 게임"입니다(#243).
+ *
+ * `skipAuth`를 씁니다. 공개 경로라 인증이 필요 없고, 주최자가 자기 폰으로 참가자 화면을
+ * 열어도 같은 응답을 받아야 합니다.
+ */
+export const fetchCurrentGame = async (eventCode: string): Promise<GameView | null> => {
+  try {
+    const data = await apiClient<unknown>(`/events/${eventCode}/games/current`, { skipAuth: true });
+    return parseResponse(gameViewSchema, data, 'GET /events/{eventCode}/games/current');
+  } catch (error) {
+    /*
+     * 열린 게임이 없으면 서버가 GAME_NOT_FOUND(404)를 줍니다. 이 화면에서 그건 실패가
+     * 아니라 "아직 안 열렸다"는 정상 상태입니다.
+     *
+     * 에러로 남기면 useEventEntryFeed의 isPermanentFailure가 4xx로 보고 폴링을 멈춰서,
+     * 주최자가 나중에 게임을 열어도 화면이 영영 모릅니다. 리포트 쪽 fetchReportExists가
+     * 같은 이유로 404를 삼킵니다.
+     */
+    if (error instanceof ApiError && error.code === 'GAME_NOT_FOUND') return null;
+    throw error;
+  }
 };


### PR DESCRIPTION
> ⚠️ **머지해도 바로 배포하지 말아주세요.**
> 배너가 `/e/{code}/game`으로 보내는데 그 화면이 아직 없습니다. 게임 화면 PR까지 머지된 뒤에 함께 배포합니다.

## 변경 사항

참가자가 게임으로 갈 길을 만듭니다. 소감 화면(`/e/[code]`) 본문에 배너를 띄우고, 누르면 게임 화면으로 갑니다.

```
🎲 지금 게임이 열렸어요 · 47명 참가 중                    →
```

**게임 화면 자체는 이 PR에 없습니다.** 여기서 만드는 `games/current` 폴링을 게임 화면과 프로젝터 화면이 그대로 쓰기 때문에 순서상 먼저입니다.

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `036fda1` | `fetchCurrentGame` + `useEventEntryFeed`에 게임 쿼리 |
| `2ab2157` | `GameBanner` + 문구 모듈 + 화면 연결 |

SSE 전환(#263)이 `useEventEntryFeed.ts`를 크게 고쳐서 `dev` 위로 rebase했습니다. 충돌 해결은 팀원 버전을 통째로 받고 게임 쿼리만 다시 얹는 방식으로 했습니다.

## 왜 QR을 게임으로 직접 보내지 않나

게임 화면으로 바로 보내면 **게임만 하고 나갑니다.** 소감 화면을 한 번은 보게 하는 게 이 기능의 목적입니다(#243).

QR 주소도 안 바뀝니다. 인쇄된 게 이미 있으면 그대로 씁니다.

## `canSubmit` 분기 밖에 둡니다

```tsx
</section>

{currentGame ? <GameBanner eventCode={eventCode} game={currentGame} /> : null}

{canSubmit ? (
```

아이스브레이킹은 **행사 시작 직전**이라 그때 이벤트가 `DRAFT`일 수 있습니다. `canSubmit`이 `LIVE`를 요구해서 안쪽에 넣으면 정작 필요한 순간에 배너가 안 뜹니다.

## ⚠️ 404가 정상 상태입니다

`GET .../games/current`는 열린 게임이 없을 때 `GAME_NOT_FOUND`(404)를 줍니다. **이 화면에서 그건 실패가 아닙니다.**

그런데 훅의 폴링 정지 조건이 4xx를 영구 실패로 봅니다.

```ts
const isPermanentFailure = (error: Error | null): boolean =>
  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
```

404를 그대로 던지면 **게임이 없는 동안 폴링이 멈추고, 주최자가 나중에 열어도 화면이 영영 모릅니다.** 같은 파일의 `fetchReportExists`가 정확히 같은 이유로 404를 삼키고 있어 그 모양을 따랐습니다.

**상태 코드가 아니라 에러 코드로 가릅니다.** 없는 이벤트도 404지만 이건 진짜 실패라 삼키면 안 됩니다 — 배너만 조용히 안 뜨고 원인을 알 수 없게 됩니다.

```ts
it('없는 이벤트의 404는 삼키지 않는다', async () => {
  await expect(fetchCurrentGame('nope00')).rejects.toMatchObject({ code: 'EVENT_NOT_FOUND' });
});
```

## 훅에 넣은 이유

`useEventEntryFeed`가 이미 이벤트·세션·리포트를 한 훅에서 다룹니다.

- **이벤트 상태 폴링과 같은 5초 리듬**에 얹히므로 요청이 두 박자로 겹치지 않습니다
- SSR 초기값(`initialData`)을 받는 구조가 이미 있어서 **첫 화면에 배너가 바로 뜹니다.** 없으면 폴링 한 박자 뒤에 나타나 화면이 밀립니다
- `CLAUDE.md`의 "폴링 → SSE 승급, 훅으로 격리" 원칙대로 갱신 방식을 아는 코드가 한 파일에 남습니다

파일 상단 주석의 「셋」을 「넷」으로 고쳤습니다.

### 게임에는 스트림이 없습니다

`dev`에 SSE 전환(#263)이 들어오면서 세션은 `.../sessions/stream`으로 바뀌었습니다. **게임은 폴링으로 남습니다** — 명세의 실시간 3종(소감·집계·세션)에 게임이 안 들어가 있어서, 이벤트 상태와 같은 처지입니다.

간격을 이벤트 상태와 맞춘 것도 그래서입니다. 둘 다 「주최자가 스위치를 눌렀나」를 묻는 질문이고 반응 속도 요구가 같습니다.

나중에 게임 스트림이 명세에 들어오면 이 쿼리만 갈아 끼우면 됩니다. `queryKey`와 반환 모양은 그대로 두고요.

## `isEnded`면 폴링도 멈추고 값도 지웁니다

세션 쿼리가 `ENDED`에서 멈추는 것과 같은 기준입니다 — 행사가 끝나면 게임이 새로 열릴 일이 없습니다.

**멈추기만 하고 마지막 값을 남기면** 주최자가 결과를 안 올린 채 종료했을 때 배너가 「레이스 진행 중」에 굳습니다.

## 닫기 버튼은 없습니다

`info` 톤 그대로 상시형입니다. 닫으면 `sessionStorage`에 박혀 **되돌릴 방법이 없는데** 얻는 게 「한 줄 치우기」라 남는 장사가 아니라고 봤습니다(#259에서 논의하고 닫음).

덕분에 `Banner` 컴포넌트를 **안 건드립니다.** 배너 전체를 `Link`로 감싸므로 터치 영역이 배너 전체가 되어 모바일에서 오히려 낫습니다.

## 문구를 순수 모듈로 뺐습니다

`vitest.config`가 `environment: 'node'`라 렌더링 테스트를 못 씁니다. 문구 만드는 로직을 `gameBannerMessage.ts`로 빼서 값을 직접 검사합니다(`components/dashboard/metrics.ts`와 같은 방식).

`vitest` 환경을 바꾸는 건 이 PR 범위 밖이라 안 했습니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관, #256에서 들어옴)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 6 files, 147 tests passed
```

테스트 8개가 늘었습니다(139 → 147).

| 테스트 | 확인하는 것 |
|---|---|
| `fetchCurrentGame` 3건 | 정상 응답 · 404 → `null` · 없는 이벤트 404는 던짐 |
| `isVisibleGame` 1건 | `DRAFT` 걸러냄 |
| `gameBannerMessage` 4건 | 상태별 문구 · `results`가 비어도 안 터짐 |

`npm run dev`로 `/e/ab3f9x`를 띄워 배너가 뜨는 것, `max-w-md` 열에 맞는 것, 화살표가 오른쪽 끝에 붙는 것까지 눈으로 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **게스트 화면에 요청이 하나 늘어납니다.** 이벤트 상태 폴링과 같은 5초 간격이라 새 리듬은 아닙니다
- `useEventEntryFeed`와 `EventEntryView`에 필수 prop이 하나씩 늘었습니다(`initialCurrentGame`). 둘 다 이 PR 안에서만 쓰입니다

## 트러블슈팅 및 참고 사항

`Banner`가 `inline-flex`라 `w-full`을 안 주면 화살표가 텍스트에 달라붙습니다. 쓰는 쪽이 매번 `w-full`을 붙이는 게 지금 이 컴포넌트의 관례라(`FeedbackForm`·`EventForm`·`QrCodeDialog`) 그대로 따랐습니다. 정리할 만하지만 다섯 파일을 건드리는 별개 변경입니다.

## 관련 이슈

- Closes #260
- Refs #243

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
