### PR TITLE
feat(events): 이벤트를 복제해 새 이벤트를 만든다

### DIFF
--- a/app/(host)/events/new/page.tsx
+++ b/app/(host)/events/new/page.tsx
@@ -1,10 +1,18 @@
 import EventForm from '@/components/events/EventForm';
 
-const NewEventPage = () => {
+interface NewEventPageProps {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}
+
+const NewEventPage = async ({ searchParams }: NewEventPageProps) => {
   // API: POST /events. events/page.tsx의 "새 이벤트 만들기" 버튼이 이 페이지로 이동합니다.
+  let { duplicateFrom } = await searchParams;
+
+  duplicateFrom = typeof duplicateFrom === 'string' ? duplicateFrom : undefined;
+
   return (
     <div className="w-full flex flex-col items-center gap-6 px-14 py-8 bg-background-default">
-      <EventForm />
+      <EventForm duplicateFrom={duplicateFrom} />
     </div>
   );
 };

--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -1,9 +1,13 @@
-import { PulseEvent } from '@/lib/schemas/api';
+import Link from 'next/link';
+import { type MouseEvent } from 'react';
+
 import { Badge } from '@/components/ui/Badge';
 import { ChevronRightIcon } from '@/components/ui/icons';
-import Link from 'next/link';
-import formatEventDate from '@/lib/formatEventDate';
 import { EVENT_STATUS_BADGE } from '@/components/events/eventStatusBadge';
+
+import { PulseEvent } from '@/lib/schemas/api';
+import formatEventDate from '@/lib/formatEventDate';
+import { useRouter } from 'next/navigation';
 
 export interface EventCardProps {
   event: PulseEvent;
@@ -28,13 +32,24 @@ const ROUTE_BY_STATUS = {
 };
 
 const EventCard = ({ event }: EventCardProps) => {
-  if (event.status === 'DELETED') return;
+  const router = useRouter();
+
+  if (event.status === 'DELETED') {
+    return;
+  }
 
   const { tone, label } = EVENT_STATUS_BADGE[event.status];
 
   const datetime = formatEventDate(event.eventDate);
   const rightContent = RIGHT_CONTENT_BY_STATUS[event.status](event);
   const href = ROUTE_BY_STATUS[event.status](event);
+  const eventCode = event.code;
+
+  const handleDuplicateClick = (event: MouseEvent<HTMLButtonElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    router.push(`/events/new?duplicateFrom=${eventCode}`);
+  };
 
   return (
     <Link
@@ -52,6 +67,9 @@ const EventCard = ({ event }: EventCardProps) => {
       </div>
       <div className="flex items-center gap-2">
         <p className={rightContent.className}>{rightContent.label}</p>
+        <button type="button" onClick={handleDuplicateClick}>
+          복제
+        </button>
         <ChevronRightIcon className="h-4.5 w-4.5 text-text-primary" />
       </div>
     </Link>

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -28,6 +28,7 @@ import { ApiError } from '@/lib/apiClient';
 interface EventFormProps {
   /** 있으면 수정 모드(기존 값 로드 + PATCH), 없으면 생성 모드(POST)입니다. */
   eventCode?: string;
+  duplicateFrom?: string;
 }
 
 type EventFormInputs = {
@@ -42,10 +43,64 @@ type EventFormErrors = {
   eventDate?: string;
 };
 
+type IncompleteCleanup = {
+  eventTitle: string;
+  failedSessionTitles: string[];
+  eventDeleted: boolean;
+} | null;
+
+type UndeletedItem = {
+  type: '이벤트' | '세션';
+  title: string;
+};
+
 const initialEventFormInputs: EventFormInputs = {
   title: '',
   description: '',
   eventDate: '',
+};
+
+/**
+ * 세션 및 이벤트를 삭제하는 헬퍼 함수
+ * @param deleteFn
+ * @param maxRetries
+ */
+const deleteWithRetry = async (
+  deleteFn: () => Promise<void>,
+  maxRetries: number,
+): Promise<boolean> => {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await deleteFn();
+      return true;
+    } catch (error) {
+      const isAlreadyDeleted =
+        error instanceof ApiError &&
+        (error.code === 'EVENT_ALREADY_DELETED' || error.code === 'SESSION_ALREADY_DELETED');
+
+      if (isAlreadyDeleted) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const getUndeletedItems = (failure: IncompleteCleanup): UndeletedItem[] => {
+  if (!failure) {
+    return [];
+  }
+
+  const items: UndeletedItem[] = failure.failedSessionTitles.map((title) => ({
+    type: '세션' as const,
+    title,
+  }));
+
+  if (!failure.eventDeleted) {
+    items.unshift({ type: '이벤트', title: failure.eventTitle });
+  }
+
+  return items;
 };
 
 // 이벤트 등록/수정 공용 폼. 세션 추가·수정·삭제는 페이지 이동 없이 이 컴포넌트
@@ -54,8 +109,9 @@ const initialEventFormInputs: EventFormInputs = {
 // DELETE /events/{eventCode}(삭제), POST /events/{eventCode}/sessions(세션 추가),
 // PATCH /events/{eventCode}/sessions/{sessionId}(세션 수정),
 // DELETE /events/{eventCode}/sessions/{sessionId}(세션 삭제).
-const EventForm = ({ eventCode }: EventFormProps) => {
+const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
   const isEditMode = Boolean(eventCode);
+  const isDuplicateMode = Boolean(duplicateFrom);
   const router = useRouter();
   const queryClient = useQueryClient();
 
@@ -69,16 +125,20 @@ const EventForm = ({ eventCode }: EventFormProps) => {
   const [editingSessionTitle, setEditingSessionTitle] = useState('');
   const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null);
 
+  const [incompleteCleanup, setIncompleteCleanup] = useState<IncompleteCleanup>(null);
+
+  const targetCode = isEditMode ? eventCode : duplicateFrom;
+
   const eventQuery = useQuery({
-    queryKey: ['event', eventCode],
-    queryFn: () => fetchEventByCode(eventCode as string),
-    enabled: isEditMode,
+    queryKey: ['event', targetCode],
+    queryFn: () => fetchEventByCode(targetCode as string),
+    enabled: isEditMode || isDuplicateMode,
   });
 
   const sessionsQuery = useQuery({
-    queryKey: ['sessions', eventCode],
-    queryFn: () => fetchSessionsByEventCode(eventCode as string),
-    enabled: isEditMode,
+    queryKey: ['sessions', targetCode],
+    queryFn: () => fetchSessionsByEventCode(targetCode as string),
+    enabled: isEditMode || isDuplicateMode,
   });
   const sessions: SessionView[] = sessionsQuery.data ?? [];
 
@@ -94,7 +154,7 @@ const EventForm = ({ eventCode }: EventFormProps) => {
     setEventFormInputs({
       title: eventQuery.data.title,
       description: eventQuery.data.description ?? '',
-      eventDate: eventQuery.data.eventDate,
+      eventDate: isEditMode ? eventQuery.data.eventDate : '',
     });
   }
 
@@ -103,8 +163,54 @@ const EventForm = ({ eventCode }: EventFormProps) => {
     isPending: isSaving,
     error: saveError,
   } = useMutation({
-    mutationFn: (body: EventFormInputs) =>
-      isEditMode ? updateEvent(eventCode as string, body) : createEvent(body),
+    mutationFn: async (body: EventFormInputs) => {
+      if (isEditMode) {
+        return updateEvent(eventCode as string, body);
+      }
+
+      const newEvent = await createEvent(body);
+      const createdSessions: { id: number; title: string }[] = [];
+
+      if (isDuplicateMode) {
+        try {
+          for (const session of sessions) {
+            const createdSession = await createSession(newEvent.code, {
+              title: session.title,
+              order: session.order,
+            });
+
+            createdSessions.push({
+              id: createdSession.id,
+              title: createdSession.title,
+            });
+          }
+        } catch (error) {
+          const sessionDeleteResults = await Promise.all(
+            createdSessions.map(async (session) => ({
+              title: session.title,
+              succeeded: await deleteWithRetry(() => deleteSession(newEvent.code, session.id), 3),
+            })),
+          );
+
+          const eventDeleteResult = await deleteWithRetry(() => deleteEvent(newEvent.code), 3);
+
+          const failedSessionTitles = sessionDeleteResults
+            .filter((result) => !result.succeeded)
+            .map((result) => result.title);
+
+          if (failedSessionTitles.length > 0 || !eventDeleteResult) {
+            setIncompleteCleanup({
+              eventTitle: newEvent.title,
+              failedSessionTitles,
+              eventDeleted: eventDeleteResult,
+            });
+          }
+
+          throw error;
+        }
+      }
+      return newEvent;
+    },
     onSuccess: () => {
       if (isEditMode) {
         queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
@@ -375,6 +481,16 @@ const EventForm = ({ eventCode }: EventFormProps) => {
             {isEditMode
               ? '이벤트를 저장하지 못했습니다. 잠시 후 다시 시도해주세요.'
               : '이벤트를 등록하지 못했습니다. 잠시 후 다시 시도해주세요.'}
+          </Banner>
+        ) : null}
+
+        {incompleteCleanup ? (
+          <Banner type="negative" className="w-full">
+            {`다음 항목이 정리되지 않았습니다. 
+            ${getUndeletedItems(incompleteCleanup)
+              .map((item) => `${item.type} ${item.title}`)
+              .join(', ')}
+            이벤트 목록에서 직접 삭제해주세요.`}
           </Banner>
         ) : null}
 

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -486,11 +486,11 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
 
         {incompleteCleanup ? (
           <Banner type="negative" className="w-full">
-            {`다음 항목이 정리되지 않았습니다. 
-            ${getUndeletedItems(incompleteCleanup)
-              .map((item) => `${item.type} ${item.title}`)
-              .join(', ')}
-            이벤트 목록에서 직접 삭제해주세요.`}
+            <span className="whitespace-pre-line">
+              {`다음 항목이 정리되지 않았습니다.\n${getUndeletedItems(incompleteCleanup)
+                .map((item) => `${item.type} '${item.title}'`)
+                .join(', ')}\n이벤트 목록에서 직접 삭제해주세요.`}
+            </span>
           </Banner>
         ) : null}
 


### PR DESCRIPTION
## 변경 사항

이벤트 목록 카드에 복제 버튼을 추가해, 기존 이벤트의 제목·설명·세션 목록을 그대로 가져와 새 이벤트를 등록할 수 있게 합니다.
새 이벤트의 행사 날짜는 원본 값을 가져오지 않고 사용자가 직접 입력해야 합니다.

### 정상적으로 동작하는 경우

- 이벤트 목록 화면에서 카드의 복제 버튼을 누르면, 새 이벤트 생성 화면(`/events/new?duplicateFrom={원본코드}`)으로 이동합니다.
- 제목·설명은 원본 값으로 미리 채워지고, 행사 날짜는 비어 있어 사용자가 직접 입력해야 합니다.
- 등록을 누르면 새 이벤트를 생성한 뒤, 원본 세션들을 순서를 지켜 순차로 생성합니다.

### 실패하는 경우

- 세션 생성 도중 하나라도 실패하면, 지금까지 만든 세션과 새 이벤트를 되돌립니다. 세션을 먼저 지우고 이벤트를 나중에 지우는 순서입니다.
  이벤트를 먼저 지우면 소프트 삭제로 상태만 바뀌는데, 그러면 그 이벤트 밑 세션을 지우려는 요청이 `EVENT_NOT_FOUND`로 거절되기 때문입니다.
- 되돌리는 삭제 요청도 실패할 수 있는데, 이미 삭제된 항목(409 응답)은 성공으로 간주하고 최대 3회까지 재시도합니다.
- 재시도 후에도 정리되지 않은 항목이 남으면, 어떤 이벤트·세션인지 Banner로 안내하고 이벤트 목록에서 직접 삭제하도록 안내합니다.

## 개발 과정 로그

| 커밋 | 메시지 | 이유 / 결정 |
| ---- | ------ | ----------- |
| df539ad | feat(events): 이벤트를 복제해 새 이벤트를 만든다 | 복제 기능 전체(진입점, 원본 값 채우기, 세션 순차 생성, 실패 시 되돌리기, 재시도) 구현 |
| a2fcba1 | fix(events): 정리 실패 안내 배너에 줄바꿈을 적용한다 | 정리되지 않은 항목이 여러 개면 한 줄로 이어져 가독성이 떨어지는 문제를 브라우저 검증 중 발견해 수정 |

## 참고 사항

### 복제 버튼의 아이콘화·배치 개선은 별도 이슈·PR로 진행합니다

리뷰 중 복제 버튼이 텍스트("복제")로 되어 있고, 카드 우측에서 상태별 텍스트(URL 등)·화살표 아이콘과 한 줄에 몰려 있어 시각적으로 복잡하다는 의견이 나왔습니다.
이 PR의 목적(복제 기능 자체의 동작)과는 다른 관심사라, 별도 이슈([#279](https://github.com/HANCOM-E/pulse-frontend/issues/279))로 분리해서 이 PR이 머지된 뒤 새 PR로 진행합니다.

## 관련 이슈

- Closes #273
