### PR TITLE
fix(events): 등록/수정/복제 화면 제목을 모드별로 구분한다

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -330,6 +330,13 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
     return <ReportPanel />;
   }
 
+  let formTitle = '새 이벤트 만들기';
+  if (isEditMode) {
+    formTitle = '이벤트 수정하기';
+  } else if (isDuplicateMode) {
+    formTitle = '이벤트 복제하기';
+  }
+
   return (
     <>
       <div className="w-full max-w-190">
@@ -342,7 +349,7 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
           <ChevronLeftIcon className="h-6 w-6" />
         </button>
       </div>
-      <h1 className="w-full max-w-190 text-xl font-semibold text-text-primary">이벤트 설정</h1>
+      <h1 className="w-full max-w-190 text-xl font-semibold text-text-primary">{formTitle}</h1>
       <form onSubmit={handleFormSubmit} className="w-full max-w-190 flex flex-col gap-6">
         <Field
           label="제목"


### PR DESCRIPTION
## 변경 사항

이벤트 등록·수정·복제 화면에서 모드와 무관하게 같은 제목이 표시되던 문제를 고쳤습니다.

- `EventForm.tsx`(등록·수정·복제 화면에서 공통으로 쓰는 폼 컴포넌트입니다)에 이미 있는 `isEditMode`·`isDuplicateMode` 값(각각 `eventCode`·`duplicateFrom` prop의 존재 여부로 계산되는 값입니다)을 활용해, 화면 제목을 세 가지로 분기했습니다.

### 화면 제목이 모드와 무관하게 하나로 고정되어 있었습니다.

**이벤트 등록·수정·복제 세 가지 모드 각각에 다른 제목을 표시하도록 고쳤습니다.**
이렇게 고친 이유는 세 화면이 `EventForm.tsx`의 `<h1>` 텍스트("이벤트 설정")를 공유하고 있기 때문입니다.
그래서 화면에 진입해도 지금 등록 중인지 수정 중인지 복제 중인지 제목만으로 구분할 수 없었습니다.

- AS-IS: 지금은 `eventCode`·`duplicateFrom` 두 prop과 무관하게 "이벤트 설정" 한 가지 문구만 렌더링하고 있습니다.
- TO-BE: 아래 세 가지로 구분해서 표시합니다.
  - 순수 등록(`eventCode`·`duplicateFrom` 둘 다 없음): "새 이벤트 만들기"
  - 수정(`eventCode` 있음): "이벤트 수정하기"
  - 복제(`duplicateFrom` 있음): "이벤트 복제하기"
  
### 스크린샷
- **이벤트 등록 화면**
> <img width="600" height="" alt="SCR-20260827-kalw" src="https://github.com/user-attachments/assets/560a800a-d8a5-451e-a36a-cc91856717b1" />

- **이벤트 수정 화면**
> <img width="600" height="" alt="SCR-20260827-kaoc" src="https://github.com/user-attachments/assets/05192457-ee94-4397-9905-d94d9ee96ac0" />

- **이벤트 복제 화면**
> <img width="600" height="" alt="SCR-20260827-kapp" src="https://github.com/user-attachments/assets/0625a16d-dd93-4f95-94dd-f2de7b81c004" />



## 관련 이슈

- Closes #282

## 검증 방법

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

아래 항목은 전부 이 PR이 머지된 이후를 기준으로 한 설명입니다.

- 새 이벤트를 만들려고 이벤트 목록에서 등록 화면(`/events/new`)에 들어가면  
  화면 제목이 "새 이벤트 만들기"로 보입니다.
- 이벤트 카드의 복제 버튼을 눌러 복제 경로로 등록 화면(`/events/new?duplicateFrom=...`)에 들어가면  
  제목·행사 날짜·설명 필드에 원본 이벤트 값이 채워진 채로, 화면 제목이 "이벤트 복제하기"로 보입니다.
- 기존 이벤트를 눌러 수정 화면(`/events/{eventCode}`)에 들어가면  
  화면 제목이 "이벤트 수정하기"로 보입니다.

브라우저에서 위 세 가지 경로 모두 직접 확인했습니다.

타입 체크(`npx tsc --noEmit`)와 린트(`npm run lint`)도 통과했습니다.
린트 결과에는 `DashboardView.tsx`의 기존 경고 1건만 남아 있고, 이번 변경과는 무관합니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

