### PR TITLE
feat(auth): 이미 인증된 상태로 로그인·회원가입 화면 접근 시 미들웨어에서 먼저 리다이렉트한다

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -14,6 +14,16 @@ const ACCESS_TOKEN_COOKIE = 'accessToken';
 export default function proxy(request: NextRequest) {
   const hasAccessToken = request.cookies.has(ACCESS_TOKEN_COOKIE);
 
+  const isAuthPage =
+    request.nextUrl.pathname === '/login' || request.nextUrl.pathname === '/signup';
+
+  if (isAuthPage) {
+    if (hasAccessToken) {
+      return NextResponse.redirect(new URL('/events', request.url));
+    }
+    return NextResponse.next();
+  }
+
   if (!hasAccessToken) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
@@ -22,5 +32,5 @@ export default function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/events/:path*'],
+  matcher: ['/events/:path*', '/signup', '/login'],
 };


### PR DESCRIPTION
## 변경 사항

**이미 인증된 상태로 `/login`·`/signup`에 접근하면, 화면이 그려지기 전에 미들웨어 단계에서 `/events`로 리다이렉트하도록 고쳤습니다.**  
이렇게 바꾼 이유는 이슈 #262(PR #265)의 클라이언트 사이드 리다이렉트가 화면이 한 번 그려진 뒤에야 동작해서, 깜빡임이 남아있었기 때문입니다.

`proxy.ts`는 Next.js 미들웨어(요청이 화면 렌더링으로 이어지기 전에 먼저 실행되는 서버 코드)입니다.

- AS-IS: 지금은 `/events/:path*`에서만 `accessToken` 쿠키 존재 여부를 확인해서, 쿠키가 없으면 `/login`으로 보내고 있습니다.
- TO-BE: `/login`·`/signup`도 확인 대상에 추가해서, `accessToken` 쿠키가 있으면 화면이 그려지기 전에 `/events`로, 없으면 그대로 통과시킵니다. 기존 `/events` 보호 로직은 그대로 둡니다.

## 관련 이슈

- Closes #266

## 검증 방법

- `npx tsc --noEmit` 통과했습니다.
- `npx eslint`(커밋 시 lint-staged로도 재확인) 통과했습니다.
- `npm run dev`로 아래 시나리오를 직접 확인했습니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- **로그인된 상태로 `/login`에 직접 접근하면** 로그인 폼이 한순간도 그려지지 않고 바로 `/events`로 이동합니다.
- **로그인된 상태로 `/signup`에 직접 접근하면** 회원가입 폼이 그려지지 않고 바로 `/events`로 이동합니다.

### 회귀가 없는 경우 (이 PR을 반영한 뒤 기준)

- **로그아웃한 상태로 `/login`·`/signup`에 접근하면** 이전과 동일하게 폼이 정상적으로 보입니다.
- **로그아웃한 상태로 `/events`에 접근하면** 이전과 동일하게 `/login`으로 리다이렉트됩니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 로그아웃 상태로 `/login`·`/signup`에 접근할 때 자기 자신으로 리다이렉트되는 문제가 있었습니다

`/login`·`/signup`을 `matcher`에 추가하면서, 기존 `/events` 보호 로직("`accessToken`이 없으면 `/login`으로 보낸다")이 `/login`·`/signup` 자기 자신에도 그대로 적용되는 문제가 있었습니다.  
로그아웃 상태로 `/login`에 접근하면 이 로직이 다시 `/login`으로 리다이렉트를 걸어서, 브라우저가 "리디렉션한 횟수가 너무 많습니다"로 요청을 차단했습니다.  
`/login`·`/signup` 경로인지 먼저 갈래를 나누고, 그 갈래 안에서 `accessToken` 유무에 따른 두 결과(리다이렉트 또는 그대로 통과)를 모두 명시적으로 반환하도록 고쳐서 해결했습니다.

### 미들웨어가 다루지 않는 경우가 하나 남아있습니다

`accessToken` 쿠키가 없고 `refreshToken` 쿠키만 있는 경우는 이번 변경 범위에서 제외했습니다.  
이 경우는 지금처럼 `/login`으로 먼저 이동한 뒤, 클라이언트 사이드에서 `useRedirectIfAuthenticated` 훅(이슈 #262·PR #265)이 refresh 성공 후 다시 `/events`로 보내는 기존 흐름을 그대로 씁니다.  
미들웨어가 `/auth/refresh`를 직접 호출하는 건 `proxy.ts`의 기존 설계 철학(쿠키 존재 여부만 보는 낙관적 체크)을 바꾸는 결정이라 별도로 검토하기로 했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략합니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
