### PR TITLE
fix(events): 이벤트 카드의 복제 버튼을 아이콘으로 바꾸고 배치를 조정한다

### DIFF
--- a/components/events/EventCard.tsx
+++ b/components/events/EventCard.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import { type MouseEvent } from 'react';
 
 import { Badge } from '@/components/ui/Badge';
-import { ChevronRightIcon } from '@/components/ui/icons';
+import { ChevronRightIcon, DuplicateIcon } from '@/components/ui/icons';
 import { EVENT_STATUS_BADGE } from '@/components/events/eventStatusBadge';
 
 import { PulseEvent } from '@/lib/schemas/api';
@@ -65,12 +65,20 @@ const EventCard = ({ event }: EventCardProps) => {
         </div>
         <p className="text-lg text-text-primary">{event.title}</p>
       </div>
-      <div className="flex items-center gap-2">
-        <p className={rightContent.className}>{rightContent.label}</p>
-        <button type="button" onClick={handleDuplicateClick}>
-          복제
+      <div className="flex flex-col items-end gap-1">
+        <button
+          type="button"
+          onClick={handleDuplicateClick}
+          aria-label="이벤트 복제"
+          title="이벤트 복제"
+          className="cursor-pointer text-text-tertiary transition-colors hover:text-text-primary"
+        >
+          <DuplicateIcon className="h-5 w-5" />
         </button>
-        <ChevronRightIcon className="h-4.5 w-4.5 text-text-primary" />
+        <div className="flex items-center gap-2">
+          <p className={rightContent.className}>{rightContent.label}</p>
+          <ChevronRightIcon className="h-4.5 w-4.5 text-text-primary" />
+        </div>
       </div>
     </Link>
   );

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -35,6 +35,33 @@ const InfoIcon = (props: IconProps) => (
   </svg>
 );
 
+const DuplicateIcon = (props: IconProps) => (
+  <svg width="16" height="16" viewBox="0 0 16 16" fill="none" {...props} aria-hidden="true">
+    <rect
+      x="2.5"
+      y="2.5"
+      width="8"
+      height="8"
+      rx="1.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <rect
+      x="5.5"
+      y="5.5"
+      width="8"
+      height="8"
+      rx="1.5"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 const ChevronRightIcon = (props: IconProps) => (
   <svg width="18" height="18" viewBox="0 0 18 18" fill="none" aria-hidden="true" {...props}>
     <path
@@ -59,5 +86,5 @@ const ChevronLeftIcon = (props: IconProps) => (
   </svg>
 );
 
-export { AlertIcon, CheckIcon, InfoIcon, XIcon, ChevronRightIcon, ChevronLeftIcon };
+export { AlertIcon, CheckIcon, InfoIcon, XIcon, DuplicateIcon, ChevronRightIcon, ChevronLeftIcon };
 export type { IconProps };


### PR DESCRIPTION
## 변경 사항

이벤트 카드(`EventCard.tsx`)의 복제 버튼을 텍스트("복제")에서 아이콘으로 바꾸고, 
카드 우측의 상태 텍스트·화살표 줄과 분리해 배치했습니다.

> <img width="782" height="" alt="shot-mtauwg3l" src="https://github.com/user-attachments/assets/4dc472c8-b011-4f71-952a-ece828eb0c3b" />

- **`components/ui/icons.tsx`** 에 겹친 사각형 두 개로 구성된 `DuplicateIcon`을 추가했습니다.
- **`components/events/EventCard.tsx`** 에서 복제 버튼의 텍스트를 `DuplicateIcon`으로 교체하고, 
   상태 텍스트·화살표 줄 위쪽 줄에 우측 정렬로 배치했습니다.
- 아이콘만 남은 버튼에 `aria-label="이벤트 복제"`와 `title="이벤트 복제"`를 추가해 
   스크린 리더 사용자와 아이콘 모양이 낯선 사용자 모두 의미를 확인할 수 있게 했습니다.
- hover 시 아이콘 색이 옅은 색(`text-text-tertiary`)에서 진한 색(`text-text-primary`)으로 바뀌도록 했고(`transition-colors`), 순수 `<button>` 요소라 자동 적용되지 않는 `cursor-pointer`를 명시적으로 추가했습니다.

## 관련 이슈

- Closes #279

## 검증 방법

### 실행한 명령과 결과

- `npx tsc --noEmit` — 통과했습니다.
- `npm run lint` — 이번 변경과 무관한 기존 경고 1개(`DashboardView.tsx`)만 남고 에러는 없습니다.

### 수동으로 확인한 절차와 결과 (이 PR을 반영한 뒤 기준)

- `/events` 목록 화면에서 LIVE·ENDED·DRAFT 각 상태 카드 모두 복제 아이콘이 상태 텍스트·화살표 위쪽 줄에 우측 정렬로 표시됩니다.
- 복제 아이콘에 마우스를 올리면 커서가 포인터로 바뀌고, 아이콘 색이 진해지며, 브라우저 기본 툴팁으로 "이벤트 복제" 문구가 뜹니다.
- 복제 아이콘을 클릭하면 카드 링크(`href`)로 이동하지 않고 `/events/new?duplicateFrom={code}`로 정상 이동합니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 아이콘 선 두께를 조정했습니다

`icons.tsx`의 다른 아이콘들은 `strokeWidth="2.5"`를 쓰지만, 이번 아이콘은 겹친 사각형 두 개로 구성되어 있어 같은 두께를 쓰면 선이 많이 겹쳐 지나치게 두꺼워 보였습니다.
`strokeWidth="1.5"`로 낮춰서 해결했습니다.

### 복제로 이동하는 등록 화면의 제목이 수정 화면과 같아 혼동될 수 있는 문제를 발견해 별도 이슈로 분리했습니다

이 PR을 검증하는 과정에서, 복제 버튼으로 이동하는 새 이벤트 등록 화면과 기존 이벤트 수정 화면이 화면 제목("이벤트 설정")을 공유해 헷갈릴 수 있다는 점을 발견했습니다.
이 PR이 다루는 복제 버튼 UI 범위 밖의 문제라 별도 이슈로 분리해뒀습니다(이슈 #282).

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
