### PR TITLE
feat(auth): 이미 인증된 상태에서 로그인·회원가입 화면 접근 시 이벤트 목록으로 보낸다

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { Field } from '@/components/ui/Field';
 import { Button } from '@/components/ui/Button';
 import { useAuth } from '@/hooks/useAuth';
 import { ApiError } from '@/lib/apiClient';
+import useRedirectIfAuthenticated from '@/hooks/useRedirectIfAuthenticated';
 
 type LoginInputs = {
   email: string;
@@ -30,6 +31,7 @@ const LoginForm = () => {
 
   const router = useRouter();
   const { login } = useAuth();
+  useRedirectIfAuthenticated();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     setLoginInputs((prev) => ({

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { passwordSchema, signupRequestSchema } from '@/lib/schemas/api';
 import { useAuth } from '@/hooks/useAuth';
 import { ApiError } from '@/lib/apiClient';
+import useRedirectIfAuthenticated from '@/hooks/useRedirectIfAuthenticated';
 
 type SignupInputs = {
   email: string;
@@ -57,6 +58,7 @@ const SignupForm = () => {
 
   const router = useRouter();
   const { signup } = useAuth();
+  useRedirectIfAuthenticated();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;

--- a/hooks/useRedirectIfAuthenticated.ts
+++ b/hooks/useRedirectIfAuthenticated.ts
@@ -1,0 +1,18 @@
+'use client';
+
+import useAuth from '@/hooks/useAuth';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+
+const useRedirectIfAuthenticated = () => {
+  const { isAuthenticated } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      router.push('/events');
+    }
+  }, [isAuthenticated, router]);
+};
+
+export default useRedirectIfAuthenticated;


### PR DESCRIPTION
## 변경 사항

**이미 인증된 상태에서 `/login`·`/signup`에 들어와도 자동으로 `/events`로 이동하도록 고쳤습니다.**  
이렇게 바꾼 이유는 세션이 refresh로 조용히 복구되거나 이미 로그인된 채 화면에 들어와도 로그인·회원가입 폼이 그대로 남아있었기 때문입니다.  
이 문제는 이슈 #247(PR #257) 검증 중 발견했습니다.

- **`hooks/useRedirectIfAuthenticated.ts`** — 로그인 여부(`isAuthenticated`)가 `false`에서 `true`로 바뀌는 순간을 감지해서 `/events`로 이동시키는 훅입니다. 새로 만든 공통 훅이라 `LoginForm.tsx`·`SignupForm.tsx` 양쪽에서 그대로 재사용합니다.
- **`components/auth/LoginForm.tsx`** 는 로그인 폼을 그리고 제출을 처리하는 컴포넌트입니다.
  - AS-IS: 지금은 로그인에 성공했을 때(`handleSubmit` 안)만 `/events`로 이동시키고 있습니다.
  - TO-BE: 화면에 들어오는 시점에 이미 로그인돼 있어도(새로고침, refresh로 세션이 막 복구된 경우 등) 위 훅을 호출해서 자동으로 이동합니다.
- `components/auth/SignupForm.tsx`는 회원가입 폼을 그리고 제출을 처리하는 컴포넌트입니다. `LoginForm.tsx`와 같은 이유로 같은 훅을 호출합니다.

## 관련 이슈

- Closes #262

## 검증 방법

- `npx tsc --noEmit` 통과했습니다.
- `npx eslint`(커밋 시 lint-staged로도 재확인) 통과했습니다.
- `npm run dev`로 아래 시나리오를 직접 확인했습니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- **로그인된 상태로 `/login`에 직접 접근하면** 로그인 폼이 보이지 않고 바로 `/events`로 이동합니다.
- **로그인된 상태로 `/signup`에 직접 접근하면** 회원가입 폼이 보이지 않고 바로 `/events`로 이동합니다.
- **access 토큰 쿠키만 지우고 refresh 토큰 쿠키는 남긴 채 `/login`에 접근하면** refresh 로직(이슈 #247)이 조용히 세션을 복구한 뒤 `/events`로 이동합니다.

### 회귀가 없는 경우 (이 PR을 반영한 뒤 기준)

- **로그아웃한 상태로 `/login`에 접근하면** 새 훅이 로그인 안 된 사용자까지 쫓아내지 않으므로, 로그인 폼이 이전과 동일하게 계속 보입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 이미 인증된 상태로 접근하면 화면이 잠깐 깜빡입니다

같은 화면을 검증하다가 별개 문제를 하나 발견했습니다.  
이미 인증된 상태로 `/login`·`/signup`에 들어올 때, 폼이 잠깐 렌더링됐다 사라지는 깜빡임이 있습니다.  
이 PR의 리다이렉트가 `useEffect`(컴포넌트가 화면에 그려진 뒤에 실행되는 훅) 안에서 실행되기 때문에 생기는 현상입니다.

이 깜빡임은 이번 PR 범위 밖입니다.  
미들웨어(`proxy.ts`) 레벨에서 낙관적으로 리다이렉트하면 없앨 수 있다고 판단했습니다.  
그래서 이 PR에는 넣지 않고 별도 이슈로 분리하기로 했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략합니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
