### PR TITLE
feat(speaker): 강연자가 자기 세션 반응만 보는 화면을 만든다

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ BACKEND_API_URL=http://localhost:8080/api/v1
 # 개발 중에는 기본으로 켜지고, 프로덕션 빌드에서는 항상 꺼집니다.
 # 실제 백엔드에 붙여볼 때만 주석을 풀어 disabled로 둡니다.
 # NEXT_PUBLIC_API_MOCKING=disabled
+
+#오픈 라우터 키는 노션 참조
+OPENROUTER_API_KEY = 
+OPENROUTER_MODEL=qwen/qwen3.7-flash

--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -26,8 +26,15 @@ import type { FeedbackSnapshot } from '@/lib/schemas/api';
  * 서버가 공개 API로 직접 받아옵니다. 프롬프트도 서버가 조립합니다.
  */
 
-/** 모델은 환경변수로 뺍니다. OpenRouter는 모델이 자주 바뀌어서 코드에 박으면 금방 낡습니다. */
-const MODEL = process.env.OPENROUTER_MODEL ?? 'google/gemini-2.5-flash';
+/**
+ * 모델은 환경변수로 뺍니다. OpenRouter는 모델이 자주 바뀌어서 코드에 박으면 금방 낡습니다.
+ *
+ * 기본값은 팀이 쓰기로 한 모델과 같아야 합니다. 배포 환경에는 키만 넣고 이 변수는 두지 않기로
+ * 해서, 폴백이 항상 발동합니다 — 즉 이 기본값이 곧 배포에서 도는 모델입니다. 여기가 다른 값이면
+ * 로컬과 배포가 서로 다른 모델로 돌고, 로컬에서 멀쩡한 요약이 배포에서만 깨져도 원인을 짚기
+ * 어렵습니다.
+ */
+const MODEL = process.env.OPENROUTER_MODEL ?? 'qwen/qwen3.7-flash';
 
 /**
  * 요약 본문의 상한입니다. 3~4문장 한국어면 250토큰 안쪽이라 두 배 남짓 여유를 뒀습니다.

--- a/app/api/summary/route.ts
+++ b/app/api/summary/route.ts
@@ -1,0 +1,209 @@
+import { fetchFeedbackSnapshot, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import type { FeedbackSnapshot } from '@/lib/schemas/api';
+
+/**
+ * 세션 하나의 소감을 AI로 요약합니다(강연자 화면 전용).
+ *
+ * 주최자 리포트(`POST /events/{code}/report/generate`)를 쓰지 않는 이유는 셋입니다.
+ * 그쪽은 (1) 주최자 계정이 있어야 하고, (2) 이벤트가 `ENDED`여야 하며, (3) `Report`에
+ * `sessionId`가 없어서 애초에 이벤트 전체 요약입니다. 강연자가 자기 세션 것을 발표 직후에
+ * 받으려면 지금 계약으로는 길이 없습니다.
+ *
+ * 그래서 백엔드(`pulse-backend`) 대신 이 레포의 Route Handler에서 부릅니다. 백엔드 담당자를
+ * 거치지 않고 프론트 PR 하나로 끝납니다.
+ *
+ * ── 키를 서버에 두는 이유 ──
+ * `OPENROUTER_API_KEY`에 `NEXT_PUBLIC_` 접두사가 없어서 브라우저 번들에 실리지 않습니다.
+ * 강연자 화면은 로그인이 없는 공개 페이지라, 키가 번들에 들어가면 주소를 아는 누구나 꺼내
+ * 우리 크레딧을 쓸 수 있습니다.
+ *
+ * 브라우저에서 직접 부르고 싶다면 `hooks/useSpeakerSummary.ts` 맨 위 주석에 바꿀 부분을
+ * 적어뒀습니다(OpenRouter는 Anthropic과 달리 CORS를 열어둬서 동작은 합니다).
+ *
+ * ── 소감 본문을 클라이언트에서 받지 않는 이유 ──
+ * 이 경로에는 인증이 없습니다. 본문을 그대로 받아 모델에 넘기면 누구나 우리 크레딧으로
+ * 아무 프롬프트나 돌리는 무료 프록시가 됩니다. 그래서 `eventCode`·`sessionId`만 받고 소감은
+ * 서버가 공개 API로 직접 받아옵니다. 프롬프트도 서버가 조립합니다.
+ */
+
+/** 모델은 환경변수로 뺍니다. OpenRouter는 모델이 자주 바뀌어서 코드에 박으면 금방 낡습니다. */
+const MODEL = process.env.OPENROUTER_MODEL ?? 'google/gemini-2.5-flash';
+
+/**
+ * 요약 본문의 상한입니다. 3~4문장 한국어면 250토큰 안쪽이라 두 배 남짓 여유를 뒀습니다.
+ *
+ * 추론을 끄고도 남기는 이유는 모델마다 `effort: 'none'` 지원이 다르기 때문입니다. 무시하는
+ * 모델을 만나도 본문이 통째로 잘리지는 않게 하는 완충입니다. 남용 시 비용 상한 역할도 합니다.
+ */
+const MAX_TOKENS = 1000;
+
+/**
+ * 실패 원인을 응답에 실을지입니다. 502만 돌려주고 끝내면 어디가 틀렸는지 알 방법이 없어서,
+ * 개발 중에는 업스트림 응답을 그대로 보여줍니다. 프로덕션에서는 내보내지 않습니다.
+ */
+const isDevelopment = process.env.NODE_ENV !== 'production';
+
+/** 모델에 넘길 소감 개수 상한입니다. 스냅샷이 최대 50건이라 사실상 전량입니다. */
+const MAX_FEEDBACKS = 50;
+
+const buildPrompt = (sessionTitle: string, snapshot: FeedbackSnapshot): string => {
+  const { POS, NEU, NEG } = snapshot.sentimentBreakdown;
+  const keywords = snapshot.topKeywords.map((item) => item.keyword).join(', ');
+  const texts = snapshot.recentFeedbacks
+    .slice(0, MAX_FEEDBACKS)
+    .map((feedback) => `- ${feedback.text}`)
+    .join('\n');
+
+  return [
+    `아래는 "${sessionTitle}" 세션에 참가자들이 남긴 소감입니다.`,
+    '',
+    `감정 분포: 긍정 ${POS}건, 중립 ${NEU}건, 부정 ${NEG}건 (미분류 ${snapshot.unclassifiedCount}건)`,
+    keywords.length > 0 ? `자주 언급된 키워드: ${keywords}` : '',
+    '',
+    '소감:',
+    texts,
+    '',
+    '위 내용을 강연자가 읽을 3~4문장짜리 한국어 단락 하나로 요약해 주세요.',
+    '전반적인 반응, 자주 나온 칭찬, 개선 요청을 담되 목록이 아니라 이어지는 문장으로 쓰세요.',
+    '주어진 소감에 없는 내용이나 숫자를 지어내지 마세요.',
+  ]
+    .filter((line) => line !== '')
+    .join('\n');
+};
+
+export async function POST(request: Request) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+
+  if (!apiKey) {
+    /* 설정 누락과 호출 실패는 다음 행동이 달라서 코드를 나눕니다. 이건 개발자가 고칠 일입니다. */
+    return Response.json(
+      { code: 'SUMMARY_NOT_CONFIGURED', message: 'OPENROUTER_API_KEY가 설정되지 않았습니다.' },
+      { status: 503 },
+    );
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return Response.json(
+      { code: 'VALIDATION_ERROR', message: '본문이 JSON이 아닙니다.' },
+      { status: 400 },
+    );
+  }
+
+  const { eventCode, sessionId } = (body ?? {}) as { eventCode?: unknown; sessionId?: unknown };
+
+  if (
+    typeof eventCode !== 'string' ||
+    typeof sessionId !== 'number' ||
+    !Number.isInteger(sessionId)
+  ) {
+    return Response.json(
+      { code: 'VALIDATION_ERROR', message: 'eventCode(string)와 sessionId(number)가 필요합니다.' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    /* 세션 제목은 프롬프트에 들어가므로 실재하는 세션인지 여기서 함께 걸러집니다. */
+    const [sessions, snapshot] = await Promise.all([
+      fetchSessionsByEventCode(eventCode),
+      fetchFeedbackSnapshot(eventCode, sessionId),
+    ]);
+
+    const session = sessions.find((item) => item.id === sessionId);
+    if (!session) {
+      return Response.json(
+        { code: 'SESSION_NOT_FOUND', message: '세션을 찾을 수 없습니다.' },
+        { status: 404 },
+      );
+    }
+
+    if (snapshot.recentFeedbacks.length === 0) {
+      return Response.json(
+        { code: 'NO_FEEDBACK', message: '요약할 소감이 아직 없습니다.' },
+        { status: 409 },
+      );
+    }
+
+    const completion = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: MODEL,
+        max_tokens: MAX_TOKENS,
+        /*
+         * 추론을 끕니다. 켜두면 추론 토큰이 `max_tokens`를 통째로 먹고 본문이 빈 채로
+         * `finish_reason: "length"`가 옵니다(2026-08-25 qwen3.7-flash 실측 — 500토큰을
+         * 영어 사고 과정에 다 쓰고 요약을 한 글자도 못 냈습니다).
+         *
+         * `exclude: true`가 아니라 `effort: 'none'`입니다. 저쪽은 추론을 생성은 하고
+         * 응답에서 숨기기만 해서 비용이 그대로 나갑니다. 이 작업은 소감 몇십 건을 한 문단으로
+         * 줄이는 일이라 추론이 필요하지 않습니다.
+         */
+        reasoning: { effort: 'none' },
+        /* 실제 과금 토큰과 비용을 응답에 실어달라고 요청합니다. 모델 비교의 근거가 됩니다. */
+        usage: { include: true },
+        messages: [{ role: 'user', content: buildPrompt(session.title, snapshot) }],
+      }),
+    });
+
+    if (!completion.ok) {
+      const detail = await completion.text();
+      console.error('[summary] OpenRouter 응답 실패', completion.status, detail);
+      return Response.json(
+        {
+          code: 'SUMMARY_FAILED',
+          message: `모델 호출이 실패했습니다 (${completion.status}).`,
+          ...(isDevelopment ? { detail } : {}),
+        },
+        { status: 502 },
+      );
+    }
+
+    const data: unknown = await completion.json();
+    const choice = (
+      data as { choices?: { finish_reason?: unknown; message?: { content?: unknown } }[] }
+    )?.choices?.[0];
+    const text = choice?.message?.content;
+
+    /*
+     * 본문이 비는 원인은 대개 잘림입니다. 사유를 나눠야 로그만 보고 `max_tokens`를 올릴지
+     * 추론 설정을 볼지 판단할 수 있습니다.
+     */
+    if (typeof text !== 'string' || text.trim() === '') {
+      if (choice?.finish_reason === 'length') {
+        console.error('[summary] 본문이 잘렸습니다 — max_tokens 또는 추론 설정을 확인하세요');
+      }
+      console.error('[summary] 본문이 비어 있습니다', JSON.stringify(data));
+      return Response.json(
+        {
+          code: 'SUMMARY_FAILED',
+          message: '모델이 빈 응답을 돌려줬습니다.',
+          ...(isDevelopment ? { detail: data } : {}),
+        },
+        { status: 502 },
+      );
+    }
+
+    if (isDevelopment) {
+      console.log('[summary] usage', MODEL, JSON.stringify((data as { usage?: unknown })?.usage));
+    }
+
+    return Response.json({ text: text.trim() });
+  } catch (error) {
+    console.error('[summary] 요약 생성 실패', error);
+    return Response.json(
+      {
+        code: 'SUMMARY_FAILED',
+        message: '요약을 만들지 못했습니다.',
+        ...(isDevelopment ? { detail: String(error) } : {}),
+      },
+      { status: 502 },
+    );
+  }
+}

--- a/app/speaker/[eventCode]/[sessionId]/page.tsx
+++ b/app/speaker/[eventCode]/[sessionId]/page.tsx
@@ -1,0 +1,43 @@
+import { notFound } from 'next/navigation';
+
+import { SpeakerSessionView } from '@/components/speaker/SpeakerSessionView';
+
+/**
+ * 강연자가 자기 세션 반응만 보는 화면입니다.
+ *
+ * 화면 전체가 클라이언트 아일랜드(`SpeakerSessionView`)입니다. 주최자 대시보드와 같은 이유로
+ * CSR입니다 — 숫자·차트·피드가 전부 스트림 결과에서 나와서 서버가 미리 그릴 게 없습니다.
+ *
+ * 로그인을 보지 않습니다. 여기 그리는 값은 전부 공개 엔드포인트
+ * (`GET /events/{code}/feedbacks?sessionId=`)에서 오고, 그 엔드포인트가 인증을 요구하지 않습니다.
+ * 그래서 이 화면은 접근 제어가 아니라 화면 분리입니다 — 주소를 아는 사람은 누구나 열 수
+ * 있지만, 이 화면 때문에 새로 새는 정보는 없습니다.
+ */
+interface SpeakerSessionPageProps {
+  params: Promise<{ eventCode: string; sessionId: string }>;
+}
+
+const SpeakerSessionPage = async ({ params }: SpeakerSessionPageProps) => {
+  const { eventCode, sessionId } = await params;
+
+  /*
+   * 숫자가 아닌 `sessionId`는 렌더 전에 끊습니다. 그대로 넘기면 `Number()`가 `NaN`이 되어
+   * 어떤 세션과도 매칭되지 않는데, 화면에는 "세션을 찾을 수 없어요"가 떠서 삭제된 세션과
+   * 구분이 안 됩니다. 주소가 잘못된 것은 404가 맞습니다.
+   *
+   * 소수점·음수·0도 함께 거릅니다. 계약의 `id`가 양의 정수라 그 밖의 값은 존재할 수 없습니다.
+   */
+  const parsedSessionId = Number(sessionId);
+
+  if (!Number.isInteger(parsedSessionId) || parsedSessionId <= 0) {
+    notFound();
+  }
+
+  return (
+    <main className="flex flex-col gap-6 p-5 md:px-20">
+      <SpeakerSessionView eventCode={eventCode} sessionId={parsedSessionId} />
+    </main>
+  );
+};
+
+export default SpeakerSessionPage;

