### PR TITLE
feat(auth): 인증 확인 중 로그인·회원가입 화면에 로딩 스켈레톤을 보여준다

### DIFF
--- a/components/auth/LoginForm.tsx
+++ b/components/auth/LoginForm.tsx
@@ -30,7 +30,7 @@ const LoginForm = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const router = useRouter();
-  const { login } = useAuth();
+  const { login, isLoading } = useAuth();
   useRedirectIfAuthenticated();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -65,6 +65,16 @@ const LoginForm = () => {
       setIsSubmitting(false);
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col w-full gap-4">
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+      </div>
+    );
+  }
 
   return (
     <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit}>

--- a/components/auth/SignupForm.tsx
+++ b/components/auth/SignupForm.tsx
@@ -57,7 +57,7 @@ const SignupForm = () => {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const router = useRouter();
-  const { signup } = useAuth();
+  const { signup, isLoading } = useAuth();
   useRedirectIfAuthenticated();
 
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
@@ -99,6 +99,17 @@ const SignupForm = () => {
       setIsSubmitting(false);
     }
   };
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col w-full gap-4">
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+        <div className="h-12 w-full animate-pulse rounded-lg bg-neutral-subtle" />
+      </div>
+    );
+  }
 
   return (
     <form className="flex flex-col w-full gap-4" onSubmit={handleSubmit} noValidate={true}>


### PR DESCRIPTION
## 변경 사항

**`/auth/me`·`/auth/refresh` 응답을 기다리는 동안 로그인·회원가입 화면에 로딩 스켈레톤(콘텐츠가 나타나기 전 자리를 대신 채우는 회색 블록)을 보여주도록 고쳤습니다.**  
이렇게 바꾼 이유는 응답이 느려지면(콜드 스타트 등) 화면에 아무 표시도 없어서 완전히 멈춘 것처럼 보였기 때문입니다.

`hooks/useAuth.ts`는 `/auth/me` 응답을 아직 못 받은 상태를 `isLoading`(9-10번째 줄 주석, `meQuery.isPending` 값)으로 반환합니다.

- **`components/auth/LoginForm.tsx`** 는 로그인 폼을 그리고 제출을 처리하는 컴포넌트입니다.
  - AS-IS: 지금은 `isLoading` 값을 전혀 참조하지 않고, 항상 같은 로그인 폼만 그리고 있습니다.
  - TO-BE: `isLoading`이 `true`인 동안은 폼 대신 스켈레톤 3개(이메일·비밀번호 입력칸, 버튼 자리)를 그립니다.
- `components/auth/SignupForm.tsx`는 회원가입 폼을 그리고 제출을 처리하는 컴포넌트입니다. `LoginForm.tsx`와 같은 방식이며, 필드가 하나 더 많아 스켈레톤도 4개입니다.

새 컴포넌트를 만들지 않고 `components/layout/Header.tsx` 26-30번째 줄의 기존 스켈레톤 패턴(`animate-pulse` 클래스)을 그대로 재사용했습니다.

## 관련 이슈

- Closes #267

## 검증 방법

- `npx tsc --noEmit` 통과했습니다.
- `npx eslint`(커밋 시 lint-staged로도 재확인) 통과했습니다.
- `npm run dev`로 아래 시나리오를 직접 확인했습니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- **로그아웃 상태로 `/login`에 접속하면** `/auth/me` 응답을 기다리는 동안 스켈레톤이 보이다가, 응답이 오면 사라지고 로그인 폼이 보입니다.
- **로그아웃 상태로 `/signup`에 접속해도** 마찬가지로 스켈레톤이 보이다가 회원가입 폼으로 바뀝니다.
- **access 토큰 쿠키만 지우고 refresh 토큰 쿠키는 남긴 채 `/login`에 접속하면** 스켈레톤이 보이는 동안 refresh가 조용히 진행되고, 성공하면 로그인 폼 없이 바로 `/events`로 이동합니다(관련 이슈: #262, #266).

### 회귀가 없는 경우 (이 PR을 반영한 뒤 기준)

- **스켈레톤이 사라진 뒤 로그인 폼에 시드 계정(`host@example.com` / `pulse1234`)으로 로그인하면** 이전과 동일하게 `/events`로 이동합니다.
- **잘못된 계정 정보로 로그인을 시도하면** 이전과 동일하게 이동하지 않고, 입력칸이 invalid 스타일로 바뀌며 에러 문구가 뜹니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 스켈레톤에 애니메이션이 적용되지 않는 오탈자가 있었습니다

스켈레톤 코드를 처음 작성할 때 `animate-pulse` 클래스를 `animatepulse`(하이픈 누락)로 썼습니다.  
Tailwind는 정확한 클래스 이름만 인식하므로, 이 상태로는 회색 블록은 보이지만 펄스 애니메이션은 동작하지 않았습니다.  
`Header.tsx`의 기존 표기와 대조해서 발견하고 수정했습니다.

### 스켈레톤을 별도 컴포넌트(`LoginSkeleton`·`SignupSkeleton`)로 분리할지 검토했습니다

지금은 분리하지 않기로 결정했습니다.  
반복이 `LoginForm.tsx`·`SignupForm.tsx` 두 곳뿐이고 각 3-4줄 수준이라, 컴포넌트로 추출하는 비용이 그대로 두는 것보다 더 큽니다.  
세 번째 화면에서도 같은 스켈레톤이 필요해지는 시점에 다시 검토하기로 했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략합니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
