### PR TITLE
fix(events): 행사 날짜 미입력 시 한국어 에러 메시지를 노출한다

### DIFF
--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -84,7 +84,7 @@ const isoDateTime = z.iso.datetime();
  * UTC보다 서쪽 지역에서는 하루 앞선 날짜로 보입니다(명세 2026-08-12 경고). 화면까지
  * 문자열로 나르고, 포맷이 필요하면 그 자리에서 연·월·일을 직접 쪼개 씁니다.
  */
-const calendarDate = z.iso.date();
+const calendarDate = z.iso.date('행사 날짜를 선택해 주세요.');
 
 /**
  * 집계 개수. 0은 나오지만 음수는 나올 수 없습니다.


### PR DESCRIPTION
## 변경 사항

**`lib/schemas/api.ts:87`의 `calendarDate`(행사 날짜 값을 검증하는 스키마)** 에 한국어 커스텀 에러 메시지를 추가했습니다.

- AS-IS: 지금은 `calendarDate`에 커스텀 에러 메시지가 지정되어 있지 않습니다.  
  그래서 검증에 실패하면 zod 기본 영어 메시지("Invalid ISO date")가 그대로 노출되고 있습니다.
- TO-BE: `z.iso.date('행사 날짜를 선택해 주세요.')`처럼 메시지 인자를 추가해, 
   다른 필드(`title` 등)와 동일하게 한국어 메시지가 노출되도록 고쳤습니다.

`calendarDate`는 이벤트 생성 요청 스키마(`eventCreateRequestSchema`)와 
수정 요청 스키마(`eventUpdateRequestSchema`)에서 공유되는 스키마입니다.  
그래서 이 스키마 하나만 고치면 이벤트 생성 화면과 수정 화면 양쪽 모두에 반영됩니다.

## 관련 이슈

- Closes #278

## 검증 방법

### 실행한 명령

- `npx tsc --noEmit`: 에러 없이 통과했습니다.
- `npm run lint`: 이번 변경과 무관한 기존 경고 1건(`components/dashboard/DashboardView.tsx:169`)만 있고, 
    이번 변경으로 인한 에러·경고는 없습니다.

### 행사 날짜를 비운 채 등록·수정을 시도하는 경우 (이 PR을 반영한 뒤 기준)

이벤트 생성 화면과 수정 화면 모두, 행사 날짜(`eventDate`) 입력란을 비운 채 제출 버튼을 누르면 
입력란 아래에 "행사 날짜를 선택해 주세요."라는 한국어 메시지가 뜹니다.  
더 이상 "Invalid ISO date" 영어 메시지가 노출되지 않습니다.

### 스크린샷

- 이벤트 생성 화면 — 행사 날짜를 비운 채 등록을 시도해 한국어 에러 메시지가 뜬 상태
> <img width="700" height="" alt="shot-mtatg9o2" src="https://github.com/user-attachments/assets/2f9d5825-f742-47ff-be32-cbc8c6ea93f5" />

- 이벤트 수정 화면 — 행사 날짜를 비운 채 수정을 시도해 한국어 에러 메시지가 뜬 상태
> <img width="700" height="" alt="shot-mtatgsz2" src="https://github.com/user-attachments/assets/4f0081e5-0908-4484-8a0d-467c90534a8b" />

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략합니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 의도하지 않은 내용이 없습니다.