--- a/app/speaker/layout.tsx
+++ b/app/speaker/layout.tsx
@@ -1,0 +1,35 @@
+import { Logo } from '@/components/brand/Logo';
+
+interface SpeakerLayoutProps {
+  children: React.ReactNode;
+}
+
+/**
+ * 강연자 화면의 레이아웃입니다.
+ *
+ * `app/(host)`의 `HostHeader`를 쓰지 않습니다. 그쪽은 `useAuth`로 이메일과 로그아웃 버튼을
+ * 그리는데, 강연자는 계정 없이 링크로 들어와서 보여줄 값이 없고 `/auth/me` 요청만 새로 나갑니다.
+ *
+ * `app/e`의 참가자 레이아웃도 쓰지 않습니다. 저쪽은 QR로 들어오는 모바일 전용이라 `max-w-md`
+ * 한 열인데, 이 화면은 강연 중 노트북에 띄워두는 모니터링 화면이라 넓은 화면을 씁니다.
+ *
+ * 로고에 링크를 걸지 않습니다. 강연자에게는 돌아갈 상위 화면이 없습니다 — 이벤트 홈은 참가자용
+ * 제출 화면이고, 주최자 화면은 로그인이 필요합니다.
+ *
+ * 이 경로는 `proxy.ts`의 matcher(`/events/:path*`)에 걸리지 않습니다. 걸리면 쿠키 없는 강연자가
+ * 화면을 보기도 전에 `/login`으로 튕깁니다. 라우트를 `/events` 아래로 옮기지 마세요.
+ */
+const SpeakerLayout = ({ children }: SpeakerLayoutProps) => {
+  return (
+    <div className="flex flex-1 flex-col">
+      <header className="px-5 md:px-20">
+        <div className="flex h-14 items-center border-b border-border-subtle md:h-16">
+          <Logo />
+        </div>
+      </header>
+      {children}
+    </div>
+  );
+};
+
+export default SpeakerLayout;

