### PR TITLE
feat(dashboard): 주최자 대시보드를 세션별 PDF로 내보낸다

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -87,3 +87,36 @@ body {
 body:has(dialog[open]) {
   overflow: hidden;
 }
+
+/*
+ * 대시보드 PDF 내보내기(#268)입니다. 그리는 쪽은 `components/dashboard/DashboardPrintDocument.tsx`,
+ * 언제 붙는지는 `hooks/useDashboardPrint.ts`가 압니다. 여기에는 문서 전체에 걸리는 것만 둡니다.
+ *
+ * Tailwind 유틸리티보다 이 규칙들이 이깁니다. `@import 'tailwindcss'`가 넣는 것은 전부
+ * 레이어 안이고, 레이어 밖 선언은 명시도와 무관하게 레이어를 이깁니다(위 `body` 규칙과 같은 근거).
+ */
+@page {
+  size: A4;
+  margin: 12mm;
+}
+
+@media print {
+  /*
+   * 인쇄용 문서가 붙어 있을 때만 나머지를 걷어냅니다. 조건 없이 걸면 주최자가 그냥 Ctrl+P를
+   * 눌렀을 때 빈 종이가 나옵니다 — 그때는 인쇄용 문서가 없어서 남는 게 아무것도 없습니다.
+   */
+  body:has(> [data-print-document]) > *:not([data-print-document]) {
+    display: none;
+  }
+
+  /*
+   * 배경과 색을 지우는 인쇄 기본값을 끕니다. 도넛 조각과 스탯 타일은 Tailwind 클래스로
+   * 칠해져 있어서, 이게 없으면 감정 분포가 흑백 고리로 나갑니다. 추이 차트는 stroke가
+   * 인라인 `var(--color-*)`라 이것 없이도 살아남지만, 상속되는 속성이라 문서 뿌리에 한 번만
+   * 걸어두면 둘 다 덮입니다.
+   */
+  [data-print-document] {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+}

--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -36,6 +36,9 @@ interface DashboardHeaderProps {
   /** 확인 다이얼로그를 엽니다. 되돌릴 수 없는 전이라 버튼이 바로 쏘지 않습니다. */
   onEndEvent: () => void;
   isEndEventPending: boolean;
+  /** 대시보드를 PDF로 내보냅니다. 소감을 받아 인쇄창을 여는 일은 밖에서 합니다(#268). */
+  onExportPdf: () => void;
+  isExportPdfPending: boolean;
 }
 
 const DashboardHeader = ({
@@ -47,6 +50,8 @@ const DashboardHeader = ({
   onCopyLink,
   onEndEvent,
   isEndEventPending,
+  onExportPdf,
+  isExportPdfPending,
 }: DashboardHeaderProps) => (
   <div className="flex flex-wrap items-start justify-between gap-3">
     {/* 제목과 상태는 붙어 있어야 해서 바깥 `gap-4`에서 빼고 따로 묶습니다. */}
@@ -123,16 +128,29 @@ const DashboardHeader = ({
         {/*
          * 다 만든 리포트에만 붙습니다. 만들기 전이나 만드는 중에는 뒤집을 공개 여부 자체가
          * 없습니다(`GENERATED`가 아니면 공개해도 게스트는 404를 봅니다).
+         *
+         * PDF도 같은 조건입니다. 마지막 장이 요약 리포트라 리포트가 없으면 문서가 성립하지
+         * 않습니다(#268).
          */}
         {report.isGenerated && (
-          <Button
-            variant="secondary"
-            size="sm"
-            disabled={report.isTogglePublicPending}
-            onClick={report.togglePublic}
-          >
-            {report.isPublic ? '리포트 비공개' : '리포트 공개'}
-          </Button>
+          <>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={report.isTogglePublicPending}
+              onClick={report.togglePublic}
+            >
+              {report.isPublic ? '리포트 비공개' : '리포트 공개'}
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              disabled={isExportPdfPending}
+              onClick={onExportPdf}
+            >
+              PDF 내보내기
+            </Button>
+          </>
         )}
         {event.status === 'LIVE' && (
           <Button

--- a/components/dashboard/DashboardPrintDocument.tsx
+++ b/components/dashboard/DashboardPrintDocument.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+
+import { KeywordCard } from '@/components/dashboard/KeywordCard';
+import { buildPrintPages } from '@/components/dashboard/printPages';
+import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
+import { Donut } from '@/components/feedback/Donut';
+import { Badge } from '@/components/ui/Badge';
+import { Stat } from '@/components/ui/Stat';
+import formatEventDate from '@/lib/formatEventDate';
+import type { Feedback, PulseEvent, SessionView } from '@/lib/schemas/api';
+
+/**
+ * PDF로 나갈 문서입니다(#268). 칩 순서대로 "전체" 한 칸 + 세션마다 한 칸, 마지막이 AI 요약
+ * 리포트입니다. 언제 붙었다 사라지는지는 `hooks/useDashboardPrint.ts`가 정합니다.
+ *
+ * 한 장에 두 칸씩 앉힙니다. 목 데이터(세션 2개)로 치면 [전체 · 오전] [오후 · 요약] 두 장입니다.
+ * 그래서 아래 `SECTION_*`은 "장"이 아니라 "칸"입니다 — 종이를 넘기는 건 짝수 번째 칸뿐입니다.
+ *
+ * 소감 원문 목록(실시간 피드·모더레이션 큐)은 넣지 않습니다. 건수는 스탯 타일에 이미 숫자로
+ * 있고, 소감이 많은 이벤트에서는 그 두 카드 때문에 문서가 수십 장이 됩니다. 사후 보고서에
+ * 운영용 작업 목록이 들어갈 이유도 없습니다.
+ *
+ * 화면 밖(`-left-[200vw]`)에 두고 인쇄할 때만 종이 위로 올립니다. `display: none`으로 숨기면
+ * 안 됩니다 — 그 이유는 `useDashboardPrint.ts`의 `SETTLE_FRAMES` 주석에 적어뒀습니다.
+ *
+ * `body` 바로 아래로 보내는 이유는 인쇄할 때 나머지를 걷어내는 규칙(`app/globals.css`)이
+ * 이 문서를 `body`의 형제로 보기 때문입니다. 대시보드 안에 두면 이 문서를 살리려다
+ * 조상들까지 함께 살려야 합니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+/**
+ * A4 세로의 내용 폭입니다(210mm - `@page`의 좌우 여백 12mm씩).
+ *
+ * 길이 단위 규칙(CLAUDE.md)에서 벗어난 자리입니다. 여기서 정하는 건 화면 요소의 크기가 아니라
+ * 종이 크기라, 종이를 재는 단위를 그대로 씁니다. 화면 밖에 있는 동안에도 이 폭을 지켜야
+ * 인쇄 순간에 폭이 바뀌지 않고, 그래야 추이 차트가 다시 크기를 재려다 빈칸으로 나가지 않습니다.
+ */
+const PAGE_WIDTH = 'w-[186mm]';
+
+/**
+ * 한 장에 앉히는 칸 수입니다. 늘리려면 아래 `SECTION_HEIGHT`를 함께 줄여야 합니다 —
+ * A4 한 장의 내용 높이(297mm - 위아래 12mm = 273mm)를 이 수로 나눈 값이어야 합니다.
+ */
+const SECTIONS_PER_SHEET = 2;
+
+/**
+ * 칸 하나의 높이입니다. 273mm를 둘로 나눈 값에서 조금 덜어냈습니다.
+ *
+ * 딱 절반(136.5mm)으로 잡으면 반올림 한 번에 두 번째 칸이 다음 장으로 밀리고, 그러면 장마다
+ * 반쯤 빈 종이가 한 장씩 더 나옵니다. 높이를 고정하는 이유는 두 번째 칸이 늘 같은 자리에서
+ * 시작하게 하려는 것입니다 — 키워드가 한 줄 늘었다고 아래 칸이 따라 내려가면 장마다 경계가
+ * 달라집니다.
+ */
+const SECTION_HEIGHT = 'h-[133mm]';
+
+const SECTION = `flex flex-col gap-3 ${SECTION_HEIGHT}`;
+
+interface PrintSection {
+  key: string;
+  /** 칩 이름이거나 「AI 요약 리포트」입니다. */
+  label: string;
+  body: ReactNode;
+}
+
+interface DashboardPrintDocumentProps {
+  event: PulseEvent;
+  /** 칩 줄과 같은 순서여야 합니다. 이 순서가 곧 칸 순서입니다. */
+  sessions: SessionView[];
+  /**
+   * 이벤트 전체 소감입니다. 세션별로 거른 목록을 넘기면 그 세션 칸만 채워지고 나머지는
+   * 빈 칸이 됩니다(`useDashboardPrint`가 "전체" 한 벌을 받아 넘깁니다).
+   */
+  feedbacks: Feedback[];
+  /** 마지막 칸의 본문입니다. `GENERATED`인데 본문이 비어 오는 응답이 있어 `null`을 받습니다. */
+  summaryText: string | null;
+}
+
+const DashboardPrintDocument = ({
+  event,
+  sessions,
+  feedbacks,
+  summaryText,
+}: DashboardPrintDocumentProps) => {
+  const sections: PrintSection[] = [
+    ...buildPrintPages(feedbacks, sessions).map((page) => ({
+      key: String(page.sessionId ?? 'all'),
+      label: page.title,
+      body: (
+        <>
+          {/* 대시보드 상단 타일과 같은 값·같은 순서입니다. */}
+          <div className="grid shrink-0 grid-cols-4 gap-3">
+            <Stat label="총 소감" value={`${page.visibleCount}`} />
+            <Stat label="긍정 비율" value={`${page.summary.positiveRate}%`} tone="positive" />
+            <Stat label="독성 플래그" value={`${page.toxicCount}`} tone="toxic" />
+            <Stat label="미분류" value={`${page.summary.unclassified}`} tone="muted" />
+          </div>
+
+          <div className="grid shrink-0 grid-cols-[14rem_1fr] gap-3">
+            <section className={CARD}>
+              <h2 className={CARD_TITLE}>감정 분포</h2>
+              {/* 종이에는 좁은 화면이 없어서 온도계 쪽은 쓰지 않습니다. */}
+              <Donut
+                positive={page.summary.positive}
+                neutral={page.summary.neutral}
+                negative={page.summary.negative}
+                className="py-1"
+              />
+            </section>
+
+            {/*
+             * 「실시간 갱신 중」도 선이 그려지는 애니메이션도 종이에서는 뜻이 없습니다.
+             * 애니메이션은 켜두면 선이 통째로 빠진 채 인쇄됩니다(`SentimentTrendChart`).
+             */}
+            <SentimentTrendCard
+              trend={page.trend}
+              positive={page.summary.positive}
+              neutral={page.summary.neutral}
+              negative={page.summary.negative}
+              isLive={false}
+              isAnimated={false}
+            />
+          </div>
+
+          {/*
+           * 칸 안에서 유일하게 높이가 변하는 자리입니다(배지가 늘면 줄이 늘어납니다). 남는
+           * 높이를 이 카드가 받게 두고, 모자라면 여기만 줄어들어 잘립니다 — 위 세 덩어리에
+           * `shrink-0`을 건 이유입니다. 칸 높이가 고정이라 이 안전장치가 없으면 키워드가
+           * 두세 줄로 늘어난 칸이 아래 칸 위로 넘쳐 글자가 겹칩니다.
+           */}
+          <div className="min-h-0 overflow-hidden">
+            <KeywordCard keywords={page.keywords} />
+          </div>
+        </>
+      ),
+    })),
+    {
+      key: 'report',
+      label: 'AI 요약 리포트',
+      body:
+        (
+          /*
+           * 줄바꿈을 살립니다. 요약은 서버가 만든 문단이라 여러 줄로 옵니다.
+           * 본문이 비어 오는 경우의 문구는 리포트 카드(`ReportSection`)와 같이 갑니다.
+           */
+          <p className="text-sm leading-6 font-normal whitespace-pre-line text-text-secondary">
+            {summaryText ?? '요약 본문을 받지 못했어요'}
+          </p>
+        ),
+    },
+  ];
+
+  /**
+   * 종이를 넘길 자리입니다. 장의 마지막 칸마다 넘기되 문서의 마지막 칸에서는 넘기지 않습니다 —
+   * 거기서 넘기면 빈 종이가 한 장 더 딸려 나옵니다.
+   *
+   * `even:`·`last:` 변형을 겹쳐 쓰지 않고 여기서 셉니다. 그 둘은 같은 명시도라 어느 쪽이
+   * 이기는지가 Tailwind가 뽑아내는 순서에 달리는데, 그건 여기서 읽히지 않습니다.
+   */
+  const isSheetEnd = (index: number) =>
+    index % SECTIONS_PER_SHEET === SECTIONS_PER_SHEET - 1 && index !== sections.length - 1;
+
+  /*
+   * `document`를 바로 읽습니다. 이 컴포넌트는 주최자가 버튼을 누른 뒤에만 트리에 들어오므로
+   * 서버 렌더에서는 여기까지 오지 않습니다(대시보드 자체가 CSR입니다).
+   */
+  return createPortal(
+    <div
+      data-print-document
+      /* 화면에 보이지 않는 사본입니다. 스크린리더가 대시보드를 두 번 읽지 않게 합니다. */
+      aria-hidden
+      className={`absolute top-0 -left-[200vw] flex flex-col bg-background-default print:static ${PAGE_WIDTH}`}
+    >
+      {sections.map((section, index) => (
+        <article
+          key={section.key}
+          className={`${SECTION} ${isSheetEnd(index) ? 'break-after-page' : ''}`}
+        >
+          {/*
+           * 칸마다 이벤트 제목을 답니다. 낱장으로 흩어지거나 다른 보고서에 섞여도 어느 행사
+           * 것인지 남아야 합니다. 바로 옆 배지가 이 칸의 범위(칩 이름)입니다.
+           *
+           * 제목과 배지를 한 줄에 세우는 건 높이 때문이기도 합니다. 두 줄로 쌓으면 30px쯤
+           * 더 먹는데, 칸 높이가 고정이라 그만큼이 아래 키워드 카드에서 빠집니다.
+           */}
+          <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border-default pb-2">
+            <div className="flex items-center gap-2">
+              <h1 className="text-xl leading-7 font-semibold text-text-primary">{event.title}</h1>
+              <Badge tone="info">{section.label}</Badge>
+            </div>
+            <span className="shrink-0 text-xs leading-4 font-normal text-text-tertiary">
+              {formatEventDate(event.eventDate)}
+            </span>
+          </header>
+
+          {section.body}
+        </article>
+      ))}
+    </div>,
+    document.body,
+  );
+};
+
+export { DashboardPrintDocument };

--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
 import { DashboardHeader } from '@/components/dashboard/DashboardHeader';
+import { DashboardPrintDocument } from '@/components/dashboard/DashboardPrintDocument';
 import { DashboardSkeleton } from '@/components/dashboard/DashboardSkeleton';
 import { KeywordCard } from '@/components/dashboard/KeywordCard';
 import { LiveFeedCard } from '@/components/dashboard/LiveFeedCard';
@@ -32,6 +33,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { Stat } from '@/components/ui/Stat';
 import { useCopyLink } from '@/hooks/useCopyLink';
 import { useDashboardFeed } from '@/hooks/useDashboardFeed';
+import { useDashboardPrint } from '@/hooks/useDashboardPrint';
 import { useEventReport } from '@/hooks/useEventReport';
 import { useModerationActions } from '@/hooks/useModerationActions';
 import { useSessionControls } from '@/hooks/useSessionControls';
@@ -153,6 +155,12 @@ const DashboardView = () => {
 
   /* 뒤집기와 「이 화면에서 멈춘 세션인가」 판정이 한 덩어리라 훅으로 묶여 있습니다. */
   const sessionControls = useSessionControls(eventCode);
+
+  /*
+   * PDF 내보내기입니다(#268). 아래 `feedbacks`를 그대로 쓰지 않는 이유는 저 목록이 지금 고른
+   * 세션으로 이미 걸러져 있기 때문입니다. 훅이 "전체" 한 벌을 따로 받아옵니다.
+   */
+  const printControls = useDashboardPrint(eventCode);
 
   /*
    * 소감에서 뽑는 값들입니다. 정작 그리는 자리는 한참 아래지만 계산은 여기서 합니다.
@@ -419,6 +427,8 @@ const DashboardView = () => {
         onCopyLink={handleCopyLink}
         onEndEvent={() => setIsEndConfirmOpen(true)}
         isEndEventPending={endEventMutation.isPending}
+        onExportPdf={printControls.start}
+        isExportPdfPending={printControls.isPreparing}
       />
 
       <SessionFilterBar
@@ -437,6 +447,9 @@ const DashboardView = () => {
       )}
       {sessionControls.isError && (
         <Banner type="negative">세션의 소감 수신 상태를 바꾸지 못했어요</Banner>
+      )}
+      {printControls.isError && (
+        <Banner type="negative">PDF로 내보낼 소감을 불러오지 못했어요</Banner>
       )}
       {isCopyFailed && (
         <Banner type="negative">링크를 복사하지 못했어요. 위 주소를 직접 복사해주세요</Banner>
@@ -514,6 +527,19 @@ const DashboardView = () => {
 
           <ReportSection report={report} />
         </>
+      )}
+
+      {/*
+       * 인쇄용 문서입니다. 버튼을 누른 뒤 인쇄창이 닫힐 때까지만 붙어 있습니다. 상시 마운트하면
+       * 세션 수만큼 추이 차트가 더 그려지므로, 마운트 시점을 훅이 쥐고 있습니다(#268).
+       */}
+      {printControls.feedbacks !== null && (
+        <DashboardPrintDocument
+          event={event}
+          sessions={sessions}
+          feedbacks={printControls.feedbacks}
+          summaryText={report.summaryText}
+        />
       )}
 
       <QrCodeDialog open={isQrOpen} url={publicUrl} onClose={() => setIsQrOpen(false)} />

--- a/components/dashboard/SentimentTrendCard.tsx
+++ b/components/dashboard/SentimentTrendCard.tsx
@@ -21,6 +21,8 @@ interface SentimentTrendCardProps extends SentimentCounts {
    * 문구를 감춥니다 — 그 사이에도 숫자는 갱신되지만 "실시간"은 아닙니다.
    */
   isLive: boolean;
+  /** 인쇄용 문서가 끕니다. 이유는 `SentimentTrendChart`의 같은 이름 prop에 적어뒀습니다. */
+  isAnimated?: boolean;
 }
 
 const SentimentTrendCard = ({
@@ -29,6 +31,7 @@ const SentimentTrendCard = ({
   neutral,
   negative,
   isLive,
+  isAnimated,
 }: SentimentTrendCardProps) => (
   <section className={CARD}>
     <div className="flex items-center justify-between gap-2">
@@ -48,6 +51,7 @@ const SentimentTrendCard = ({
         positive={positive}
         neutral={neutral}
         negative={negative}
+        isAnimated={isAnimated}
       />
     )}
   </section>

--- a/components/dashboard/SentimentTrendChart.tsx
+++ b/components/dashboard/SentimentTrendChart.tsx
@@ -13,8 +13,23 @@ import type { SentimentCounts } from '@/components/feedback/sentiment';
 
 interface SentimentTrendChartProps extends SentimentCounts {
   trend: TrendPoint[];
+  /**
+   * 선이 그려지는 등장 애니메이션입니다. 인쇄용 문서(#268)만 끕니다.
+   *
+   * recharts는 선을 `stroke-dasharray`로 늘리면서 그립니다. 켜져 있으면 붙자마자 찍는
+   * 순간에는 선이 거의 0 길이라, 종이에는 축과 격자만 있고 선은 왼쪽 끝 토막만 남습니다.
+   * 애니메이션이 끝날 때까지 기다리는 방법도 있지만(기본 1.5초), 그동안 인쇄창이 안 떠서
+   * 버튼이 먹통처럼 보입니다. 종이에서 애니메이션은 어차피 뜻이 없어서 아예 끕니다.
+   */
+  isAnimated?: boolean;
 }
-const SentimentTrendChart = ({ trend, positive, neutral, negative }: SentimentTrendChartProps) => {
+const SentimentTrendChart = ({
+  trend,
+  positive,
+  neutral,
+  negative,
+  isAnimated = true,
+}: SentimentTrendChartProps) => {
   return (
     <div
       className="h-40"
@@ -55,6 +70,7 @@ const SentimentTrendChart = ({ trend, positive, neutral, negative }: SentimentTr
             stroke="var(--color-positive-default)"
             strokeWidth={2}
             dot={false}
+            isAnimationActive={isAnimated}
           />
           <Line
             type="monotone"
@@ -63,6 +79,7 @@ const SentimentTrendChart = ({ trend, positive, neutral, negative }: SentimentTr
             stroke="var(--color-neutral-default)"
             strokeWidth={2}
             dot={false}
+            isAnimationActive={isAnimated}
           />
           <Line
             type="monotone"
@@ -71,6 +88,7 @@ const SentimentTrendChart = ({ trend, positive, neutral, negative }: SentimentTr
             stroke="var(--color-negative-default)"
             strokeWidth={2}
             dot={false}
+            isAnimationActive={isAnimated}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/components/dashboard/printPages.test.ts
+++ b/components/dashboard/printPages.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildPrintPages } from '@/components/dashboard/printPages';
+import type { Feedback, SessionView } from '@/lib/schemas/api';
+
+/**
+ * PDF 한 장에 들어갈 숫자입니다. 화면과 달리 눈으로 검산할 수 없어서 여기서 봅니다 —
+ * 버튼을 눌러야 나타나고, 인쇄창을 닫으면 사라지고, 틀려도 종이에서만 틀립니다.
+ *
+ * 특히 독성 플래그는 화면에서는 맞고 PDF에서만 0으로 나가는 종류의 실수라(집계 모집단이
+ * 다른 유일한 숫자입니다) 따로 못 박아둡니다.
+ */
+
+const makeFeedback = (overrides: Partial<Feedback> = {}): Feedback => ({
+  id: 1,
+  sessionId: 101,
+  text: '소감',
+  sentiment: 'POS',
+  keywords: [],
+  createdAt: '2026-08-13T09:03:00.000Z',
+  toxic: false,
+  taggerVersion: 'v1',
+  status: 'VISIBLE',
+  ...overrides,
+});
+
+const makeSession = (id: number, title: string): SessionView => ({
+  id,
+  title,
+  order: id,
+  status: 'ACTIVE',
+});
+
+const SESSIONS = [makeSession(101, '오프닝'), makeSession(102, '키노트')];
+
+describe('buildPrintPages', () => {
+  it('"전체" 한 장으로 시작해 세션을 받은 순서대로 잇는다', () => {
+    const pages = buildPrintPages([], SESSIONS);
+
+    expect(pages.map((page) => page.title)).toEqual(['전체', '오프닝', '키노트']);
+    expect(pages.map((page) => page.sessionId)).toEqual([null, 101, 102]);
+  });
+
+  it('소감이 한 건도 없는 세션도 자기 장을 받는다', () => {
+    const pages = buildPrintPages([makeFeedback({ sessionId: 101 })], SESSIONS);
+
+    expect(pages).toHaveLength(3);
+    expect(pages[2]).toMatchObject({ title: '키노트', visibleCount: 0, toxicCount: 0 });
+    expect(pages[2].trend).toEqual([]);
+    expect(pages[2].keywords).toEqual([]);
+  });
+
+  it('세션 장은 그 세션의 소감만 센다', () => {
+    const pages = buildPrintPages(
+      [
+        makeFeedback({ id: 1, sessionId: 101, sentiment: 'POS' }),
+        makeFeedback({ id: 2, sessionId: 101, sentiment: 'NEG' }),
+        makeFeedback({ id: 3, sessionId: 102, sentiment: 'POS' }),
+      ],
+      SESSIONS,
+    );
+
+    expect(pages[0].visibleCount).toBe(3);
+    expect(pages[1]).toMatchObject({ visibleCount: 2, summary: { positive: 1, negative: 1 } });
+    expect(pages[2]).toMatchObject({ visibleCount: 1, summary: { positive: 1, negative: 0 } });
+  });
+
+  it('숨긴 소감은 집계에서 뺀다', () => {
+    const pages = buildPrintPages(
+      [
+        makeFeedback({ id: 1, sessionId: 101 }),
+        makeFeedback({ id: 2, sessionId: 101, status: 'HIDDEN', keywords: ['숨김'] }),
+      ],
+      SESSIONS,
+    );
+
+    expect(pages[1].visibleCount).toBe(1);
+    expect(pages[1].summary.positive).toBe(1);
+    expect(pages[1].keywords).toEqual([]);
+  });
+
+  it('독성 플래그만은 숨긴 소감까지 센다', () => {
+    /* 독성 소감은 제출 시점에 이미 HIDDEN이라, VISIBLE만 세면 늘 0입니다. */
+    const pages = buildPrintPages(
+      [
+        makeFeedback({ id: 1, sessionId: 101, status: 'HIDDEN', toxic: true }),
+        makeFeedback({ id: 2, sessionId: 102, status: 'HIDDEN', toxic: true }),
+        makeFeedback({ id: 3, sessionId: 102, status: 'VISIBLE' }),
+      ],
+      SESSIONS,
+    );
+
+    expect(pages[0]).toMatchObject({ visibleCount: 1, toxicCount: 2 });
+    expect(pages[1]).toMatchObject({ visibleCount: 0, toxicCount: 1 });
+    expect(pages[2]).toMatchObject({ visibleCount: 1, toxicCount: 1 });
+  });
+
+  it('키워드와 추이도 장마다 따로 뽑는다', () => {
+    const pages = buildPrintPages(
+      [
+        makeFeedback({ id: 1, sessionId: 101, keywords: ['발표'] }),
+        makeFeedback({ id: 2, sessionId: 102, keywords: ['질문'] }),
+      ],
+      SESSIONS,
+    );
+
+    expect(pages[0].keywords).toEqual([
+      ['발표', 1],
+      ['질문', 1],
+    ]);
+    expect(pages[1].keywords).toEqual([['발표', 1]]);
+    expect(pages[2].keywords).toEqual([['질문', 1]]);
+    expect(pages[1].trend).toHaveLength(1);
+  });
+
+  it('세션이 없으면 "전체" 한 장뿐이다', () => {
+    const pages = buildPrintPages([makeFeedback()], []);
+
+    expect(pages).toHaveLength(1);
+    expect(pages[0].title).toBe('전체');
+  });
+});

--- a/components/dashboard/printPages.ts
+++ b/components/dashboard/printPages.ts
@@ -1,0 +1,84 @@
+import {
+  buildTrend,
+  countKeywords,
+  summarizeSentiments,
+  type KeywordCount,
+  type SentimentSummary,
+  type TrendPoint,
+} from '@/components/dashboard/metrics';
+import type { Feedback, SessionView } from '@/lib/schemas/api';
+
+/**
+ * PDF 한 장에 들어갈 숫자를 미리 뽑아둡니다(#268).
+ *
+ * 화면에서 떼어낸 이유는 `metrics.ts`와 같습니다 — 인쇄용 DOM은 눈으로 검산할 수 없는 데다
+ * (버튼을 눌러야 나타나고, 인쇄창이 닫히면 사라집니다) `vitest`가 `environment: 'node'`라
+ * 순수 함수로 있어야 테스트가 붙습니다.
+ *
+ * 세는 규칙은 대시보드가 하던 그대로입니다. 페이지마다 다시 조합하지 않고 여기 한 번만
+ * 적어두는 게 이 파일의 존재 이유입니다 — 세션이 다섯이면 같은 규칙을 여섯 번 지켜야 하고,
+ * 그중 한 장만 틀려도 화면과는 맞는 PDF가 나옵니다.
+ */
+
+/** "전체" 페이지의 제목입니다. 세션 칩 줄의 첫 칩과 같은 말을 씁니다. */
+const ALL_SESSIONS_LABEL = '전체';
+
+interface PrintPage {
+  /** 세션 페이지면 세션 id, "전체"면 `null`입니다. 칩의 선택값과 같은 규칙입니다. */
+  sessionId: number | null;
+  /** 칩에 적힌 말 그대로입니다. */
+  title: string;
+  /** 스탯 「총 소감」입니다. 아래 `toxicCount`와 모집단이 다릅니다. */
+  visibleCount: number;
+  summary: SentimentSummary;
+  /**
+   * 스탯 「독성 플래그」입니다. 숨긴 건까지 셉니다.
+   *
+   * 여기만 모집단이 다릅니다. 독성 소감은 제출 시점에 이미 HIDDEN으로 저장돼서 `visible`에는
+   * 한 건도 남지 않습니다. 감정 집계가 아니라 모더레이션 지표라 숨겼어도 몇 건 들어왔는지는
+   * 보여야 합니다. `visible` 기준으로 되돌리면 전 페이지가 0으로 나갑니다.
+   */
+  toxicCount: number;
+  trend: TrendPoint[];
+  keywords: KeywordCount[];
+}
+
+const buildPage = (sessionId: number | null, title: string, feedbacks: Feedback[]): PrintPage => {
+  /* 집계 모집단은 화면과 같이 VISIBLE만입니다(독성 건수만 위 주석대로 예외). */
+  const visible = feedbacks.filter((feedback) => feedback.status === 'VISIBLE');
+
+  return {
+    sessionId,
+    title,
+    visibleCount: visible.length,
+    summary: summarizeSentiments(visible),
+    toxicCount: feedbacks.filter((feedback) => feedback.toxic).length,
+    trend: buildTrend(visible),
+    keywords: countKeywords(visible),
+  };
+};
+
+/**
+ * 칩 순서대로 페이지를 만듭니다 — "전체" 한 장, 그다음 세션마다 한 장씩입니다.
+ * 마지막 요약 리포트 장은 여기서 만들지 않습니다. 소감에서 뽑는 숫자가 없어서입니다.
+ *
+ * 소감이 한 건도 없는 세션도 자기 장을 받습니다. 건너뛰면 PDF의 장 수가 화면의 칩 수와
+ * 달라져서, 받아 본 사람이 어느 세션이 빠졌는지 세어봐야 합니다. 빈 장은 그 자체로
+ * "이 세션에는 소감이 없었다"는 결과입니다.
+ *
+ * 소감은 세션별로 나눠 받지 않고 전량 한 벌을 받아 여기서 쪼갭니다. 세션마다 요청하면
+ * 다섯 세션에 요청 여섯 번인데, 위 집계 셋이 전부 `Feedback[]` 하나만 받는 순수 함수라
+ * 나눌 이유가 없습니다.
+ */
+const buildPrintPages = (feedbacks: Feedback[], sessions: SessionView[]): PrintPage[] => [
+  buildPage(null, ALL_SESSIONS_LABEL, feedbacks),
+  ...sessions.map((session) =>
+    buildPage(
+      session.id,
+      session.title,
+      feedbacks.filter((feedback) => feedback.sessionId === session.id),
+    ),
+  ),
+];
+
+export { buildPrintPages, type PrintPage };

--- a/hooks/useDashboardPrint.ts
+++ b/hooks/useDashboardPrint.ts
@@ -1,0 +1,135 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { DASHBOARD_FEED_KEY } from '@/hooks/useDashboardFeed';
+import { fetchModerationQueue } from '@/lib/api/endpoints';
+import type { Feedback } from '@/lib/schemas/api';
+
+/**
+ * 대시보드를 PDF로 내보냅니다(#268). 소감 전량을 받아 인쇄용 문서를 띄우고 브라우저
+ * 인쇄창을 여는 데까지가 이 훅의 일입니다. 무엇을 그리는지는 `DashboardPrintDocument`가 압니다.
+ *
+ * 라이브러리를 쓰지 않고 `window.print()`로 가는 이유는 이슈에 적어둔 그대로입니다 —
+ * 의존성이 0개라 Vercel 비용 0 원칙을 건드리지 않고, 한글 폰트가 그대로 나가며,
+ * recharts SVG가 벡터로 인쇄돼 확대해도 선명하고 텍스트 선택·검색이 됩니다.
+ *
+ * 화면이 보고 있는 `useDashboardFeed`를 그대로 쓸 수 없습니다. 저쪽은 `sessionId`를 서버로
+ * 넘겨 거른 목록이라, 주최자가 세션 칩 하나를 눌러둔 채로 내보내면 나머지 세션 장을 그릴
+ * 원본이 메모리에 없습니다. 그래서 "전체"(`sessionId: null`) 한 벌을 따로 받습니다.
+ */
+
+/**
+ * 인쇄창을 열기 전에 기다리는 프레임 수입니다.
+ *
+ * 인쇄용 문서를 상시 마운트해두지 않아서(세션 10개면 recharts 차트가 11개 더 붙습니다)
+ * 버튼을 누른 뒤에야 DOM이 생깁니다. 그런데 `SentimentTrendChart`의 `ResponsiveContainer`는
+ * ResizeObserver로 부모의 실제 픽셀 크기를 재서 SVG 크기를 정하고, 그 콜백은 레이아웃이
+ * 끝난 다음에 옵니다. `window.print()`는 동기로 블로킹해서 그 사이에 끼어들 틈을 주지
+ * 않으므로, 붙이자마자 부르면 차트가 통째로 빈칸인 종이가 나갑니다.
+ *
+ * 두 프레임을 세는 건 첫 프레임에서 레이아웃이 잡히고 다음 프레임에 관측 결과가 반영되기
+ * 때문입니다. 같은 이유로 인쇄용 문서를 `display: none`으로 숨기면 안 됩니다 — 부모가
+ * 0×0이라 잴 크기 자체가 없습니다. 화면 밖으로 미는 쪽(`DashboardPrintDocument`)을 보세요.
+ *
+ * 종이에 선이 안 나오는 문제를 여기서 고치려 들지 마세요. 그건 크기가 아니라 등장
+ * 애니메이션 때문이고(선을 1.5초에 걸쳐 늘려 그립니다), 프레임 수를 늘리는 대신
+ * `SentimentTrendChart`의 `isAnimated`를 끄는 것으로 해결했습니다.
+ */
+const SETTLE_FRAMES = 2;
+
+/** 프레임을 세는 일만 합니다. 되돌려주는 함수를 부르면 아직 남은 예약을 취소합니다. */
+const afterFrames = (count: number, run: () => void) => {
+  let handle = 0;
+
+  const tick = (remaining: number) => {
+    if (remaining === 0) {
+      run();
+      return;
+    }
+
+    handle = requestAnimationFrame(() => tick(remaining - 1));
+  };
+
+  tick(count);
+
+  return () => cancelAnimationFrame(handle);
+};
+
+type PrintState =
+  /** 소감을 받는 중입니다. 캐시에 이미 있으면 이 구간을 통과만 합니다. */
+  | { phase: 'loading' }
+  /** 인쇄용 문서가 붙어 있는 동안입니다. 인쇄창이 닫히면 끝납니다. */
+  | { phase: 'printing'; feedbacks: Feedback[] }
+  | { phase: 'idle' };
+
+interface DashboardPrintControls {
+  /**
+   * 인쇄용 문서에 넘길 소감 전량입니다. `null`이면 아직 그릴 때가 아니라는 뜻이라,
+   * 화면은 이 값이 있을 때만 문서를 마운트합니다.
+   */
+  feedbacks: Feedback[] | null;
+  /** 버튼을 잠그는 데 씁니다. 소감을 받는 동안과 인쇄창이 떠 있는 동안 참입니다. */
+  isPreparing: boolean;
+  isError: boolean;
+  start: () => void;
+}
+
+const useDashboardPrint = (eventCode: string): DashboardPrintControls => {
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<PrintState>({ phase: 'idle' });
+  const [isError, setIsError] = useState(false);
+
+  const feedbacks = state.phase === 'printing' ? state.feedbacks : null;
+
+  useEffect(() => {
+    if (feedbacks === null) return;
+
+    return afterFrames(SETTLE_FRAMES, () => {
+      /*
+       * 지금 브라우저들은 인쇄창이 닫힐 때까지 이 줄에서 멈춥니다. 그래서 바로 다음 줄에서
+       * 문서를 걷어내도 인쇄에 들어간 내용이 사라지지 않습니다. `afterprint`를 기다리는
+       * 방법도 있지만, 그 이벤트가 오지 않는 경우에는 화면 밖 문서와 잠긴 버튼이 영영
+       * 남습니다.
+       */
+      window.print();
+      setState({ phase: 'idle' });
+    });
+  }, [feedbacks]);
+
+  /*
+   * 화면이 보고 있는 것과 같은 캐시 칸(`sessionId`가 `null`인 자리)을 씁니다. "전체" 칩을
+   * 눌러둔 상태였다면 이미 채워져 있어서 요청이 나가지 않고, `staleTime`이 그 판단을 합니다.
+   *
+   * 훅이 아니라 눌렀을 때 한 번 부르는 이유는, 관찰자로 붙여두면 이 화면이 쓰지도 않는
+   * 목록을 이벤트가 끝날 때까지 들고 있게 되기 때문입니다.
+   */
+  const start = () => {
+    if (state.phase !== 'idle') return;
+
+    setIsError(false);
+    setState({ phase: 'loading' });
+
+    queryClient
+      .fetchQuery({
+        queryKey: [DASHBOARD_FEED_KEY, eventCode, null],
+        queryFn: () => fetchModerationQueue({ eventCode, includeHidden: true }),
+        staleTime: Infinity,
+      })
+      .then((items) => setState({ phase: 'printing', feedbacks: items }))
+      .catch(() => {
+        setIsError(true);
+        setState({ phase: 'idle' });
+      });
+  };
+
+  return {
+    feedbacks,
+    isPreparing: state.phase !== 'idle',
+    isError,
+    start,
+  };
+};
+
+export { useDashboardPrint, type DashboardPrintControls };


### PR DESCRIPTION
## 변경 사항

주최자가 끝난 이벤트의 대시보드를 PDF로 내보낼 수 있게 합니다. 리포트 생성이 끝난(`GENERATED`) 이벤트에서만 헤더에 「PDF 내보내기」 버튼이 열립니다 — 마지막 칸이 요약 리포트라 리포트가 없으면 문서가 성립하지 않습니다.

**문서 구성**

칩 순서대로 "전체" 한 칸 + 세션마다 한 칸, 마지막이 AI 요약 리포트입니다. 한 칸에 담기는 것은 스탯 4개(총 소감 / 긍정 비율 / 독성 플래그 / 미분류), 감정 분포 도넛, 감정 추이 차트, 상위 키워드입니다. 실시간 피드와 모더레이션 큐는 넣지 않습니다(건수는 스탯에 이미 있고, 소감이 많은 이벤트에서 문서가 수십 장이 됩니다).

**이슈와 달라진 점: 한 장에 두 칸**

이슈 #268은 칩 하나당 한 장으로 잡았지만, 한 칸이 A4의 절반을 겨우 채우는 분량이라 그대로 두면 장마다 아래 절반이 빕니다. 세션 2개짜리 목 기준으로 4장 → 2장이 됩니다.

| | 이슈 | 이 PR |
| --- | --- | --- |
| 목(세션 2개) 결과 | 4장 | 2장 — `[전체 · 오전]` `[오후 · AI 요약]` |
| 종이 넘김 | 칸마다 | 짝수 번째 칸에서만(마지막 칸 제외) |

**생성 방식: 라이브러리 0개**

`window.print()` + `@media print`입니다. 의존성이 늘지 않아 비용 0 원칙을 건드리지 않고, 한글 폰트가 그대로 나가며, recharts SVG가 벡터로 인쇄돼 확대해도 선명하고 텍스트 선택·검색이 됩니다.

**신규 파일**

| 파일 | 역할 |
| --- | --- |
| `components/dashboard/printPages.ts` | 칸 하나가 받을 숫자를 소감 전량에서 잘라내는 순수 함수 |
| `components/dashboard/printPages.test.ts` | 위 함수 테스트 6개 |
| `components/dashboard/DashboardPrintDocument.tsx` | 인쇄용 문서 |
| `hooks/useDashboardPrint.ts` | 소감 조회 → 마운트 → `window.print()` → 언마운트 |

## 개발 과정 로그

커밋 1개라 생략합니다. 위 「변경 사항」과 아래 「트러블슈팅」을 봐주세요.

## 관련 이슈

- Closes #268

이슈의 남은 결정(「소감 0건인 세션도 빈 칸을 낼지, 건너뛸지」)은 **빈 칸도 낸다**로 정했습니다. 건너뛰면 문서의 칸 수가 화면의 칩 수와 달라져서, 받아 본 사람이 어느 세션이 빠졌는지 세어봐야 합니다. 빈 칸은 그 자체로 "이 세션에는 소감이 없었다"는 결과입니다.

## 검증 방법

**명령**

```
npm run test    146 passed (6 files) — printPages 6개 신규
npm run lint    0 errors (기존 경고 1개: DashboardView.tsx:169, 이 PR 변경분 아님)
npm run build   Compiled successfully / TypeScript 통과
```

**실제 PDF로 확인** — MSW 목의 `kd7m2p`(ENDED, 리포트 GENERATED, 세션 2개)에서 Playwright `page.pdf()`로 실제 인쇄 결과를 뽑아 확인했습니다. 화면 스크린샷이 아니라 인쇄 파이프라인을 통과한 PDF입니다.

- 2장, 칸 4개(전체 / 오전: 조직 소개 / 오후: 코드 리뷰 문화 / AI 요약 리포트), 빈 종이 없음
- 감정 추이 선 3개가 모든 칸에 그려짐 (아래 트러블슈팅 참고)
- 도넛·스탯 색이 인쇄물에 남음
- 칸마다 이벤트 제목이 붙음
- 문서 폭 703px = 186mm (A4 210mm - `@page` 좌우 여백 12mm씩)
- 인쇄창이 닫히면 인쇄용 문서가 DOM에서 사라짐

**인쇄 CSS 격리 확인** — `emulateMedia({ media: 'print' })` 상태에서 `body` 직계 자식들의 computed `display`를 비교했습니다.

- 인쇄용 문서가 **없을 때**: `HEADER:flex MAIN:flex` — 주최자가 그냥 Ctrl+P를 눌러도 대시보드가 평소대로 인쇄됩니다
- 인쇄용 문서가 **있을 때**: `HEADER:none MAIN:none` — 나머지가 걷히고 문서만 남습니다
<img width="596" height="840" alt="스크린샷 2026-08-25 113438" src="https://github.com/user-attachments/assets/942a8520-3ebe-4638-87b5-c7105e3315cf" />
<img width="608" height="844" alt="스크린샷 2026-08-25 113445" src="https://github.com/user-attachments/assets/10697ad3-817f-4302-b273-eb7ddabaaa2c" />
<img width="599" height="847" alt="스크린샷 2026-08-25 113452" src="https://github.com/user-attachments/assets/8a41a353-41d9-435c-b669-6a877f9a2e0c" />

**수동 확인 절차** (`npm run dev` → MSW 목)

1. `host@example.com` / `pulse1234` 로그인
2. `/events/kd7m2p/dashboard` 진입
3. 헤더의 「PDF 내보내기」 클릭 → 브라우저 인쇄 대화상자에서 미리보기 확인
4. 세션 칩을 「오후: 코드 리뷰 문화」로 바꾼 뒤 다시 눌러도 **모든 세션 칸이 채워지는지** 확인 (아래 참고)

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
  - `DashboardHeader`에 필수 prop `onExportPdf` / `isExportPdfPending`가 추가됐지만, 이 컴포넌트를 쓰는 곳은 `DashboardView` 하나뿐이라 같은 PR에서 배선했습니다.
  - `SentimentTrendChart` / `SentimentTrendCard`의 `isAnimated`는 선택 prop이고 기본값이 기존 동작(`true`)입니다. 대시보드 화면 애니메이션은 그대로입니다.

## 트러블슈팅 및 참고 사항

### 1. 세션 칩을 눌러두면 나머지 세션 칸을 그릴 원본이 없다

`useDashboardFeed`는 `sessionId`를 **서버로 넘겨서** 필터합니다(캐시 키에도 SSE 주소에도 들어갑니다). 그래서 주최자가 「오후」 칩을 누른 상태로 PDF를 누르면 메모리에는 그 세션 소감만 있습니다.

세션마다 요청을 도는 대신(세션 5개면 요청 6번), `sessionId: null`(전체) 한 벌만 받아 클라이언트에서 `feedback.sessionId`로 쪼갭니다. 집계 3개가 전부 `Feedback[]` 하나만 받는 순수 함수라 그대로 넣으면 됩니다. 화면이 보는 캐시 칸과 **같은 키**를 쓰므로 「전체」를 보고 있었다면 요청이 아예 나가지 않습니다.

집계 규칙 두 개를 칸마다 다시 지켜야 하는데, `printPages.ts` 한 곳에만 적고 테스트로 못 박았습니다.

1. 집계 모집단은 `status === 'VISIBLE'`만
2. **독성 카운트만 예외로 전체를 셉니다.** 독성 소감은 제출 시점에 이미 HIDDEN으로 저장돼 `visible`에 한 건도 남지 않습니다. `visible` 기준으로 세면 **화면에서는 맞고 PDF에서만 독성 플래그가 전 칸 0으로** 나가는, 눈치채기 어려운 종류의 버그가 됩니다.

### 2. 감정 추이 선만 종이에서 사라졌다 (가장 오래 걸린 것)

축·격자·눈금은 다 나오는데 **선 3개만** 빠지고 왼쪽 끝에 토막 하나만 찍혔습니다.

DOM을 열어보면 `<path d="M16,99.5C33.042,...">`가 좌표까지 멀쩡히 들어 있고 clip 사각형(`16,8,409,122`)도 정상이라, 처음에는 크기와 `clip-path`를 의심했습니다. 둘 다 아니었습니다.

원인은 **recharts의 등장 애니메이션**입니다. recharts는 선을 `stroke-dasharray`로 1.5초에 걸쳐 늘려 그립니다. 인쇄창을 여는 시점은 DOM이 붙은 지 두 프레임(≈30ms) 뒤라, 그때 선은 길이가 거의 0입니다.

이게 까다로웠던 이유는 **DOM에 `<path>`가 있는지만 확인하면 정상으로 보이기 때문**입니다. 스크린샷도 몇 초 뒤에 찍으면 애니메이션이 끝나 있어서 멀쩡합니다. `page.pdf()`로 실제 PDF를 뽑아 비교하고 나서야 드러났습니다.

`SentimentTrendChart`에 `isAnimated` prop을 추가해서 인쇄용 문서에서만 끕니다. 애니메이션이 끝나기를 기다리는 방법도 있지만, 그동안 1.5초간 인쇄창이 안 떠서 버튼이 먹통처럼 보입니다.

### 3. 숨긴 DOM에서는 차트가 빈칸으로 나간다

`SentimentTrendChart`의 `ResponsiveContainer`는 ResizeObserver로 부모의 실제 픽셀을 재서 SVG 크기를 정합니다. 인쇄용 DOM을 `hidden print:block`으로 숨기면 부모가 0×0이라 차트를 통째로 빼먹습니다. 인쇄 순간에 `display`가 바뀌어도 구제되지 않습니다 — ResizeObserver 콜백은 다음 프레임에 오는데 `window.print()`는 동기로 블로킹합니다.

그래서 숨기지 않고 **화면 밖으로 밉니다**(`-left-[200vw]`). A4 실제 폭을 유지한 채로요. 대신 상시 마운트하면 대시보드가 늘 recharts를 N+1개 그리게 되므로(세션 10개면 차트 11개) 버튼을 누른 뒤에 마운트하고, 두 프레임 기다렸다가 인쇄창을 엽니다.

### 4. 인쇄하면 색이 빠진다

브라우저 인쇄 기본값이 배경·일부 색을 지웁니다. 추이 차트는 stroke가 인라인 `var(--color-*)`라 살아남지만, 도넛 조각과 스탯 타일 배경은 Tailwind 클래스라 흑백으로 나갑니다. `print-color-adjust: exact`를 문서 뿌리에 한 번 겁니다(상속되는 속성입니다).

### 5. 그냥 Ctrl+P를 눌렀을 때 빈 종이가 나오지 않게

나머지를 걷어내는 규칙에 `body:has(> [data-print-document])` 조건을 걸었습니다. 조건 없이 걸면 인쇄용 문서가 없는 평소에 Ctrl+P를 눌렀을 때 남는 게 아무것도 없습니다.

### 6. 칸 높이 고정과 넘침 방지 — 리뷰 시 봐주셨으면 하는 곳

한 장에 두 칸을 앉히려면 칸 높이를 고정해야 두 번째 칸이 늘 같은 자리에서 시작합니다(`h-[133mm]`). 딱 절반(136.5mm)이 아닌 이유는 반올림 한 번에 두 번째 칸이 다음 장으로 밀려 장마다 반쯤 빈 종이가 하나씩 더 나오기 때문입니다.

문제는 칸 안에서 **키워드 카드만 높이가 변한다**는 점입니다(배지가 늘면 줄이 늘어납니다). 실측으로 칸 하나가 503px 중 458px을 쓰므로 키워드 한 줄(32px)이 더 늘어도 들어가지만, 키워드가 아주 길어 세 줄이 되면 아래 칸 위로 넘칩니다.

그래서 나머지 덩어리에 `shrink-0`을 걸고 키워드 카드만 줄어들도록 뒀습니다. 극단적인 경우 **키워드 뒷줄이 잘리는 대신 글자가 겹치지는 않습니다.** 잘리는 쪽과 넘치는 쪽 중 잘리는 쪽을 골랐는데, 다른 의견 있으면 알려주세요.

### 참고: 왜 이 방식인가

검토한 대안입니다.

| 방식 | 왜 안 골랐나 |
| --- | --- |
| jsPDF + html2canvas | 래스터라 확대하면 흐리고 텍스트 선택·검색이 안 됩니다. 의존성도 큽니다 |
| @react-pdf/renderer | 레이아웃을 자체 프리미티브로 다시 짜야 하고, 한글 폰트를 직접 등록해야 합니다. 차트도 다시 그려야 합니다 |
| 서버 사이드(Puppeteer) | 재현도는 가장 좋지만 서버가 필요해 비용 0 원칙과 충돌합니다 |
| `react-to-print` | 패턴은 같지만(인쇄용 노드를 따로 만들어 가리킴) iframe에 스타일시트를 복사하는 방식이라 Tailwind v4에서 손이 갑니다. 위 1·2번 문제는 라이브러리를 써도 똑같이 남습니다 |

인쇄 전용 라우트(`/events/[eventCode]/report/print`)로 빼는 방법도 있습니다. `body:has(...)`로 화면을 걷어내는 규칙과 화면 밖으로 미는 트릭이 통째로 필요 없어져서 더 평범한 구조가 됩니다. 대신 라우트가 늘고 새 탭이라 인증·데이터를 다시 받아야 해서 이번에는 지금 구조로 갔습니다. 리뷰에서 라우트 쪽이 낫다는 의견이면 후속 이슈로 옮기겠습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