--- a/components/dashboard/metrics.ts
+++ b/components/dashboard/metrics.ts
@@ -58,6 +58,15 @@ interface SentimentSummary {
 type KeywordCount = [keyword: string, count: number];
 
 /**
+ * 추이 계산이 실제로 읽는 필드입니다.
+ *
+ * `Feedback` 전체를 받지 않는 이유는 강연자 화면이 같은 차트를 공개 스냅샷의
+ * `FeedbackView`로 그리기 때문입니다. 저쪽에는 `toxic`·`status`가 없지만 추이에 필요한 두
+ * 필드는 있어서, 인자 타입을 여기까지만 좁혀두면 두 화면이 같은 계산을 나눠 씁니다.
+ */
+type TrendInput = Pick<Feedback, 'createdAt' | 'sentiment'>;
+
+/**
  * 소감을 5분 칸으로 묶어 감정별 건수를 셉니다.
  *
  * 누적이 아니라 칸별 건수입니다. 누적은 언제 반응이 몰렸는지가 기울기로만 남아서,
@@ -67,7 +76,7 @@ type KeywordCount = [keyword: string, count: number];
  * 앞 칸들의 경계를 밀지 않아 차트가 흔들리지 않습니다. `UNKNOWN`은 태깅 실패라
  * 감정선에 올리지 않습니다.
  */
-const buildTrend = (feedbacks: Feedback[]) => {
+const buildTrend = (feedbacks: TrendInput[]) => {
   if (feedbacks.length === 0) return [];
 
   const times = feedbacks.map((feedback) => Date.parse(feedback.createdAt));
@@ -226,7 +235,7 @@ const isNegativeAlerting = ({
  * 서버 시각이 클라이언트보다 조금 앞서면 `age`가 음수가 되는데, 그대로 최근 구간에 넣습니다.
  * 방금 들어온 소감이라는 뜻이라 다른 칸에 둘 이유가 없습니다.
  */
-const isPositiveSurging = (feedbacks: Feedback[], now: number): boolean => {
+const isPositiveSurging = (feedbacks: TrendInput[], now: number): boolean => {
   let recent = 0;
   let baseline = 0;
   /* 목록이 언제부터의 기록인지입니다. 아래에서 기준 구간이 실제로 얼마나 채워졌는지 재는 데 씁니다. */
@@ -281,5 +290,6 @@ export {
   toRelativeTime,
   type KeywordCount,
   type SentimentSummary,
+  type TrendInput,
   type TrendPoint,
 };

--- a/components/speaker/SpeakerPrintDocument.tsx
+++ b/components/speaker/SpeakerPrintDocument.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { createPortal } from 'react-dom';
+
+import { KeywordCard } from '@/components/dashboard/KeywordCard';
+import type { KeywordCount, SentimentSummary, TrendPoint } from '@/components/dashboard/metrics';
+import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
+import { Donut } from '@/components/feedback/Donut';
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
+import { Badge } from '@/components/ui/Badge';
+import { Stat } from '@/components/ui/Stat';
+import formatEventDate from '@/lib/formatEventDate';
+import type { EventView, FeedbackView, SessionView } from '@/lib/schemas/api';
+
+/**
+ * 강연자 화면이 PDF로 내보내는 문서입니다. 언제 붙었다 사라지는지는 `hooks/useSpeakerPrint.ts`가
+ * 정합니다.
+ *
+ * 주최자의 `DashboardPrintDocument`와 달리 한 장입니다. 저쪽은 "전체" 한 칸에 세션마다 한
+ * 칸씩 더하고 마지막에 AI 요약을 붙이는데, 강연자는 자기 세션 하나만 보므로 칸을 나누고
+ * 종이를 넘길 일이 없습니다. 그래서 칸 높이를 고정하지 않고 내용이 흐르게 뒀습니다.
+ *
+ * 요약 리포트 칸도 없습니다. 리포트는 이벤트 단위(`Report`에 `sessionId`가 없습니다)라
+ * 세션별로 뽑을 수 있는 값이 아니고, 생성 API도 주최자 전용입니다.
+ *
+ * 「독성 플래그」 타일이 빠진 자리는 그대로 둡니다. 공개 뷰(`FeedbackView`)에 `toxic`이 없어서
+ * 셀 수 없고, 모더레이션 신호를 공개 경로로 내보내지 않기로 한 계약이라 앞으로도 오지 않습니다.
+ *
+ * 화면 밖(`-left-[200vw]`)에 두고 인쇄할 때만 종이 위로 올립니다. `display: none`으로 숨기면
+ * 안 되는 이유는 `useDashboardPrint.ts`의 `SETTLE_FRAMES` 주석에 적혀 있습니다.
+ *
+ * `data-print-document` 속성이 `app/globals.css`의 인쇄 규칙과 짝입니다 — 이 속성이 붙은
+ * 문서가 있을 때만 나머지 화면을 걷어냅니다. 주최자 문서와 같은 속성을 쓰므로 규칙을 새로
+ * 추가할 필요가 없습니다.
+ */
+
+/* 카드 모양이 대시보드의 다른 섹션과 같습니다. `components/ui/`에 카드 프리미티브가 아직 없습니다. */
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+
+/**
+ * A4 세로의 내용 폭입니다(210mm - `@page`의 좌우 여백 12mm씩).
+ *
+ * 길이 단위 규칙(CLAUDE.md)에서 벗어난 자리입니다. 여기서 정하는 건 화면 요소의 크기가 아니라
+ * 종이 크기라 종이를 재는 단위를 그대로 씁니다. 화면 밖에 있는 동안에도 이 폭을 지켜야
+ * 인쇄 순간에 폭이 바뀌지 않고, 그래야 추이 차트가 다시 크기를 재려다 빈칸으로 나가지 않습니다.
+ */
+const PAGE_WIDTH = 'w-[186mm]';
+/**
+ * 종이에 적는 시각입니다. 화면이 쓰는 `toRelativeTime`(「20일 전」)은 읽는 시점이 기준이라,
+ * 나중에 열어 본 사람에게는 뜻이 달라집니다. 인쇄물에는 절대값이 맞습니다.
+ */
+const toPrintTime = (iso: string) =>
+  new Date(iso).toLocaleString('ko-KR', {
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false,
+  });
+
+
+interface SpeakerPrintDocumentProps {
+  event: EventView;
+  session: SessionView;
+  /** 서버 집계에서 옮긴 값입니다(`summarizeBreakdown`). */
+  summary: SentimentSummary;
+  /** 미분류까지 포함한 전체 건수입니다. 비율의 분모와 다릅니다. */
+  totalCount: number;
+  trend: TrendPoint[];
+  keywords: KeywordCount[];
+  /**
+   * 원문을 실을 소감입니다. 누적 기록(`useSessionArchive`)을 그대로 받습니다 — 스냅샷의
+   * 최근 50건이 아니라 화면을 켜둔 동안 모인 전부라, 종이에 담을 수 있는 최대치입니다.
+   */
+  feedbacks: FeedbackView[];
+  /**
+   * AI 요약입니다. 강연자가 화면에서 만들어두지 않았으면 `null`이고, 그때는 칸 자체를
+   * 넣지 않습니다 — 빈 제목만 남으면 요약을 만들었는데 실패한 것처럼 보입니다.
+   */
+  summaryText: string | null;
+}
+
+const SpeakerPrintDocument = ({
+  event,
+  session,
+  summary,
+  totalCount,
+  trend,
+  keywords,
+  feedbacks,
+  summaryText,
+}: SpeakerPrintDocumentProps) => {
+  /*
+   * `document`를 바로 읽습니다. 이 컴포넌트는 강연자가 버튼을 누른 뒤에만 트리에 들어오므로
+   * 서버 렌더에서는 여기까지 오지 않습니다.
+   */
+  return createPortal(
+    <div
+      data-print-document
+      /* 화면에 보이지 않는 사본입니다. 스크린리더가 같은 내용을 두 번 읽지 않게 합니다. */
+      aria-hidden
+      className={`absolute top-0 -left-[200vw] flex flex-col gap-3 bg-background-default print:static ${PAGE_WIDTH}`}
+    >
+      {/*
+       * 이벤트 제목과 세션 이름을 함께 답니다. 낱장으로 흩어지거나 다른 보고서에 섞여도
+       * 어느 행사의 어느 세션인지 남아야 합니다.
+       */}
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-border-default pb-2">
+        <div className="flex items-center gap-2">
+          <h1 className="text-xl leading-7 font-semibold text-text-primary">{event.title}</h1>
+          <Badge tone="info">{session.title}</Badge>
+        </div>
+        <span className="shrink-0 text-xs leading-4 font-normal text-text-tertiary">
+          {formatEventDate(event.eventDate)}
+        </span>
+      </header>
+
+      {/* 화면 상단 타일과 같은 값·같은 순서입니다. */}
+      <div className="grid shrink-0 grid-cols-3 gap-3">
+        <Stat label="총 소감" value={`${totalCount}`} />
+        <Stat label="긍정 비율" value={`${summary.positiveRate}%`} tone="positive" />
+        <Stat label="미분류" value={`${summary.unclassified}`} tone="muted" />
+      </div>
+
+      <div className="grid shrink-0 grid-cols-[14rem_1fr] gap-3">
+        <section className={CARD}>
+          <h2 className={CARD_TITLE}>감정 분포</h2>
+          {/* 종이에는 좁은 화면이 없어서 온도계 쪽은 쓰지 않습니다. */}
+          <Donut
+            positive={summary.positive}
+            neutral={summary.neutral}
+            negative={summary.negative}
+            className="py-1"
+          />
+        </section>
+
+        {/*
+         * 「실시간 갱신 중」도 선이 그려지는 애니메이션도 종이에서는 뜻이 없습니다.
+         * 애니메이션은 켜두면 선이 통째로 빠진 채 인쇄됩니다(`SentimentTrendChart`).
+         */}
+        <SentimentTrendCard
+          trend={trend}
+          positive={summary.positive}
+          neutral={summary.neutral}
+          negative={summary.negative}
+          isLive={false}
+          isAnimated={false}
+        />
+      </div>
+
+      <KeywordCard keywords={keywords} />
+
+      {/*
+       * 요약은 키워드 다음, 원문 장 앞에 둡니다. 요약 → 근거(원문) 순서라 읽는 사람이
+       * 문장을 먼저 보고 뒷장에서 확인하게 됩니다.
+       */}
+      {summaryText !== null && (
+        <section className={CARD}>
+          <h2 className={CARD_TITLE}>AI 요약</h2>
+          <p className="text-sm leading-6 font-normal whitespace-pre-line text-text-secondary">
+            {summaryText}
+          </p>
+        </section>
+      )}
+
+      {/*
+       * 추이 차트만 모집단이 다르다는 사실을 종이에도 남깁니다. 위 타일과 도넛은 서버가
+       * 전량으로 집계해 보낸 값이지만, 추이는 이 화면을 켜둔 동안 모인 소감으로 그립니다
+       * (`lib/storage/sessionArchive.ts`). 받아 본 사람이 두 값을 대조하다 어긋난 것으로
+       * 오해하지 않도록 문서 안에 근거를 둡니다.
+       */}
+      <p className="text-xs leading-4 font-normal text-text-tertiary">
+        총 소감·감정 분포·키워드는 전체 집계입니다. 시간대별 추이는 이 화면을 열어둔 동안 모인
+        소감으로 그립니다.
+      </p>
+
+      {/*
+       * 소감 원문입니다. 주최자 문서에는 없는 칸입니다 — 그쪽은 이벤트 전체 소감을 받아 세션마다
+       * 장을 만들어서, 원문까지 실으면 문서가 수십 장이 됩니다. 여기는 세션 하나뿐이라 그만큼
+       * 나오지 않습니다.
+       *
+       * 두 단으로 세웁니다. 소감이 한두 줄짜리가 많아 한 단으로 두면 오른쪽이 절반 넘게 빕니다.
+       * `column-fill`은 기본값(balance)을 씁니다. `auto`로 두면 안 됩니다 — 높이 제약이 없는
+       * 컨테이너에서는 첫 단에 전부 쌓여서 한 단짜리 문서가 됩니다(실측 12330px, 약 12장).
+       * `break-inside-avoid`는 소감 하나가 단이나 장 경계에서 잘리는 것을 막습니다.
+       *
+       * 담는 것은 스냅샷의 최근 50건이 아니라 누적 기록 전부입니다. 화면을 켜기 전에 들어온
+       * 소감은 여기에도 마지막 50건까지만 잡힙니다.
+       */}
+      {feedbacks.length > 0 && (
+        <section className="flex break-before-page flex-col gap-3 pt-3">
+          <h2 className={CARD_TITLE}>소감 원문 {feedbacks.length}건</h2>
+
+          <div className="columns-2 gap-3">
+            {feedbacks.map((feedback) => (
+              <div key={feedback.id} className="mb-2 break-inside-avoid">
+                <FeedItem
+                  state="normal"
+                  sentiment={FEED_SENTIMENT[feedback.sentiment]}
+                  meta={toPrintTime(feedback.createdAt)}
+                  content={feedback.text}
+                />
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+    </div>,
+    document.body,
+  );
+};
+
+export { SpeakerPrintDocument };

--- a/components/speaker/SpeakerSessionView.tsx
+++ b/components/speaker/SpeakerSessionView.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+import { useState } from 'react';
+
+import { KeywordCard } from '@/components/dashboard/KeywordCard';
+import { QrCodeDialog } from '@/components/dashboard/QrCodeDialog';
+import { buildTrend, toRelativeTime } from '@/components/dashboard/metrics';
+import { SentimentTrendCard } from '@/components/dashboard/SentimentTrendCard';
+import { Donut } from '@/components/feedback/Donut';
+import { FEED_SENTIMENT, FeedItem } from '@/components/feedback/FeedItem';
+import { Thermometer } from '@/components/feedback/Thermometer';
+import { SpeakerPrintDocument } from '@/components/speaker/SpeakerPrintDocument';
+import {
+  summarizeBreakdown,
+  toKeywordCounts,
+  toTotalCount,
+} from '@/components/speaker/speakerMetrics';
+import { Badge } from '@/components/ui/Badge';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Stat } from '@/components/ui/Stat';
+import { useFeedbackSnapshot } from '@/hooks/useFeedbackSnapshot';
+import { useSentimentAlerts } from '@/hooks/useSentimentAlerts';
+import { useSessionArchive } from '@/hooks/useSessionArchive';
+import { useCopyLink } from '@/hooks/useCopyLink';
+import { useSpeakerPrint } from '@/hooks/useSpeakerPrint';
+import { useSpeakerSessionMeta } from '@/hooks/useSpeakerSessionMeta';
+import { useSpeakerSummary, type SummaryErrorCode } from '@/hooks/useSpeakerSummary';
+import { showToast } from '@/hooks/useToast';
+
+/**
+ * 강연자가 자기 세션 반응만 보는 화면입니다.
+ *
+ * 주최자 대시보드(`DashboardView`)와 카드 구성은 닮았지만 데이터 출처가 다릅니다. 저쪽은
+ * `/admin/feedbacks`의 소감 원본을 받아 직접 세고, 이쪽은 공개 스냅샷이 서버에서 집계해 보낸
+ * 값을 그립니다. 강연자는 계정이 없어서 `/admin` 계열에 닿을 수 없습니다.
+ *
+ * 그래서 못 그리는 게 셋입니다.
+ *
+ * 1. 독성 플래그 — 공개 뷰에 `toxic`이 없습니다(모더레이션 신호를 공개 경로로 내보내지 않는
+ *    계약). 상단 타일이 넷이 아니라 셋인 이유입니다.
+ * 2. 숨기기·삭제 — 조치 API가 전부 주최자 전용이라 피드가 읽기 전용입니다.
+ * 3. 소감 받기 ON/OFF — 세션 수정도 주최자 전용입니다. 상태는 배지로 보여주기만 합니다.
+ *
+ * 시간대별 추이만 스냅샷 한 장으로 안 나옵니다. 소감마다 `createdAt`이 있어야 하는데 스냅샷은
+ * 최근 50건만 싣기 때문입니다. 대신 스트림이 밀어주는 스냅샷을 `useSessionArchive`가 계속
+ * 쌓아서 이 화면을 켜둔 구간의 추이를 만듭니다.
+ *
+ * 이 화면은 URL만 알면 누구나 열 수 있습니다. `eventCode`·`sessionId`가 둘 다 참가자에게
+ * 공개된 값이라 접근 제어가 아니라 화면 분리입니다. 다만 여기 그리는 값은 전부 이미 공개
+ * 엔드포인트로 나가는 것이라, 이 화면 때문에 새로 새는 정보는 없습니다.
+ */
+
+const CARD = 'flex flex-col gap-3 rounded-xl border border-border-subtle p-4';
+const CARD_TITLE = 'text-xs font-normal leading-4 text-text-tertiary';
+/**
+ * 주소 옆에 서는 조치의 모양입니다. `Button`을 쓰지 않는 건 BASE에 `text-base
+ * font-semibold`와 `px-5`, 보더가 박혀 있어서 12px 주소 옆에 두면 크기가 겉돌기
+ * 때문입니다. className으로 덮는 건 Tailwind가 속성 순서가 아니라 스타일시트 순서로
+ * 이겨서 믿을 수 없습니다. 밑줄 텍스트 버튼은 `Header`의 로그아웃과 같은 모양입니다.
+ */
+const LINK_ACTION = [
+  'cursor-pointer underline underline-offset-2',
+  'transition-colors hover:text-text-primary',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker',
+].join(' ');
+/**
+ * 요약 실패 문구입니다. 사유마다 다음 행동이 달라서 하나로 뭉치지 않습니다 — 설정 누락은
+ * 강연자가 할 수 있는 일이 없고, 호출 실패는 다시 눌러볼 만합니다.
+ */
+const SUMMARY_ERROR_MESSAGE: Record<SummaryErrorCode, string> = {
+  SUMMARY_NOT_CONFIGURED: '요약 기능이 아직 설정되지 않았어요',
+  NO_FEEDBACK: '요약할 소감이 아직 없어요',
+  SUMMARY_FAILED: '요약을 만들지 못했어요. 잠시 후 다시 시도해 주세요',
+};
+
+/**
+ * 첫 스냅샷이 오기 전 자리표시자입니다.
+ *
+ * 실제 화면을 먼저 그리면 집계가 전부 0으로 찍히는데, 소감이 진짜 0건인 세션과 구분이 안
+ * 됩니다(`DashboardSkeleton`과 같은 이유). 그쪽을 그대로 쓰지 않는 건 타일 수가 다르고
+ * 스크린리더가 읽는 문구도 이 화면 것이어야 하기 때문입니다.
+ */
+const SpeakerSkeleton = () => (
+  <div className="flex flex-col gap-3" role="status" aria-live="polite">
+    <span className="sr-only">세션 반응을 불러오고 있어요</span>
+    <div aria-hidden="true" className="grid grid-cols-3 gap-3">
+      {[0, 1, 2].map((slot) => (
+        <div key={slot} className="h-20 animate-pulse rounded-lg bg-background-muted" />
+      ))}
+    </div>
+    <div aria-hidden="true" className="h-48 animate-pulse rounded-xl bg-background-muted" />
+  </div>
+);
+
+interface SpeakerSessionViewProps {
+  eventCode: string;
+  /** 페이지가 숫자로 바꿔서 넘깁니다. 숫자가 아닌 값은 여기까지 오지 않습니다. */
+  sessionId: number;
+}
+
+const SpeakerSessionView = ({ eventCode, sessionId }: SpeakerSessionViewProps) => {
+  const {
+    event,
+    session,
+    isPending: isMetaPending,
+    isError: isMetaError,
+  } = useSpeakerSessionMeta({ eventCode, sessionId });
+
+  const {
+    snapshot,
+    isPending: isSnapshotPending,
+    isError: isSnapshotError,
+    isLive,
+  } = useFeedbackSnapshot({ eventCode, sessionId });
+
+  const archive = useSessionArchive({ eventCode, sessionId, recent: snapshot?.recentFeedbacks });
+
+  const [isQrOpen, setIsQrOpen] = useState(false);
+
+  const { copy: copyLink, isFailed: isCopyFailed } = useCopyLink();
+
+  const print = useSpeakerPrint();
+
+  /* AI 요약입니다. 주최자 리포트를 못 쓰는 이유는 `app/api/summary/route.ts`에 적어뒀습니다. */
+  const aiSummary = useSpeakerSummary({ eventCode, sessionId });
+
+  /*
+   * 집계는 서버가 보낸 전량 기준입니다. 누적 기록으로 다시 세지 않습니다 — 그러면 화면 숫자가
+   * 서버 집계와 미묘하게 어긋나고, 같은 세션을 주최자와 나란히 봤을 때 값이 달라집니다.
+   */
+  const summary =
+    snapshot === undefined
+      ? null
+      : summarizeBreakdown(snapshot.sentimentBreakdown, snapshot.unclassifiedCount);
+
+  /*
+   * 급변 배너입니다. 부정 비율은 서버 전량 집계를 그대로 보고, 급증만 누적 기록을 봅니다.
+   * 훅은 early return 뒤로 내려갈 수 없어서 화면 분기보다 위에 둡니다.
+   */
+  const alerts = useSentimentAlerts({
+    eventStatus: event?.status,
+    negativeRate: summary?.negativeRate ?? 0,
+    classified: summary?.classified ?? 0,
+    feedbacks: archive,
+    scope: sessionId,
+  });
+
+  if (isMetaError) {
+    return <Banner type="negative">세션 정보를 불러올 수 없어요</Banner>;
+  }
+
+  if (isMetaPending || event === undefined) {
+    return <SpeakerSkeleton />;
+  }
+
+  /*
+   * 목록에 없는 id는 버립니다. 삭제된 세션을 가리키는 옛 링크나 손으로 고친 주소로
+   * "0개 소감 · 긍정 0%"라는 멀쩡해 보이는 빈 집계가 나오는 걸 막습니다(`LiveResult`와 같은 판정).
+   * 훅이 목록에서 찾아주므로 여기서는 결과만 봅니다.
+   */
+  if (session === null) {
+    return (
+      <EmptyState
+        title="세션을 찾을 수 없어요"
+        description="주소가 바뀌었거나 삭제된 세션이에요. 주최자에게 링크를 다시 받아주세요"
+      />
+    );
+  }
+
+  /*
+   * 참가자 진입 주소입니다. 배포 도메인을 환경 변수로 들고 있지 않아서 지금 출처를 알 방법은
+   * 브라우저가 열고 있는 주소뿐입니다(`DashboardView`와 같은 사정).
+   *
+   * 여기서 `window`를 읽어도 되는 이유는 서버 렌더가 이 줄까지 오지 않기 때문입니다. 쿼리를
+   * 미리 채워두는 곳이 없어서 서버에서는 위 `isMetaPending`이 항상 참이고 스켈레톤에서
+   * 끊깁니다. 컴포넌트 맨 위로 올리면 그 보호가 사라지므로 옮기지 마세요.
+   *
+   * 세션이 아니라 이벤트 주소입니다 — `EventEntryView`에 세션을 미리 고르는 파라미터가 없어서
+   * 찍고 들어온 참가자가 목록에서 직접 고릅니다.
+   */
+  const publicUrl = `${window.location.origin}/e/${eventCode}`;
+
+  /* 성공을 확인했을 때만 알립니다. 실패는 아래 배너가 받습니다(`DashboardView`와 같은 처리). */
+  const handleCopyLink = async () => {
+    if (await copyLink(publicUrl)) showToast('링크가 복사되었어요');
+  };
+
+  const totalCount =
+    snapshot === undefined
+      ? 0
+      : toTotalCount(snapshot.sentimentBreakdown, snapshot.unclassifiedCount);
+
+  /* 누적 기록으로 그립니다. 위 집계와 모집단이 다른 유일한 값이라 아래 각주로 알립니다. */
+  const trend = buildTrend(archive);
+  const keywords = snapshot === undefined ? [] : toKeywordCounts(snapshot.topKeywords);
+  const recent = snapshot?.recentFeedbacks ?? [];
+
+  /*
+   * PDF를 막는 사유입니다. 문구까지 한 곳에서 정해야 버튼의 `disabled`와 안내가 갈리지
+   * 않습니다.
+   *
+   * 요약이 없으면 막는 건 문서에서 「AI 요약」 칸이 통째로 빠지기 때문입니다
+   * (`SpeakerPrintDocument`의 `summaryText !== null`). 화면에서 본 것과 다른 문서가 나가고,
+   * 받아 본 사람은 요약을 만들다 실패한 건지 원래 없는 칸인지 알 수 없습니다.
+   */
+  const pdfBlockedReason =
+    summary === null
+      ? '소감 집계를 불러오고 있어요'
+      : aiSummary.text === null
+        ? 'AI 요약을 먼저 만들어 주세요'
+        : null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs leading-4 font-normal text-text-tertiary">{event.title}</span>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl leading-8 font-semibold text-text-primary">{session.title}</h1>
+
+            {/*
+             * 상태를 보여주기만 합니다. 뒤집는 버튼은 달지 않습니다 — 세션 수정 API가
+             * 주최자 전용이라 눌러도 403입니다.
+             *
+             * 제목 옆이 자리인 건 이게 조치가 아니라 이 세션의 속성이라서입니다. 조치 쪽에
+             * 섞어두면 눌러야 하는 것으로 읽힙니다. 주최자 헤더도 이벤트 상태 배지를 같은
+             * 자리에 답니다(`DashboardHeader`).
+             */}
+            <Badge tone={session.status === 'ACTIVE' ? 'positive' : 'outline'}>
+              {session.status === 'ACTIVE' ? '소감 받는 중' : '소감 받기 멈춤'}
+            </Badge>
+          </div>
+
+          {/*
+           * 링크 복사와 QR은 둘 다 이 주소에 거는 조치라 주소 옆에 둡니다. 헤더 오른쪽에
+           * 넷을 모아두면 무엇에 대한 버튼인지가 위치로 드러나지 않고, 한 줄에 500px 가까이
+           * 서서 답답합니다.
+           */}
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-xs font-normal leading-4 break-all text-primary-darker">
+              {publicUrl}
+            </p>
+
+            <span className="flex shrink-0 items-center gap-2 text-xs leading-4 font-normal text-text-secondary">
+              <button type="button" className={LINK_ACTION} onClick={handleCopyLink}>
+                링크 복사
+              </button>
+
+              {/* 강연장 화면에 띄워두면 참가자가 찍고 들어옵니다. */}
+              <button
+                type="button"
+                className={LINK_ACTION}
+                aria-label="참가자 QR 코드"
+                onClick={() => setIsQrOpen(true)}
+              >
+                QR
+              </button>
+            </span>
+          </div>
+        </div>
+
+        {/*
+         * 화면 전체를 내보내는 조치라 특정 카드에 붙일 수 없어 헤더에 혼자 남습니다.
+         *
+         * 못 쓸 때 숨기지 않고 비활성으로 둡니다. 사라지면 원래 없는 기능인지 지금만 못 쓰는
+         * 건지 구분이 안 됩니다. 주최자 헤더가 숨기는 쪽인 건 거기서는 이벤트 상태에 따라
+         * 조치 묶음이 통째로 갈리기 때문입니다(`DashboardHeader`).
+         *
+         * 사유는 감싼 div에 답니다. 비활성 버튼은 포인터 이벤트를 받지 않아 자신에게 붙은
+         * `title`을 띄우지 못합니다.
+         */}
+        <div className="flex justify-end" title={pdfBlockedReason ?? undefined}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={print.start}
+            disabled={print.isPrinting || pdfBlockedReason !== null}
+          >
+            PDF 내보내기
+          </Button>
+        </div>
+      </header>
+
+      {isSnapshotError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
+      {isCopyFailed && (
+        <Banner type="negative">링크를 복사하지 못했어요. QR을 눌러 주소를 확인해주세요</Banner>
+      )}
+
+      {isSnapshotPending || summary === null ? (
+        <SpeakerSkeleton />
+      ) : (
+        <>
+          {/*
+           * 실패 배너와 떨어뜨려 통계 바로 위에 둡니다. 이건 고장이 아니라 지금 화면이 보여주는
+           * 숫자에 대한 경고라, 그 숫자 옆에 있어야 읽힙니다.
+           *
+           * 주최자 대시보드의 세 배너 중 둘입니다. 모더레이션 큐 배너는 `toxic`·`status`를
+           * 봐야 하는데 공개 뷰에 둘 다 없어서 여기서는 판정할 수 없습니다.
+           */}
+          {alerts.isNegativeHeavy && (
+            <Banner type="warning">부정 반응이 {summary.negativeRate}%까지 올라갔어요</Banner>
+          )}
+          {alerts.isPositiveSurge && <Banner type="info">긍정 반응이 늘고 있어요</Banner>}
+
+          {/* 「독성 플래그」 자리가 빠져 셋입니다. 이유는 파일 맨 위 주석에 적어뒀습니다. */}
+          <div className="grid grid-cols-3 gap-3">
+            <Stat label="총 소감" value={`${totalCount}`} />
+            <Stat label="긍정 비율" value={`${summary.positiveRate}%`} tone="positive" />
+            <Stat label="미분류" value={`${summary.unclassified}`} tone="muted" />
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-[16rem_1fr]">
+            <section className={CARD}>
+              <h2 className={CARD_TITLE}>감정 분포</h2>
+              <Donut
+                positive={summary.positive}
+                neutral={summary.neutral}
+                negative={summary.negative}
+                className="hidden py-2 md:flex"
+              />
+              <Thermometer
+                positive={summary.positive}
+                neutral={summary.neutral}
+                negative={summary.negative}
+                className="py-2 md:hidden"
+              />
+            </section>
+
+            <SentimentTrendCard
+              trend={trend}
+              positive={summary.positive}
+              neutral={summary.neutral}
+              negative={summary.negative}
+              isLive={isLive}
+            />
+          </div>
+
+          {/*
+           * 추이만 모집단이 다르다는 사실을 화면에도 남깁니다. 위 타일과 도넛은 서버 전량
+           * 집계인데 추이는 이 화면을 켜둔 동안 모인 소감으로 그려서, 알려주지 않으면 둘이
+           * 어긋난 것으로 읽힙니다.
+           */}
+          <p className="text-xs leading-4 font-normal text-text-tertiary">
+            시간대별 추이는 이 화면을 열어둔 동안 모인 소감으로 그려요. 나머지 숫자는 전체 집계예요.
+          </p>
+
+          {/*
+           * AI 요약입니다. 자동으로 부르지 않고 버튼을 눌러야 만들어집니다 — 호출마다 비용이
+           * 나가는데 강연 중에는 소감이 계속 들어와서, 자동이면 화면을 열어둔 내내 갱신됩니다.
+           */}
+          <section className={CARD}>
+            <div className="flex items-center justify-between gap-2">
+              <h2 className={CARD_TITLE}>AI 요약</h2>
+
+              {/* 결과가 이 카드에 그려지니 버튼도 여기 둡니다. */}
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={aiSummary.generate}
+                disabled={aiSummary.isPending}
+              >
+                {aiSummary.isPending
+                  ? '만드는 중…'
+                  : aiSummary.text === null
+                    ? '요약 만들기'
+                    : '다시 만들기'}
+              </Button>
+            </div>
+
+            {aiSummary.errorCode !== null && (
+              <p className="text-sm text-text-tertiary">
+                {SUMMARY_ERROR_MESSAGE[aiSummary.errorCode]}
+              </p>
+            )}
+
+            {aiSummary.text === null ? (
+              aiSummary.errorCode === null && (
+                <p className="text-sm text-text-tertiary">
+                  지금까지 모인 소감을 문장으로 정리해 드려요
+                </p>
+              )
+            ) : (
+              /* 모델이 문단을 나눠 오는 경우가 있어 줄바꿈을 살립니다(`ReportSection`과 같은 처리). */
+              <p className="text-sm leading-6 font-normal whitespace-pre-line text-text-secondary">
+                {aiSummary.text}
+              </p>
+            )}
+          </section>
+
+          <KeywordCard keywords={keywords} />
+
+          <section className={CARD}>
+            <h2 className={CARD_TITLE}>최근 소감</h2>
+
+            {recent.length === 0 ? (
+              <EmptyState
+                className="h-80 justify-center"
+                title="아직 들어온 소감이 없어요"
+                description="참가자가 소감을 남기면 여기에 바로 올라와요"
+              />
+            ) : (
+              <ul className="flex h-80 flex-col gap-2 overflow-y-auto">
+                {/*
+                 * 서버가 내려주는 최근 50건입니다. 숨기기 버튼은 달지 않습니다 —
+                 * 조치 API가 주최자 전용입니다.
+                 */}
+                {recent.map((feedback) => (
+                  <li key={feedback.id}>
+                    <FeedItem
+                      state="normal"
+                      sentiment={FEED_SENTIMENT[feedback.sentiment]}
+                      meta={toRelativeTime(feedback.createdAt)}
+                      content={feedback.text}
+                    />
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+
+          {print.isPrinting && (
+            <SpeakerPrintDocument
+              event={event}
+              session={session}
+              summary={summary}
+              totalCount={totalCount}
+              trend={trend}
+              keywords={keywords}
+              feedbacks={archive}
+              summaryText={aiSummary.text}
+            />
+          )}
+        </>
+      )}
+
+      <QrCodeDialog open={isQrOpen} url={publicUrl} onClose={() => setIsQrOpen(false)} />
+    </div>
+  );
+};
+
+export { SpeakerSessionView };

--- a/components/speaker/speakerMetrics.test.ts
+++ b/components/speaker/speakerMetrics.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { summarizeBreakdown, toKeywordCounts, toTotalCount } from '@/components/speaker/speakerMetrics';
+
+describe('summarizeBreakdown', () => {
+  it('미분류를 분모에서 빼고 비율을 낸다', () => {
+    /* 분류 20건 중 긍정 10 → 50%. 미분류 30건은 분모에 들어가지 않는다. */
+    const summary = summarizeBreakdown({ POS: 10, NEU: 5, NEG: 5 }, 30);
+
+    expect(summary.classified).toBe(20);
+    expect(summary.positiveRate).toBe(50);
+    expect(summary.negativeRate).toBe(25);
+    expect(summary.unclassified).toBe(30);
+  });
+
+  it('분류된 소감이 없으면 비율이 0이다', () => {
+    const summary = summarizeBreakdown({ POS: 0, NEU: 0, NEG: 0 }, 7);
+
+    expect(summary.classified).toBe(0);
+    expect(summary.positiveRate).toBe(0);
+    expect(summary.negativeRate).toBe(0);
+  });
+
+  it('대시보드와 같은 필드 이름으로 옮긴다', () => {
+    const summary = summarizeBreakdown({ POS: 3, NEU: 2, NEG: 1 }, 0);
+
+    expect(summary.positive).toBe(3);
+    expect(summary.neutral).toBe(2);
+    expect(summary.negative).toBe(1);
+  });
+});
+
+describe('toTotalCount', () => {
+  it('미분류까지 더한 전체 건수다', () => {
+    expect(toTotalCount({ POS: 10, NEU: 5, NEG: 5 }, 30)).toBe(50);
+  });
+});
+
+describe('toKeywordCounts', () => {
+  it('객체를 카드가 받는 튜플로 바꾼다', () => {
+    expect(
+      toKeywordCounts([
+        { keyword: '유익함', count: 4 },
+        { keyword: '어려움', count: 2 },
+      ]),
+    ).toEqual([
+      ['유익함', 4],
+      ['어려움', 2],
+    ]);
+  });
+
+  it('서버가 정한 순서를 바꾸지 않는다', () => {
+    /* 서버가 이미 빈도순 상위 10으로 잘라 보내므로 다시 정렬하면 안 된다. */
+    const result = toKeywordCounts([
+      { keyword: 'a', count: 1 },
+      { keyword: 'b', count: 9 },
+    ]);
+
+    expect(result.map(([keyword]) => keyword)).toEqual(['a', 'b']);
+  });
+});

--- a/components/speaker/speakerMetrics.ts
+++ b/components/speaker/speakerMetrics.ts
@@ -1,0 +1,58 @@
+import type { SentimentSummary } from '@/components/dashboard/metrics';
+import type { FeedbackView, KeywordCount, SentimentBreakdown } from '@/lib/schemas/api';
+
+/**
+ * 강연자 화면이 공개 스냅샷에서 뽑아내는 계산입니다.
+ *
+ * 대시보드의 `metrics.ts`와 나란히 있지만 입력이 다릅니다. 저쪽은 소감 원본 배열을 받아 직접
+ * 세고, 이쪽은 서버가 이미 세어 보낸 집계를 받아 모양만 맞춥니다. 강연자에게는 `/admin`
+ * 계열이 닫혀 있어서 원본 배열을 손에 넣을 방법이 없습니다.
+ *
+ * 그래도 비율 규칙은 저쪽과 같아야 합니다 — 분모에서 미분류를 뺍니다. 규칙이 갈라지면 같은
+ * 세션을 주최자와 강연자가 나란히 봤을 때 긍정 비율이 다르게 뜹니다.
+ */
+
+/**
+ * 서버 집계를 대시보드와 같은 모양으로 옮깁니다.
+ *
+ * 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅이 실패했다는 뜻이라 "중립"과 다르고, 분모에
+ * 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다(`summarizeSentiments`와 같은 규칙).
+ */
+const summarizeBreakdown = (
+  breakdown: SentimentBreakdown,
+  unclassified: number,
+): SentimentSummary => {
+  const { POS: positive, NEU: neutral, NEG: negative } = breakdown;
+  const classified = positive + neutral + negative;
+
+  return {
+    positive,
+    neutral,
+    negative,
+    unclassified,
+    classified,
+    positiveRate: classified === 0 ? 0 : Math.round((positive / classified) * 100),
+    negativeRate: classified === 0 ? 0 : Math.round((negative / classified) * 100),
+  };
+};
+
+/**
+ * 스냅샷의 키워드를 `KeywordCard`가 받는 모양으로 바꿉니다.
+ *
+ * 계약은 `{ keyword, count }` 객체인데 카드는 `Map` 엔트리 모양의 튜플을 받습니다. 카드 쪽을
+ * 고치지 않는 이유는 그쪽 입력이 대시보드의 `countKeywords`(`Map`에서 바로 뽑습니다)라,
+ * 객체로 바꾸면 훨씬 많이 쓰이는 경로에 변환이 하나 생기기 때문입니다.
+ *
+ * 서버가 이미 빈도순 상위 10으로 잘라 보내므로 다시 정렬하지 않습니다.
+ */
+const toKeywordCounts = (topKeywords: KeywordCount[]): [string, number][] =>
+  topKeywords.map(({ keyword, count }) => [keyword, count]);
+
+/** 상단 「총 소감」입니다. 미분류까지 포함한 전체 건수라 비율의 분모와 다릅니다. */
+const toTotalCount = (breakdown: SentimentBreakdown, unclassified: number): number =>
+  breakdown.POS + breakdown.NEU + breakdown.NEG + unclassified;
+
+/** 추이 차트가 읽는 필드만 남깁니다. 누적 기록을 그대로 `buildTrend`에 넘길 때 씁니다. */
+type ArchivedFeedback = Pick<FeedbackView, 'createdAt' | 'sentiment'>;
+
+export { summarizeBreakdown, toKeywordCounts, toTotalCount, type ArchivedFeedback };

--- a/hooks/useSentimentAlerts.ts
+++ b/hooks/useSentimentAlerts.ts
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  isNegativeAlerting,
+  isPositiveSurging,
+  type TrendInput,
+} from '@/components/dashboard/metrics';
+import type { EventStatus } from '@/lib/schemas/api';
+
+/**
+ * 감정 급변 배너 두 개의 상태를 들고 있습니다(#253).
+ *
+ * 무엇이 알림감인지는 `metrics.ts`가 정합니다. 이 훅이 맡는 건 그 판정을 언제 다시 하고
+ * 직전 상태를 어떻게 물려주는지, 즉 판정 규칙이 아니라 배선입니다.
+ *
+ * 주최자 대시보드에는 세 번째 배너(모더레이션 큐)가 더 있는데 여기서는 다루지 않습니다.
+ * 큐 판정은 `toxic`·`status`를 봐야 하고 둘 다 공개 뷰에 없습니다.
+ *
+ * 지금은 강연자 화면만 씁니다. `DashboardView`에도 같은 배선이 인라인으로 들어 있어서 언젠가
+ * 이쪽으로 모으는 게 맞지만, 판정 규칙 자체는 이미 `metrics.ts` 한 곳에 있으므로 갈라져 있는
+ * 것은 상태 배선뿐입니다.
+ */
+
+/**
+ * 급증 배너를 다시 판정하는 주기입니다.
+ *
+ * 둘 중 급증만 시간이 답을 바꿉니다. 소감이 들어오지 않아도 최근 창이 지나면 거짓이 되어야
+ * 하는데, 새 소감이 없으면 스트림이 같은 배열을 돌려주고 화면은 다시 그려지지 않습니다.
+ * 그러면 반응이 뚝 끊긴 상황 — 배너가 가장 내려가야 할 때 — 에 오히려 그대로 남습니다.
+ */
+const POSITIVE_SURGE_RECHECK_MS = 10_000;
+
+interface UseSentimentAlertsParams {
+  /** `LIVE`가 아니면 둘 다 끕니다. 끝난 이벤트에는 지금 대응할 일이 없습니다. */
+  eventStatus: EventStatus | undefined;
+  negativeRate: number;
+  classified: number;
+  /** 급증 판정 대상입니다. `createdAt`·`sentiment`만 봅니다. */
+  feedbacks: TrendInput[];
+  /**
+   * 판정 모집단을 가리키는 값입니다. 바뀌면 직전 상태를 물려받지 않고 처음부터 판정합니다.
+   * 세션을 오갈 때 다른 세션에서 켜둔 배너가 따라오는 것을 막습니다.
+   */
+  scope: number | null;
+}
+
+interface SentimentAlerts {
+  isNegativeHeavy: boolean;
+  isPositiveSurge: boolean;
+}
+
+const useSentimentAlerts = ({
+  eventStatus,
+  negativeRate,
+  classified,
+  feedbacks,
+  scope,
+}: UseSentimentAlertsParams): SentimentAlerts => {
+  /* 켜지는 선과 꺼지는 선이 달라서 지금 떠 있는지를 알아야 다음 판정을 할 수 있습니다. */
+  const [isNegativeHeavy, setIsNegativeHeavy] = useState(false);
+  const [isPositiveSurge, setIsPositiveSurge] = useState(false);
+
+  /** 지금 잡아둔 판정이 어느 모집단 것인지입니다. */
+  const alertScopeRef = useRef(scope);
+
+  useEffect(() => {
+    const isScopeChanged = alertScopeRef.current !== scope;
+    if (isScopeChanged) alertScopeRef.current = scope;
+
+    if (eventStatus !== 'LIVE') {
+      /*
+       * `react-hooks/set-state-in-effect`를 끕니다. 룰이 막으려는 건 렌더가 꼬리를 무는
+       * 상황인데, 여기서는 이벤트가 `LIVE`를 벗어나는 한 번뿐이고 그 뒤로는 조건이 계속
+       * 거짓이라 다시 돌지 않습니다.
+       */
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsNegativeHeavy(false);
+      return;
+    }
+
+    setIsNegativeHeavy((wasAlerting) =>
+      isNegativeAlerting({
+        negativeRate,
+        classified,
+        wasAlerting: isScopeChanged ? false : wasAlerting,
+      }),
+    );
+  }, [negativeRate, classified, eventStatus, scope]);
+
+  useEffect(() => {
+    if (eventStatus !== 'LIVE') {
+      // 위 배너와 같은 이유입니다. `LIVE`를 벗어나는 한 번으로 끝납니다.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setIsPositiveSurge(false);
+      return;
+    }
+
+    /* 목록이 바뀔 때 한 번 보고, 그 뒤로는 타이머가 같은 판정을 반복합니다. */
+    const judge = () => setIsPositiveSurge(isPositiveSurging(feedbacks, Date.now()));
+
+    judge();
+
+    const timer = setInterval(judge, POSITIVE_SURGE_RECHECK_MS);
+    return () => clearInterval(timer);
+  }, [feedbacks, eventStatus]);
+
+  return { isNegativeHeavy, isPositiveSurge };
+};
+
+export { useSentimentAlerts, type SentimentAlerts };

--- a/hooks/useSessionArchive.ts
+++ b/hooks/useSessionArchive.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { FeedbackView } from '@/lib/schemas/api';
+import { mergeArchive, readArchive, writeArchive } from '@/lib/storage/sessionArchive';
+
+/**
+ * 스냅샷으로 들어오는 소감을 쌓아 시간대별 추이의 재료를 만듭니다.
+ *
+ * 왜 쌓아야 하는지는 `lib/storage/sessionArchive.ts`에 적어뒀습니다. 요약하면, 스냅샷이
+ * 실어주는 소감은 최근 50건뿐인데 추이 차트는 소감마다 `createdAt`이 있어야 그릴 수 있어서
+ * 한 장으로는 그 너머를 복원할 수 없습니다.
+ *
+ * 이 훅이 돌려주는 값은 **추이 차트에만** 씁니다. 총 소감 수·감정 비율·상위 키워드는 서버가
+ * 전량으로 집계해 스냅샷에 실어주므로 그쪽을 그대로 쓰세요. 여기 모인 것으로 비율까지
+ * 계산하면 화면 숫자가 서버 집계와 미묘하게 어긋납니다.
+ */
+
+interface UseSessionArchiveParams {
+  eventCode: string;
+  sessionId: number;
+  /** 방금 도착한 스냅샷의 최근 50건입니다. 첫 스냅샷 전에는 `undefined`입니다. */
+  recent: FeedbackView[] | undefined;
+}
+
+const useSessionArchive = ({
+  eventCode,
+  sessionId,
+  recent,
+}: UseSessionArchiveParams): FeedbackView[] => {
+  const [archive, setArchive] = useState<FeedbackView[]>([]);
+
+  useEffect(() => {
+    /*
+     * 저장된 기록은 브라우저에만 있어서 서버 렌더에서는 항상 비어 있습니다. 렌더 중에 읽으면
+     * 서버와 클라이언트 결과가 어긋나므로 마운트 후에 읽습니다(`LiveResult`와 같은 이유).
+     *
+     * `react-hooks/set-state-in-effect`는 effect의 setState가 렌더를 연쇄시키는 걸 막는
+     * 룰인데, 여기서는 세션이 바뀔 때 한 번으로 끝납니다.
+     */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setArchive(readArchive(eventCode, sessionId));
+  }, [eventCode, sessionId]);
+
+  useEffect(() => {
+    if (recent === undefined) return;
+
+    /*
+     * 새 건이 없으면 `mergeArchive`가 받은 배열을 그대로 돌려주고, React는 같은 참조를 보고
+     * 다시 그리지 않습니다. 스트림이 2초마다 오는데 이 보장이 없으면 소감이 안 들어오는
+     * 동안에도 화면이 계속 다시 그려집니다.
+     */
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setArchive((previous) => mergeArchive(previous, recent));
+  }, [recent]);
+
+  useEffect(() => {
+    /*
+     * 저장은 병합과 나눠 둡니다. `setArchive` 안에서 저장하면 React가 업데이터를 두 번 부르는
+     * 개발 모드에서 같은 값을 두 번 쓰게 됩니다.
+     *
+     * 빈 배열은 쓰지 않습니다. 마운트 직후 읽기 전 상태가 빈 배열이라, 그대로 저장하면
+     * 새로고침할 때마다 지금까지 모은 기록을 스스로 지웁니다.
+     */
+    if (archive.length === 0) return;
+
+    writeArchive(eventCode, sessionId, archive);
+  }, [archive, eventCode, sessionId]);
+
+  return archive;
+};
+
+export { useSessionArchive };

--- a/hooks/useSpeakerPrint.ts
+++ b/hooks/useSpeakerPrint.ts
@@ -1,0 +1,68 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * 강연자 화면을 PDF로 내보냅니다. 인쇄용 문서를 붙이고 브라우저 인쇄창을 여는 데까지가
+ * 이 훅의 일입니다. 무엇을 그리는지는 `SpeakerPrintDocument`가 압니다.
+ *
+ * `useDashboardPrint`와 같은 일을 하지만 소감을 받아오는 단계가 없습니다. 그쪽은 화면이 보고
+ * 있는 목록이 세션으로 걸러져 있어서 "전체" 한 벌을 따로 받아야 하는데, 이 화면은 애초에 세션
+ * 하나만 봐서 그릴 값이 이미 전부 메모리에 있습니다.
+ */
+
+/**
+ * 인쇄창을 열기 전에 기다리는 프레임 수입니다. 값의 근거는 `useDashboardPrint`의 같은 이름
+ * 상수에 적혀 있습니다 — 요약하면 추이 차트가 부모 크기를 재는 콜백이 레이아웃 다음에 와서,
+ * 붙이자마자 인쇄하면 차트가 빈칸으로 나갑니다.
+ */
+const SETTLE_FRAMES = 2;
+
+/** 프레임을 세는 일만 합니다. 되돌려주는 함수를 부르면 아직 남은 예약을 취소합니다. */
+const afterFrames = (count: number, run: () => void) => {
+  let handle = 0;
+
+  const tick = (remaining: number) => {
+    if (remaining === 0) {
+      run();
+      return;
+    }
+
+    handle = requestAnimationFrame(() => tick(remaining - 1));
+  };
+
+  tick(count);
+
+  return () => cancelAnimationFrame(handle);
+};
+
+interface SpeakerPrintControls {
+  /** 참이면 화면이 인쇄용 문서를 마운트합니다. */
+  isPrinting: boolean;
+  start: () => void;
+}
+
+const useSpeakerPrint = (): SpeakerPrintControls => {
+  const [isPrinting, setIsPrinting] = useState(false);
+
+  useEffect(() => {
+    if (!isPrinting) return;
+
+    return afterFrames(SETTLE_FRAMES, () => {
+      /*
+       * 지금 브라우저들은 인쇄창이 닫힐 때까지 이 줄에서 멈춥니다. 그래서 바로 다음 줄에서
+       * 문서를 걷어내도 인쇄에 들어간 내용이 사라지지 않습니다. `afterprint`를 기다리면
+       * 그 이벤트가 오지 않는 경우에 화면 밖 문서와 잠긴 버튼이 영영 남습니다.
+       */
+      window.print();
+      setIsPrinting(false);
+    });
+  }, [isPrinting]);
+
+  return {
+    isPrinting,
+    start: () => setIsPrinting(true),
+  };
+};
+
+export { useSpeakerPrint, type SpeakerPrintControls };

--- a/hooks/useSpeakerSessionMeta.ts
+++ b/hooks/useSpeakerSessionMeta.ts
@@ -1,0 +1,181 @@
+'use client';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useState } from 'react';
+
+import { fetchEventByCode, fetchSessionsByEventCode } from '@/lib/api/endpoints';
+import { API_BASE_URL } from '@/lib/env';
+import {
+  listResponseSchema,
+  sessionViewSchema,
+  type EventView,
+  type SessionView,
+} from '@/lib/schemas/api';
+
+/**
+ * 강연자 화면이 보는 이벤트와 세션입니다. 소감 집계는 `useFeedbackSnapshot`이 따로 맡습니다.
+ *
+ * 둘을 한 훅에 두는 이유는 갱신 수단이 서로 다르고 그 차이를 화면에 흘리고 싶지 않아서입니다.
+ * 세션은 SSE(`.../sessions/stream`)로 밀어주고, 이벤트 상태는 스트림이 없어서 폴링입니다
+ * (명세의 스트림 3종에 이벤트가 없습니다 — `useEventEntryFeed`가 같은 이유로 같은 선택을 했습니다).
+ *
+ * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을 아는
+ * 코드는 이 파일에만 둡니다. 화면은 `EventSource`도 폴링 간격도 모릅니다.
+ *
+ * 세션 스트림 배선(스냅샷 이벤트 이름·워치독·폴백 전환)은 `useEventEntryFeed`와 거의 같습니다.
+ * 공통 훅으로 빼지 않은 이유는 호출부가 둘뿐이고 나머지가 서로 다르기 때문입니다 — 저쪽은 SSR
+ * `initialData`를 받고 리포트 폴링까지 조율하는데, 여기는 그게 없는 대신 id로 세션을 찾습니다.
+ * 공통화하면 `enabled`·`initialData`·쿼리 키를 전부 인자로 받게 되어 도리어 읽기 어려워집니다.
+ * 세 번째 소비자가 생기면 그때 빼는 게 맞습니다.
+ *
+ * 다만 스트림 계약(이벤트 이름·타임아웃)이 바뀌면 두 파일을 함께 고쳐야 합니다.
+ *
+ * 이게 없을 때 실제로 나던 문제: 주최자가 강연 중에 세션을 `CLOSED`로 내려도 강연자 화면의
+ * 배지는 `소감 받는 중`으로 남았습니다. 이벤트를 종료해도 마찬가지로 `LIVE`인 줄 알고 급변
+ * 배너를 계속 띄웠습니다. 둘 다 한 번 받고 끝이었기 때문입니다.
+ */
+
+/** 서버가 스냅샷을 싣는 이벤트 이름입니다. 스트림 3종이 모두 이 이름을 씁니다(명세 고정값). */
+const SNAPSHOT_EVENT = 'snapshot';
+
+/**
+ * 이벤트 상태를 따라가는 간격이자, 세션 스트림이 죽었을 때 되살리는 폴링 간격입니다.
+ * `useEventEntryFeed`가 같은 두 용도에 쓰는 값과 맞췄습니다.
+ */
+const REFRESH_INTERVAL_MS = 5_000;
+
+/**
+ * 연결한 뒤 첫 스냅샷을 이만큼 기다려보고, 안 오면 스트림이 죽은 것으로 봅니다.
+ *
+ * `onerror`로는 못 잡는 실패가 있어서 필요합니다. 압축 계층이 SSE를 막으면 응답이 200에
+ * `text/event-stream`이라 브라우저는 정상 연결로 보고 `open`까지 띄우는데 본문만 안 옵니다(#261).
+ */
+const STREAM_TIMEOUT_MS = 5_000;
+
+/**
+ * 스트림으로 들어온 목록을 계약 스키마로 검사합니다.
+ *
+ * `EventSource`는 `apiClient`를 거치지 않아서 `endpoints.ts`의 응답 검증이 통째로 우회됩니다.
+ * 여기서 다시 걸러주지 않으면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간
+ * 경로에서만 사라집니다.
+ */
+const parseSessions = (raw: string): SessionView[] | null => {
+  try {
+    const result = listResponseSchema(sessionViewSchema).safeParse(JSON.parse(raw));
+    return result.success ? result.data.items : null;
+  } catch {
+    return null;
+  }
+};
+
+interface UseSpeakerSessionMetaParams {
+  eventCode: string;
+  sessionId: number;
+}
+
+interface SpeakerSessionMeta {
+  event: EventView | undefined;
+  /**
+   * 목록에서 찾은 세션입니다. 목록은 받았는데 이 id가 없으면 `null`입니다 — 삭제됐거나 주소가
+   * 잘못된 경우라, 아직 못 받은 상태(`isPending`)와 구분해야 화면이 문구를 가를 수 있습니다.
+   */
+  session: SessionView | null;
+  isPending: boolean;
+  isError: boolean;
+}
+
+const useSpeakerSessionMeta = ({
+  eventCode,
+  sessionId,
+}: UseSpeakerSessionMetaParams): SpeakerSessionMeta => {
+  const queryClient = useQueryClient();
+  const [isStreamBroken, setIsStreamBroken] = useState(false);
+
+  const eventQuery = useQuery({
+    queryKey: ['event', eventCode],
+    queryFn: () => fetchEventByCode(eventCode),
+    /*
+     * `ENDED`는 종착역입니다. 전이가 `DRAFT → LIVE → ENDED` 단방향이라(`mocks/handlers/event.ts`)
+     * 되돌아올 일이 없어서, 도착하면 자기 자신을 끕니다.
+     */
+    refetchInterval: ({ state }) =>
+      state.data?.status === 'ENDED' ? false : REFRESH_INTERVAL_MS,
+  });
+
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions', eventCode],
+    queryFn: () => fetchSessionsByEventCode(eventCode),
+    /* 갱신은 아래 스트림이 맡으므로 주기적인 재요청 트리거를 끕니다. */
+    staleTime: Infinity,
+    /*
+     * 스트림이 죽은 동안만 폴링을 켭니다. `refetchInterval`은 staleness를 보지 않아서
+     * `staleTime: Infinity`와 함께 둬도 스위치처럼 동작합니다.
+     *
+     * 이게 없으면 스트림이 조용히 죽었을 때 세션 상태가 첫 응답에 영영 굳습니다. 배지가 멀쩡히
+     * 떠 있어서 아무도 눈치채지 못합니다.
+     */
+    refetchInterval: isStreamBroken ? REFRESH_INTERVAL_MS : false,
+  });
+
+  const isEnded = eventQuery.data?.status === 'ENDED';
+
+  useEffect(() => {
+    /*
+     * 이벤트가 끝난 뒤에는 열지 않습니다. 그 시점부터 세션 상태가 바뀌어도 참가자는 제출할 수
+     * 없어서(`EVENT_NOT_LIVE`) 강연자 화면이 달라질 게 없습니다.
+     *
+     * `EventSource`는 Next도 React도 아닌 브라우저 API라 서버에는 없습니다. effect가 서버에서
+     * 실행되지 않아서 SSR이 터지지 않는 것이고, 이 생성을 effect 밖으로 끌어내면 그때 깨집니다.
+     */
+    if (isEnded) return;
+
+    const source = new EventSource(`${API_BASE_URL}/events/${eventCode}/sessions/stream`);
+
+    /*
+     * 첫 스냅샷을 기다리는 타이머입니다. 연결할 때마다 새로 걸고 스냅샷이 오면 지웁니다.
+     *
+     * 스냅샷마다 다시 걸지 않는 게 중요합니다. 다시 걸면 세션이 한동안 안 바뀌는 조용한 구간을
+     * 고장으로 잘못 읽습니다. 구분점은 "연결 직후 1건"이라는 명세의 보장입니다.
+     */
+    let watchdog: ReturnType<typeof setTimeout>;
+    const armWatchdog = () => {
+      clearTimeout(watchdog);
+      watchdog = setTimeout(() => setIsStreamBroken(true), STREAM_TIMEOUT_MS);
+    };
+
+    // 연결이 아예 안 뜨는 경우까지 덮으려고 여기서 한 번, 재연결마다 `open`에서 다시 겁니다.
+    armWatchdog();
+    source.addEventListener('open', armWatchdog);
+
+    source.addEventListener(SNAPSHOT_EVENT, (message: MessageEvent<string>) => {
+      const sessions = parseSessions(message.data);
+      if (sessions === null) return;
+
+      clearTimeout(watchdog);
+      setIsStreamBroken(false);
+      queryClient.setQueryData(['sessions', eventCode], sessions);
+    });
+
+    /*
+     * 끊겨서 다시 붙는 중(`CONNECTING`)이면 곧 돌아오므로 실패로 치지 않습니다. `CLOSED`는
+     * 브라우저가 재연결을 포기한 상태라 스스로 살아나지 않습니다. 이때만 폴백을 켭니다.
+     */
+    source.onerror = () => {
+      if (source.readyState === EventSource.CLOSED) setIsStreamBroken(true);
+    };
+
+    return () => {
+      clearTimeout(watchdog);
+      source.close();
+    };
+  }, [eventCode, isEnded, queryClient]);
+
+  return {
+    event: eventQuery.data,
+    session: sessionsQuery.data?.find((item) => item.id === sessionId) ?? null,
+    isPending: eventQuery.isPending || sessionsQuery.isPending,
+    isError: eventQuery.isError || sessionsQuery.isError,
+  };
+};
+
+export { useSpeakerSessionMeta };

--- a/hooks/useSpeakerSummary.ts
+++ b/hooks/useSpeakerSummary.ts
@@ -1,0 +1,94 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+import { useState } from 'react';
+
+/**
+ * 강연자 화면 전용 AI 요약 훅입니다.
+ *
+ * 부르면 요약문을 만들어 state에 담고, 화면은 그 값을 그립니다. 요약을 만드는 곳은
+ * `app/api/summary/route.ts`이고, 왜 주최자 리포트를 안 쓰는지는 그쪽 주석에 있습니다.
+ *
+ * 값은 state에만 둡니다. 저장해두면 소감이 계속 들어오는 동안 옛 요약이 최신인 척 남습니다.
+ * 버튼 한 번이면 다시 만들어지므로 새로고침하면 사라지는 편이 낫습니다. 대신 만들어둔 요약은
+ * 같은 세션에 머무는 동안 PDF에도 함께 실립니다.
+ *
+ * 키는 서버(Route Handler)에만 둡니다. 브라우저에서 OpenRouter를 직접 부르면 환경변수에
+ * `NEXT_PUBLIC_` 접두사가 필요한데, 그 접두사가 키를 번들에 문자열로 박습니다. 이 화면은
+ * 로그인 없는 공개 페이지라 주소만 알면 누구나 꺼낼 수 있습니다.
+ */
+
+/** 화면이 문구를 가르는 데 씁니다. 서버가 내려주는 코드와 같습니다. */
+type SummaryErrorCode =
+  /** 키가 설정되지 않았습니다. 개발자가 고칠 일이라 사용자에게 재시도를 권하지 않습니다. */
+  | 'SUMMARY_NOT_CONFIGURED'
+  /** 아직 소감이 없어 요약할 게 없습니다. */
+  | 'NO_FEEDBACK'
+  /** 모델 호출이 실패했습니다. 다시 눌러볼 만합니다. */
+  | 'SUMMARY_FAILED';
+
+interface UseSpeakerSummaryParams {
+  eventCode: string;
+  sessionId: number;
+}
+
+interface SpeakerSummary {
+  /** 만들어진 요약문입니다. 아직 만들지 않았으면 `null`입니다. */
+  text: string | null;
+  isPending: boolean;
+  /** 실패 사유입니다. 성공했거나 아직 안 눌렀으면 `null`입니다. */
+  errorCode: SummaryErrorCode | null;
+  generate: () => void;
+}
+
+const toErrorCode = (value: unknown): SummaryErrorCode =>
+  value === 'SUMMARY_NOT_CONFIGURED' || value === 'NO_FEEDBACK' ? value : 'SUMMARY_FAILED';
+
+const useSpeakerSummary = ({ eventCode, sessionId }: UseSpeakerSummaryParams): SpeakerSummary => {
+  const [text, setText] = useState<string | null>(null);
+  const [errorCode, setErrorCode] = useState<SummaryErrorCode | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      /*
+       * 소감 본문을 여기서 싣지 않습니다. 서버가 `eventCode`·`sessionId`로 직접 받아옵니다 —
+       * 이유는 route handler 주석에 있습니다(무료 프록시 방지).
+       */
+      const response = await fetch('/api/summary', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ eventCode, sessionId }),
+      });
+
+      const data: unknown = await response.json();
+
+      if (!response.ok) {
+        throw new Error(toErrorCode((data as { code?: unknown })?.code));
+      }
+
+      const summaryText = (data as { text?: unknown })?.text;
+      if (typeof summaryText !== 'string' || summaryText.trim() === '') {
+        throw new Error('SUMMARY_FAILED');
+      }
+
+      return summaryText;
+    },
+    onSuccess: (summaryText) => {
+      setText(summaryText);
+      setErrorCode(null);
+    },
+    onError: (error: Error) => {
+      setText(null);
+      setErrorCode(toErrorCode(error.message));
+    },
+  });
+
+  return {
+    text,
+    isPending: mutation.isPending,
+    errorCode,
+    generate: () => mutation.mutate(),
+  };
+};
+
+export { useSpeakerSummary, type SpeakerSummary, type SummaryErrorCode };

--- a/lib/storage/sessionArchive.test.ts
+++ b/lib/storage/sessionArchive.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FeedbackView } from '@/lib/schemas/api';
+import { ARCHIVE_LIMIT, mergeArchive } from '@/lib/storage/sessionArchive';
+
+const feedback = (id: number, minutesAgo: number): FeedbackView => ({
+  id,
+  sessionId: 1,
+  text: `소감 ${id}`,
+  sentiment: 'POS',
+  keywords: [],
+  createdAt: new Date(Date.UTC(2026, 7, 25, 10, 0) + minutesAgo * 60_000).toISOString(),
+});
+
+describe('mergeArchive', () => {
+  it('새 건이 없으면 받은 배열을 그대로 돌려준다', () => {
+    /*
+     * 참조가 같아야 React가 다시 그리지 않습니다. 스트림이 2초마다 같은 50건을 밀어주는데
+     * 매번 새 배열을 만들면 소감이 안 들어오는 동안에도 화면이 계속 다시 그려집니다.
+     */
+    const previous = [feedback(1, 0), feedback(2, 1)];
+
+    expect(mergeArchive(previous, [feedback(1, 0), feedback(2, 1)])).toBe(previous);
+  });
+
+  it('처음 보는 건만 더한다', () => {
+    const previous = [feedback(1, 0)];
+
+    const merged = mergeArchive(previous, [feedback(1, 0), feedback(2, 1)]);
+
+    expect(merged).not.toBe(previous);
+    expect(merged.map((item) => item.id)).toEqual([1, 2]);
+  });
+
+  it('이미 있는 id는 덮어쓰지 않는다', () => {
+    const previous = [{ ...feedback(1, 0), text: '원본' }];
+
+    const merged = mergeArchive(previous, [{ ...feedback(1, 0), text: '덮어쓰기 시도' }]);
+
+    expect(merged).toBe(previous);
+    expect(merged[0].text).toBe('원본');
+  });
+
+  it('시간순으로 세운다', () => {
+    /* 스냅샷은 최신순으로 오는데 차트는 시간순이어야 합니다. */
+    const merged = mergeArchive([], [feedback(3, 20), feedback(1, 0), feedback(2, 10)]);
+
+    expect(merged.map((item) => item.id)).toEqual([1, 2, 3]);
+  });
+
+  it('상한을 넘으면 오래된 것부터 버린다', () => {
+    const previous = Array.from({ length: ARCHIVE_LIMIT }, (_, index) => feedback(index + 1, index));
+
+    const merged = mergeArchive(previous, [feedback(9_000, ARCHIVE_LIMIT + 1)]);
+
+    expect(merged).toHaveLength(ARCHIVE_LIMIT);
+    /* 가장 오래된 1번이 밀려나고 새 건이 끝에 붙는다. */
+    expect(merged[0].id).toBe(2);
+    expect(merged[merged.length - 1].id).toBe(9_000);
+  });
+});

--- a/lib/storage/sessionArchive.ts
+++ b/lib/storage/sessionArchive.ts
@@ -1,0 +1,99 @@
+import { feedbackViewSchema, type FeedbackView } from '@/lib/schemas/api';
+import { z } from 'zod';
+
+/**
+ * 강연자 화면이 모아두는 세션 소감 기록입니다.
+ *
+ * 공개 스냅샷은 최근 50건만 실어줍니다(`RECENT_FEEDBACK_LIMIT`). 집계 숫자는 서버가 전량으로
+ * 내려주므로 화면 상단 타일과 도넛에는 문제가 없지만, 시간대별 추이만은 소감마다 `createdAt`이
+ * 있어야 그릴 수 있어서 스냅샷 한 장으로는 50건 너머를 복원할 수 없습니다.
+ *
+ * 대신 스트림이 2초마다 최신 50건을 통째로 다시 밀어줍니다. 화면이 열려 있는 동안 들어온 건은
+ * 여기에 쌓으면 빠짐없이 모입니다. 그래서 이 기록이 담는 것은 "강연자가 화면을 켜둔 구간"의
+ * 추이입니다 — 켜기 전에 들어온 소감은 마지막 50건까지만 잡힙니다. 화면이 이 한계를 문구로
+ * 알려야 합니다.
+ *
+ *   키   pulse:archive:{eventCode}:{sessionId}
+ *   값   FeedbackView 배열의 JSON
+ *
+ * 이 파일이 키 문자열을 아는 유일한 곳입니다(`lib/storage/submitted.ts`와 같은 규칙).
+ */
+
+const storageKey = (eventCode: string, sessionId: number) =>
+  `pulse:archive:${eventCode}:${sessionId}`;
+
+/**
+ * 들고 있을 최대 건수입니다. 넘으면 오래된 것부터 버립니다.
+ *
+ * 추이 차트는 5분 칸이라 오래된 소감일수록 한 점에 뭉쳐서, 앞쪽을 잘라도 최근 구간의
+ * 모양은 그대로입니다. 상한이 없으면 종일 켜둔 화면이 localStorage 할당량을 넘겨 저장이
+ * 통째로 실패합니다.
+ */
+const ARCHIVE_LIMIT = 500;
+
+const archiveSchema = z.array(feedbackViewSchema);
+
+/**
+ * 새로 온 스냅샷을 이미 모아둔 기록에 얹습니다.
+ *
+ * 이미 있는 `id`는 덮어쓰지 않습니다. 공개 뷰의 필드는 제출 뒤에 바뀌지 않아서 덮어쓸 이유가
+ * 없고, 새 건이 하나도 없을 때 **같은 배열 참조를 그대로 돌려주기 위해서**이기도 합니다.
+ * 스트림이 2초마다 오는데 매번 새 배열을 만들면 소감이 안 들어오는 동안에도 화면이 계속
+ * 다시 그려집니다.
+ *
+ * ⚠️ 주최자가 숨긴 소감은 다음 스냅샷부터 빠지지만 이 기록에는 남습니다. 상단 타일과 도넛은
+ * 서버 집계를 그대로 쓰므로 영향이 없고, 추이 차트만 그 건을 계속 셉니다. 공개 뷰에 `status`가
+ * 없어서(계약상 의도적 제외) 화면이 숨김 여부를 알 방법이 없습니다.
+ *
+ * 순수 함수라 저장소를 건드리지 않습니다. 이래야 `environment: 'node'`인 vitest가 붙습니다.
+ */
+const mergeArchive = (previous: FeedbackView[], incoming: FeedbackView[]): FeedbackView[] => {
+  const byId = new Map(previous.map((feedback) => [feedback.id, feedback]));
+  const added = incoming.filter((feedback) => !byId.has(feedback.id));
+
+  if (added.length === 0) return previous;
+
+  added.forEach((feedback) => byId.set(feedback.id, feedback));
+
+  /* 오래된 것부터 버리므로 시간순으로 세워둡니다. 차트도 이 순서를 그대로 씁니다. */
+  return [...byId.values()]
+    .sort((left, right) => Date.parse(left.createdAt) - Date.parse(right.createdAt))
+    .slice(-ARCHIVE_LIMIT);
+};
+
+/**
+ * 서버에는 localStorage가 없어 항상 빈 배열입니다. 호출부는 마운트 후에 읽어야 합니다.
+ *
+ * 시크릿 모드의 접근 차단, 손상된 값, 그리고 계약이 바뀐 옛 기록을 모두 빈 배열로 떨어뜨립니다.
+ * 셋 다 "모아둔 게 없다"와 결과가 같고, 여기서 살려봐야 차트가 이상해질 뿐입니다.
+ */
+const readArchive = (eventCode: string, sessionId: number): FeedbackView[] => {
+  if (typeof window === 'undefined') return [];
+
+  try {
+    const raw = window.localStorage.getItem(storageKey(eventCode, sessionId));
+    if (raw === null) return [];
+
+    const parsed = archiveSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : [];
+  } catch {
+    return [];
+  }
+};
+
+/** 저장 실패는 무시합니다. 추이 차트가 새로고침 뒤 짧아질 뿐 화면은 그대로 돕니다. */
+const writeArchive = (
+  eventCode: string,
+  sessionId: number,
+  feedbacks: FeedbackView[],
+): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(storageKey(eventCode, sessionId), JSON.stringify(feedbacks));
+  } catch {
+    // 용량 초과 또는 시크릿 모드
+  }
+};
+
+export { mergeArchive, readArchive, writeArchive, ARCHIVE_LIMIT };


### PR DESCRIPTION
## 변경 사항

강연자가 **계정 없이 링크만으로** 자기 세션 반응을 보는 화면을 추가합니다.

```
/speaker/[eventCode]/[sessionId]
```

지금 세션 반응을 볼 수 있는 사람은 주최자뿐입니다. 대시보드가 `/admin` 계열을 쓰고 로그인을 요구해서, 강연자는 자기 세션에 어떤 소감이 들어오는지 볼 방법이 없었습니다. 계정을 새로 파주는 건 과합니다 — 강연자는 행사 당일 몇 시간만 보면 되고, 볼 값도 이미 전부 공개 엔드포인트로 나가고 있습니다.

| 구역 | 내용 |
| --- | --- |
| 헤더 | 이벤트명 · 세션 제목 · 소감 수집 상태 배지 · 참가 링크(복사/QR) · PDF 내보내기 |
| 타일 | 총 소감 · 긍정 비율 · 미분류 |
| 카드 | 감정 도넛(모바일은 온도계) · 시간대별 추이 · AI 요약 · 키워드 · 최근 소감 피드 |

### 로그인을 보지 않는 이유

`GET /events/{code}/feedbacks?sessionId=`가 인증을 요구하지 않고, `eventCode`·`sessionId`는 둘 다 참가자에게 이미 공개된 값입니다. **접근 제어가 아니라 화면 분리**입니다 — 주소를 아는 사람은 누구나 열 수 있지만, 이 화면 때문에 새로 새는 정보는 없습니다.

> ⚠️ 이 경로를 `/events` 아래로 옮기지 마세요. `proxy.ts`의 matcher(`/events/:path*`)에 걸려서 쿠키 없는 강연자가 화면을 보기도 전에 `/login`으로 튕깁니다.

### 주최자 대시보드와 다른 점

같은 카드를 쓰지만 데이터 출처가 다릅니다. 대시보드는 `/admin/feedbacks`의 **소감 원본**을 받아 직접 세고, 이쪽은 **공개 스냅샷이 서버에서 집계해 보낸 값**을 그립니다. 그래서 못 하는 게 셋입니다.

1. **독성 플래그** — 공개 뷰(`FeedbackView`)에 `toxic`이 없습니다(모더레이션 신호를 공개 경로로 내보내지 않는 계약). 상단 타일이 넷이 아니라 셋인 이유입니다.
2. **숨기기·삭제** — 조치 API가 전부 주최자 전용이라 피드가 읽기 전용입니다.
3. **소감 받기 ON/OFF** — 세션 수정도 주최자 전용입니다. 상태는 배지로 보여주기만 하고 버튼은 달지 않습니다(눌러도 403).

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| --- | --- | --- |
| `ee8d66f` | refactor(dashboard): 추이 계산이 받는 입력 타입을 좁힌다 | 기능 추가와 리팩토링을 섞지 않으려고 먼저 분리. `buildTrend`가 `Feedback[]`을 받는데 실제로 읽는 건 2개 필드뿐 |
| `a4e5254` | feat(speaker): 화면을 켜둔 구간의 소감을 쌓아 추이 재료를 만든다 | 스냅샷 50건 상한을 클라이언트에서 메우는 저장 계층부터 |
| `0ad2087` | feat(speaker): 세션 하나를 AI로 요약하는 Route Handler를 추가한다 | 화면과 독립적으로 검증 가능한 서버 경로 |
| `83a0000` | feat(speaker): 강연자가 자기 세션 반응만 보는 화면을 만든다 | 위 셋을 엮는 화면·페이지·훅 |
| `176c727` | chore(speaker): AI 요약 환경 변수를 예시 파일에 추가한다 | pull 받은 사람이 무엇을 채워야 하는지 알 수 있게 |
| `dfd78fe` | fix(speaker): 요약 모델 기본값을 배포에서 실제로 도는 모델로 맞춘다 | 배포에는 키만 넣기로 해서, 코드 기본값이 곧 배포에서 도는 모델이 됨 |

---

## 왜 이렇게 했는지

리뷰어가 "왜 굳이?"라고 물을 만한 결정을 전부 적었습니다.

### 1. 왜 `localStorage`인가 (`lib/storage/sessionArchive.ts`)

**문제.** 공개 스냅샷은 최근 50건만 실어줍니다(`RECENT_FEEDBACK_LIMIT`). 총 소감 수·감정 비율·키워드는 서버가 전량으로 집계해 보내주므로 타일과 도넛에는 문제가 없습니다. 그런데 **시간대별 추이만은 소감마다 `createdAt`이 있어야** 그릴 수 있어서, 스냅샷 한 장으로는 50건 너머를 복원할 방법이 없습니다.

**단서.** 스트림이 2초마다 최신 50건을 통째로 다시 밀어줍니다. 화면이 열려 있는 동안 들어온 건은 **쌓기만 하면 빠짐없이 모입니다.**

**그럼 어디에 쌓나.** 후보를 하나씩 지웠습니다.

| 후보 | 왜 안 되나 |
| --- | --- |
| 서버 | 이 기록을 저장하는 API가 없습니다. 만들려면 백엔드 담당자를 거쳐야 하는데 크리티컬 패스가 좁습니다. 애초에 서버는 이미 전량을 알고 있어서, 이건 서버가 풀 문제가 아니라 "스냅샷 50건 상한"을 클라이언트가 메우는 일입니다 |
| `useState`만 | 새로고침에 날아갑니다. 강연 중 실수로 새로고침하면 추이가 0부터 다시 시작합니다 |
| `sessionStorage` | 탭을 닫으면 사라집니다. 강연자가 쉬는 시간에 탭을 정리하고 다시 여는 경우를 감당 못 합니다 |
| **`localStorage`** | ✅ 새로고침·탭 닫기를 견디고, 세션별로 키를 나눌 수 있습니다 |

**키 규칙.** `pulse:archive:{eventCode}:{sessionId}`. 키 문자열을 아는 파일을 하나로 두고 화면에서 `localStorage`를 직접 부르지 않습니다 — `lib/storage/submitted.ts`와 같은 규칙입니다.

**SSR 주의.** 서버에는 `localStorage`가 없어 `readArchive`가 항상 빈 배열입니다. 그래서 **반드시 마운트 후에** 읽습니다. 렌더 중에 읽으면 서버·클라이언트 결과가 어긋납니다(`LiveResult`와 같은 이유).

**작업 중 실제로 밟은 지뢰 넷.**

1. **2초마다 리렌더** — 매 스냅샷마다 새 배열을 돌려주니 소감이 하나도 안 들어오는 동안에도 화면이 계속 다시 그려졌습니다. → 새 `id`가 없으면 `mergeArchive`가 **받은 배열을 그대로** 돌려주게 해서 참조 동일성으로 끊었습니다.
2. **개발 모드 이중 쓰기** — 병합과 저장을 한곳에 두니 React가 업데이터를 두 번 부르면서 같은 값을 두 번 썼습니다. → `setArchive` 밖의 **별도 effect**로 분리했습니다.
3. **스스로 기록 삭제** — 마운트 직후 읽기 전 상태가 빈 배열인데 그걸 그대로 저장해서, 새로고침할 때마다 모아둔 기록을 스스로 지웠습니다. → 빈 배열은 쓰지 않습니다.
4. **할당량 초과** — 상한이 없으면 종일 켜둔 화면이 할당량을 넘겨 저장이 **통째로** 실패합니다. → 500건 상한. 추이가 5분 칸이라 앞쪽을 잘라도 최근 구간의 모양은 그대로입니다.

**실패는 전부 빈 배열로.** 시크릿 모드 차단·손상된 값·계약이 바뀐 옛 기록 셋 다 "모아둔 게 없다"와 결과가 같고, 살려봐야 차트만 이상해집니다.

**`mergeArchive`는 순수 함수입니다.** 저장소를 건드리지 않아서 `environment: 'node'`인 vitest가 그대로 붙습니다.

> **알려진 한계 (리뷰 시 봐주세요)**
> 주최자가 **숨긴 소감**은 다음 스냅샷부터 빠지지만 이 기록에는 남습니다. 공개 뷰에 `status`가 없어서(계약상 의도적 제외) 화면이 숨김 여부를 알 방법이 없습니다. 타일·도넛은 서버 집계라 영향이 없고 **추이 차트만** 그 건을 계속 셉니다.
>
> 그리고 이 기록이 담는 건 "강연자가 화면을 켜둔 구간"입니다. 켜기 전에 들어온 소감은 마지막 50건까지만 잡힙니다. 그래서 **화면과 PDF 양쪽에 각주**를 답니다 — 알려주지 않으면 추이와 다른 숫자가 어긋난 것으로 읽힙니다.

### 2. 왜 AI 요약을 백엔드가 아니라 Route Handler에서 부르나 (`app/api/summary/route.ts`)

주최자 리포트(`POST /events/{code}/report/generate`)로는 안 됩니다. 그쪽은 (1) 주최자 계정이 있어야 하고, (2) 이벤트가 `ENDED`여야 하며, (3) `Report`에 `sessionId`가 없어서 **애초에 이벤트 전체 요약**입니다. 강연자가 자기 세션 것을 발표 직후에 받으려면 지금 계약으로는 길이 없습니다. 백엔드에 새로 요청하는 대신 이 레포의 Route Handler에서 부르면 프론트 PR 하나로 끝납니다.

**서버에 두는 것 둘, 각각 이유가 다릅니다.**

- **키** — `OPENROUTER_API_KEY`에 `NEXT_PUBLIC_` 접두사가 없어 브라우저 번들에 실리지 않습니다. 이 화면은 **로그인 없는 공개 페이지**라, 번들에 들어가면 주소를 아는 누구나 꺼내 우리 크레딧을 씁니다.
- **소감 본문** — 클라이언트에서 받지 않고 서버가 공개 API로 직접 받아옵니다. 이 경로에는 인증이 없어서, 본문을 그대로 받아 모델에 넘기면 **누구나 우리 크레딧으로 아무 프롬프트나 돌리는 무료 프록시**가 됩니다. 그래서 `eventCode`·`sessionId`만 받고 프롬프트도 서버가 조립합니다.

**트러블슈팅 — 빈 응답.** 처음에는 본문이 빈 채로 `finish_reason: "length"`만 왔습니다. 추론 토큰이 `max_tokens`를 통째로 먹은 것이었습니다(2026-08-25 실측: 500토큰을 영어 사고 과정에 다 쓰고 요약을 한 글자도 못 냈습니다).

- `reasoning: { effort: 'none' }`으로 껐습니다.
- `exclude: true`가 **아닌** 이유: 저쪽은 추론을 생성은 하고 응답에서 숨기기만 해서 **비용이 그대로** 나갑니다. 소감 몇십 건을 한 문단으로 줄이는 일에 추론은 필요 없습니다.
- 상한도 1000토큰으로 올렸습니다. `effort: 'none'`을 무시하는 모델을 만나도 본문이 통째로 잘리지는 않게 하는 완충이자 비용 상한입니다.

**실패 사유를 코드로 나눈 이유.** `SUMMARY_NOT_CONFIGURED` / `NO_FEEDBACK` / `SUMMARY_FAILED` — 설정 누락은 사용자가 할 수 있는 일이 없고 호출 실패는 다시 눌러볼 만합니다. 하나로 뭉치면 화면이 다음 행동을 안내할 수 없습니다. 업스트림 응답 원문은 **개발 환경에서만** 실어 보냅니다.

**요약값은 훅 state에만.** 저장해두면 소감이 계속 들어오는 동안 옛 요약이 최신인 척 남습니다. 버튼 한 번이면 다시 만들어지므로 새로고침에 사라지는 편이 낫습니다. 단, 만들어둔 요약은 같은 세션에 머무는 동안 PDF에도 함께 실립니다.

**자동 호출 안 합니다.** 호출마다 비용이 나가는데 강연 중에는 소감이 계속 들어와서, 자동이면 화면을 열어둔 내내 갱신됩니다.

### 3. 왜 세션은 SSE고 이벤트 상태는 폴링인가 (`hooks/useSpeakerSessionMeta.ts`)

**이게 없을 때 실제로 나던 문제:** 주최자가 강연 중에 세션을 `CLOSED`로 내려도 배지가 `소감 받는 중`으로 남았습니다. 이벤트를 종료해도 `LIVE`인 줄 알고 급변 배너를 계속 띄웠습니다. 둘 다 **한 번 받고 끝**이었기 때문입니다.

갱신 수단이 갈리는 건 명세 때문입니다 — 스트림 3종에 이벤트가 없어서 이벤트 상태는 폴링밖에 없습니다(`useEventEntryFeed`가 같은 이유로 같은 선택을 했습니다). CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 **갱신 방식을 아는 코드는 이 훅에만** 둡니다. 화면은 `EventSource`도 폴링 간격도 모릅니다.

**SSE가 조용히 죽는 경우.** 압축 계층이 SSE를 막으면 응답이 200에 `text/event-stream`이라 브라우저는 정상 연결로 보고 `open`까지 띄우는데 **본문만 안 옵니다**(#261). `onerror`로는 못 잡습니다. → 첫 스냅샷 워치독(5초)을 걸고, 안 오면 폴링으로 넘깁니다.

> 워치독을 **스냅샷마다 다시 걸지 않는 게** 중요합니다. 다시 걸면 세션이 한동안 안 바뀌는 조용한 구간을 고장으로 잘못 읽습니다. 구분점은 "연결 직후 1건"이라는 명세의 보장입니다.

**`EventSource`는 `apiClient`를 거치지 않습니다.** `endpoints.ts`의 응답 검증이 통째로 우회되므로 훅에서 계약 스키마로 다시 걸러줍니다. 안 그러면 "계약과 다른 응답을 화면까지 흘리지 않는다"는 규칙이 실시간 경로에서만 사라집니다.

**`ENDED`면 스스로 끕니다.** 전이가 `DRAFT → LIVE → ENDED` 단방향이라 되돌아올 일이 없습니다.

### 4. 잘못된 주소를 두 단계로 거르는 이유

| 단계 | 무엇을 | 왜 |
| --- | --- | --- |
| 페이지(`page.tsx`) | 숫자가 아니거나 0 이하인 `sessionId` → `notFound()` | 그대로 넘기면 `Number()`가 `NaN`이 되어 어떤 세션과도 안 맞는데, 화면에는 "세션을 찾을 수 없어요"가 떠서 **삭제된 세션과 구분이 안 됩니다.** 주소가 잘못된 것은 404가 맞습니다 |
| 화면(`SpeakerSessionView`) | 목록에 없는 id → `EmptyState` | 삭제된 세션을 가리키는 옛 링크가 **"0개 소감 · 긍정 0%"라는 멀쩡해 보이는 빈 집계**를 그리는 걸 막습니다(`LiveResult`와 같은 판정) |

### 5. 헤더 배치 — 버튼 넷을 흩은 이유

처음에는 링크 복사·참가자 QR·요약 만들기·PDF 넷이 헤더 오른쪽에 한 줄로 섰습니다. 라벨 포함 약 500px이 상시 자리를 차지해서 답답했습니다.

2열이나 드롭다운으로 묶는 대신 **각 조치를 자기가 작용하는 대상 옆으로 흩었습니다.** 묶기가 애매한 이유가 "버튼마다 대상이 다르다"는 것이었으므로, 그걸 문제가 아니라 답으로 썼습니다.

| 조치 | 자리 | 왜 |
| --- | --- | --- |
| 링크 복사 · QR | 주소 줄 | 둘 다 그 주소에 거는 조치인데 주소는 왼쪽, 버튼은 오른쪽으로 갈라져 있었습니다 |
| 요약 만들기 | AI 요약 카드 헤더 | 결과가 그 카드에 그려집니다. 카드의 `justify-between`이 자식 하나뿐인 채 남아 있어서 원래 그 자리였던 흔적이 있었습니다 |
| PDF 내보내기 | 헤더 (유지) | 화면 전체를 내보내는 조치라 특정 카드에 붙일 수 없습니다 |
| 상태 배지 | 세션 제목 옆 | 조치가 아니라 세션의 **속성**입니다. 조치 쪽에 섞어두면 눌러야 하는 것으로 읽힙니다 |

**주소 옆 조치가 `Button`이 아닌 이유.** `Button`의 BASE에 `text-base font-semibold`·`px-5`·보더가 박혀 있어서 12px 주소 옆에 두면 크기가 겉돕니다. className으로 덮는 건 **Tailwind가 속성 순서가 아니라 스타일시트 순서로 이겨서** 믿을 수 없습니다. 그래서 `Header`의 로그아웃과 같은 밑줄 텍스트 버튼을 씁니다.

**라벨은 `DashboardHeader`에 맞췄습니다** (`QR`, `PDF 내보내기`). 두 화면에서 갈리면 나중에 한쪽만 고쳐집니다.

**PDF는 요약을 만들기 전까지 비활성입니다.** 문서에서 「AI 요약」 칸이 통째로 빠져(`SpeakerPrintDocument`의 `summaryText !== null`) 화면에서 본 것과 다른 문서가 나갑니다. 숨기지 않고 비활성으로 두는 건, 사라지면 **원래 없는 기능인지 지금만 못 쓰는 건지 구분이 안 되기** 때문입니다. 사유 문구는 감싼 div의 `title`로 답니다 — 비활성 버튼은 포인터 이벤트를 받지 않아 자신에게 붙은 `title`을 못 띄웁니다.

### 6. 왜 레이아웃을 따로 만들었나 (`app/speaker/layout.tsx`)

- `app/(host)`의 `HostHeader` ✗ — `useAuth`로 이메일과 로그아웃을 그리는데 강연자는 계정이 없어 보여줄 값이 없고 `/auth/me` 요청만 새로 나갑니다.
- `app/e`의 참가자 레이아웃 ✗ — QR로 들어오는 모바일 전용이라 `max-w-md` 한 열인데, 이 화면은 강연 중 노트북에 띄워두는 모니터링 화면입니다.
- 로고에 링크를 걸지 않습니다 — 강연자에게는 돌아갈 상위 화면이 없습니다. 이벤트 홈은 참가자용 제출 화면이고 주최자 화면은 로그인이 필요합니다.

### 7. 계산을 왜 두 파일로 나눴나

`components/dashboard/metrics.ts`(대시보드)와 `components/speaker/speakerMetrics.ts`(강연자)는 **입력이 다릅니다.** 저쪽은 소감 원본 배열을 받아 직접 세고, 이쪽은 서버가 이미 세어 보낸 집계를 받아 모양만 맞춥니다.

그래도 **비율 규칙은 같아야 합니다** — 분모에서 미분류를 뺍니다. `UNKNOWN`은 태깅 실패라 "중립"과 다르고, 분모에 넣으면 분석이 많이 실패할수록 긍정 비율이 저절로 내려갑니다. 규칙이 갈라지면 같은 세션을 주최자와 강연자가 나란히 봤을 때 긍정 비율이 다르게 뜹니다.

추이 계산만은 **한 벌을 나눠 씁니다.** 그래서 `TrendInput = Pick<Feedback, 'createdAt' | 'sentiment'>`로 인자를 좁혔습니다(커밋 `ee8d66f`). 공개 뷰에 `toxic`·`status`가 없어도 추이에 필요한 두 필드는 있습니다.

### 8. 공통화하지 않은 곳과 그 이유

- **세션 스트림 배선** — `useEventEntryFeed`와 거의 같지만 합치지 않았습니다. 호출부가 둘뿐이고 나머지가 다릅니다(저쪽은 SSR `initialData`를 받고 리포트 폴링까지 조율). 공통화하면 `enabled`·`initialData`·쿼리 키를 전부 인자로 받게 되어 도리어 읽기 어려워집니다. **세 번째 소비자가 생기면 그때** 빼는 게 맞습니다. 다만 스트림 계약(이벤트 이름·타임아웃)이 바뀌면 두 파일을 함께 고쳐야 합니다.
- **급변 배너 배선** — `useSentimentAlerts`로 뽑았지만 `DashboardView`에는 아직 같은 배선이 인라인으로 남아 있습니다. 판정 규칙 자체는 이미 `metrics.ts` 한 곳에 있어서 갈라진 건 상태 배선뿐입니다. 이 PR 범위를 넘어서 손대지 않았습니다.
<img width="1916" height="954" alt="스크린샷 2026-08-26 140555" src="https://github.com/user-attachments/assets/49561a45-8cd2-44e7-9a2e-33425651416f" />

<img width="411" height="880" alt="스크린샷 2026-08-26 140607" src="https://github.com/user-attachments/assets/21f34517-513e-4d5b-a07b-c43adbbf4b69" />

## 관련 이슈

- Closes #275

이슈의 "남는 일" 중 예시 환경 변수 파일은 이 PR에 포함했습니다. 강연자료(PDF/PPTX) 업로드 건은 이슈에 적힌 대로 별도 이슈입니다.
모바일 레이아웃은 추후 수정 예정입니다.

## 검증 방법

```
npm run lint    ✓ 0 error / 1 warning
npm run test    ✓ Test Files 8 passed, Tests 157 passed
npm run build   ✓ Compiled successfully
```

- **lint 경고 1건은 이 PR과 무관합니다.** `DashboardView.tsx:169`의 `react-hooks/exhaustive-deps`로, 이 브랜치에서 그 파일은 dev와 바이트 단위로 동일합니다.
- **build 라우트 확인** — `ƒ /speaker/[eventCode]/[sessionId]`, `ƒ /api/summary` 둘 다 생성됩니다.
- **새 유닛 테스트 2벌** — `lib/storage/sessionArchive.test.ts`(병합·중복 제거·상한·참조 동일성), `components/speaker/speakerMetrics.test.ts`(비율 분모에서 미분류 제외, 0건 처리).

**수동 확인 절차**

1. 주최자로 이벤트를 `LIVE`로 올리고 세션 id를 확인합니다.
2. `/speaker/{eventCode}/{sessionId}`를 **로그아웃 상태**(또는 시크릿 창)로 엽니다 → `/login`으로 안 튕기는지.
3. 참가자로 소감을 몇 건 넣습니다 → 타일·도넛·피드가 2초 안에 갱신되는지.
4. 새로고침합니다 → 추이 차트가 0부터 다시 시작하지 않는지(= localStorage 누적이 도는지).
5. `요약 만들기`를 누릅니다 → 문단이 뜨고, 그 전까지 `PDF 내보내기`가 비활성인지.
6. `PDF 내보내기` → 인쇄 미리보기에 「AI 요약」 칸과 소감 원문 2단이 나오는지.
7. 주최자가 세션을 `CLOSED`로 내립니다 → 배지가 `소감 받기 멈춤`으로 바뀌는지.
8. 없는 세션 id·문자열 id로 접속 → 각각 `EmptyState`와 404인지.

## 영향 범위

- **새 환경 변수: 있음** ⚠️ (예시 파일에 줄은 추가했지만 **값은 각자 채워야 합니다**)
  - `OPENROUTER_API_KEY` (필수) — 키는 노션 참조. 없으면 요약 버튼이 `요약 기능이 아직 설정되지 않았어요`를 띄웁니다. **나머지 화면은 정상 동작합니다.**
  - `OPENROUTER_MODEL` (선택) — **넣지 않는 것이 기본입니다.** 없으면 코드 기본값 `qwen/qwen3.7-flash`가 쓰이고, 그게 팀이 쓰기로 한 모델입니다. 다른 모델을 시험할 때만 로컬에 넣으세요.
  - Vercel 배포에는 `OPENROUTER_API_KEY` **하나만** 넣으면 됩니다.
- **의존성 추가: 없음**
- **Breaking Change: 없음**
  - `buildTrend`·`isPositiveSurging`의 인자 타입이 `Feedback[]` → `TrendInput[]`로 **넓어졌습니다.** 기존 호출부는 `Feedback[]`이 그대로 대입되므로 수정할 게 없습니다.
  - `localStorage` 키 `pulse:archive:*`가 새로 생깁니다. 기존 키와 겹치지 않습니다.

## 트러블슈팅 및 참고 사항

**리뷰 시 특히 봐주셨으면 하는 것**

1. **요약 모델은 `qwen/qwen3.7-flash`로 통일했습니다**(`dfd78fe`). 배포에는 키만 넣고 `OPENROUTER_MODEL`은 두지 않기로 해서, 코드 기본값이 곧 배포에서 도는 모델입니다. 다만 qwen3.7-flash는 위 §2에 적은 **빈 응답 문제를 실제로 냈던 모델**입니다. `reasoning.effort: 'none'`을 넣은 뒤로는 재현되지 않았지만, 배포 후 요약이 실제로 나오는지 한 번 확인해주세요.
2. **숨긴 소감이 추이에 남는 문제** (위 §1 알려진 한계). 공개 뷰에 `status`가 없어서 지금 계약으로는 화면이 알 방법이 없습니다. 계약을 바꿔야 할 만큼 중요한지 판단이 필요합니다.
3. **`localStorage` 500건 상한**이 적절한지. 5분 칸 기준으로는 충분하다고 봤는데, 종일 행사에서 실측해본 적은 없습니다.
4. **`app/api/summary`가 인증 없는 공개 경로**라는 점. 소감 본문을 받지 않아 무료 프록시는 막았지만, `eventCode`·`sessionId`만 알면 누구나 요약을 만들 수 있어 **호출 횟수 제한은 없습니다.** 크레딧 소진이 걱정되면 rate limit을 별도 이슈로 뺄지 논의가 필요합니다.

**이 PR에서 일부러 하지 않은 것**

- **주최자 대시보드에 강연자 화면 링크를 노출하는 작업.** 작업했다가 되돌렸습니다 — 대시보드는 세션 미선택(기본값 "전체")이 가능한데 강연자 화면은 세션별이라, 그 상태에서 완성된 주소를 만들 수 없습니다. `/speaker/{code}/` 같은 404 주소가 헤더에 뜨게 됩니다. 별도로 다뤄야 합니다.
- `DashboardView`의 급변 배너 배선을 `useSentimentAlerts`로 옮기는 리팩토링(위 §8).
- 강연자료 업로드 후 요약 프롬프트에 배경으로 끼워넣기 — 별도 이슈입니다.

**접근성 관련 남은 빚**

`PDF 내보내기`가 비활성일 때 사유를 `title`로만 알립니다. `disabled` 버튼은 탭 순서에서 빠져서 키보드·스크린리더 사용자는 사유를 듣지 못합니다. 제대로 하려면 `aria-disabled` + 포커스 유지 + `aria-describedby`인데, 레포 전체가 평범한 `disabled`를 쓰고 있어 이 파일만 다르게 가지 않았습니다. 팀 차원에서 한 번에 맞추는 게 맞다고 봅니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (강연자 세션 화면 하나)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
