### PR TITLE
feat(game): 참가자 게임 화면을 만든다

### DIFF
--- a/app/e/[code]/game/page.tsx
+++ b/app/e/[code]/game/page.tsx
@@ -1,0 +1,35 @@
+import { notFound } from 'next/navigation';
+
+import { ParticipantGameView } from '@/components/game/ParticipantGameView';
+import { fetchCurrentGame } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+
+export const dynamic = 'force-dynamic';
+
+interface GamePageProps {
+  params: Promise<{ code: string }>;
+}
+
+/**
+ * 첫 게임만 서버에서 받아 넘깁니다. 상태 분기는 `ParticipantGameView`가 폴링 결과로
+ * 다시 계산합니다(`app/e/[code]/page.tsx`와 같은 구조).
+ *
+ * 열린 게임이 없으면 `fetchCurrentGame`이 404를 `null`로 삼켜서 옵니다. 그건 정상
+ * 상태라 `notFound()`가 아니라 화면에서 빈 상태로 그립니다.
+ */
+const GamePage = async ({ params }: GamePageProps) => {
+  const { code } = await params;
+
+  const game = await fetchCurrentGame(code).catch((error: unknown) => {
+    if (error instanceof ApiError && error.code === 'EVENT_NOT_FOUND') notFound();
+    throw error;
+  });
+
+  return (
+    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+      <ParticipantGameView eventCode={code} initialGame={game} />
+    </main>
+  );
+};
+
+export default GamePage;

--- a/components/game/GameJoinForm.tsx
+++ b/components/game/GameJoinForm.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { isToxic } from '@/lib/tagger/tagger';
+import { useState } from 'react';
+import { Field } from '../ui/Field';
+import { Button } from '../ui/Button';
+
+/**
+ * 닉네임을 받아 게임에 참가시킵니다.
+ *
+ * 욕설 검사를 여기서 합니다. 서버는 이 검사를 하지 않기로 했으므로(#246) 유일한
+ * 방어선입니다. `isToxic`은 사전 기반 문자열 검사라 태깅 모델(13.9MB)을 안 받아도
+ * 됩니다 — 같은 파일에 있지만 부르는 함수가 다릅니다.
+ */
+
+/** `gameJoinRequestSchema`의 `max(12)`와 같은 값입니다. 서버가 거절하기 전에 화면이 먼저 막습니다. */
+const NICKNAME_MAX = 12;
+
+interface GameJoinFormProps {
+  /** 마지막에 쓴 이름입니다. 없으면 빈 문자열입니다. */
+  defaultNickname: string;
+  /** 지금까지 참가한 사람 수입니다. 들어갈 이유를 하나 더 만듭니다. */
+  participantCount: number;
+  isPending: boolean;
+  /** 서버가 거절했을 때의 문구입니다. 입력 검증과 달리 제출한 뒤에 옵니다 */
+  submitError?: string;
+  onSubmit: (nickname: string) => void;
+}
+
+const GameJoinForm = ({
+  defaultNickname,
+  participantCount,
+  isPending,
+  submitError,
+  onSubmit,
+}: GameJoinFormProps) => {
+  const [nickname, setNickname] = useState(defaultNickname);
+  const [error, setError] = useState('');
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmed = nickname.trim();
+    if (trimmed.length === 0) {
+      setError('닉네임을 입력해주세요');
+      return;
+    }
+    if (trimmed.length > NICKNAME_MAX) {
+      setError(`${NICKNAME_MAX}자까지 쓸 수 있어요`);
+      return;
+    }
+    if (isToxic(trimmed)) {
+      setError('이 이름은 쓸 수 없어요');
+      return;
+    }
+
+    setError('');
+    onSubmit(trimmed);
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setNickname(event.target.value);
+    // 고치기 시작하면 바로 지웁니다. 남겨두면 이미 해결한 문제를 계속 지적하는 꼴입니다.
+    if (error) setError('');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+      <Field
+        label="닉네임"
+        value={nickname}
+        onChange={handleChange}
+        maxLength={NICKNAME_MAX}
+        placeholder="초코송이"
+        error={error || submitError}
+        disabled={isPending}
+      />
+      <Button type="submit" disabled={isPending}>
+        {isPending ? '참가하는 중...' : '참가하기'}
+      </Button>
+      {/*
+        참가를 망설이는 시점은 참가 전입니다. 들어간 뒤에야 인원을 보면 늦습니다.
+        0명일 때는 "아무도 없다"로 읽혀서 오히려 막으므로 안 보여줍니다.
+      */}
+      {participantCount > 0 ? (
+        <p className="text-sm font-normal leading-5 text-text-secondary">
+          지금 <span className="font-semibold text-text-primary">{participantCount}</span>명이
+          참가했어요
+        </p>
+      ) : null}
+      <p className="text-xs font-normal leading-4 text-text-tertiary">
+        게임 닉네임은 소감과 연결되지 않아요
+      </p>
+    </form>
+  );
+};
+
+export { GameJoinForm };

--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -1,0 +1,69 @@
+import { GameResultEntry, GameView } from '@/lib/schemas/api';
+
+/**
+ * 레이스가 끝난 뒤입니다.
+ *
+ * 내 순위를 먼저 보여주고 상위권을 그 아래 둡니다. 참가자가 제일 궁금한 건 자기
+ * 등수라, 목록에서 자기를 찾게 하면 안 됩니다.
+ */
+
+/** 화면에 담을 상위권 수입니다. 폰 화면이라 더 넣으면 스크롤이 생깁니다. */
+const TOP_LIMIT = 3;
+
+const RANK_LABEL: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' };
+
+interface GameResultProps {
+  game: GameView;
+  /** 참가자 목록에서 찾은 내 id입니다. 못 찾았으면 `null`입니다. */
+  myParticipantId: number | null;
+}
+
+const GameResult = ({ game, myParticipantId }: GameResultProps) => {
+  /*
+   * 계약상 `FINISHED`면 `results`가 채워지지만 그 검사는 목에만 있습니다. 실제 서버가
+   * 빠뜨려도 화면이 통째로 비지 않게 빈 배열로 떨어뜨립니다.
+   */
+  const results: GameResultEntry[] = game.results ?? [];
+  const mine = results.find((entry) => entry.participantId === myParticipantId);
+  const top = results.slice(0, TOP_LIMIT);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <h2 className="text-lg font-semibold leading-6 text-text-primary">결과가 나왔어요</h2>
+
+      {mine ? (
+        <div className="flex flex-col gap-1 rounded-xl bg-primary-subtle p-4">
+          <p className="text-xs font-normal leading-4 text-primary-darker">{mine.nickname}</p>
+          <p className="text-2xl font-semibold leading-8 text-primary-darker">{mine.rank}등</p>
+          <p className="text-xs font-normal leading-4 text-primary-darker">
+            {game.participantCount}
+          </p>
+        </div>
+      ) : null}
+
+      {top.length > 0 ? (
+        <ul className="flex flex-col gap-2">
+          {top.map((entry) => (
+            <li
+              key={entry.participantId}
+              className="flex items-center gap-3 rounded-xl border border-border-subtle p-3"
+            >
+              <span className="text-sm font-normal leading-5 text-text-secondary">
+                {RANK_LABEL[entry.rank] ?? `${entry.rank}등`}
+              </span>
+              <span className="text-sm font-normal leading-5 text-text-primary">
+                {entry.nickname}
+              </span>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm font-normal leading-5 text-text-secondary">
+          결과를 불러오지 못했어요
+        </p>
+      )}
+    </section>
+  );
+};
+
+export { GameResult };

--- a/components/game/GameWaiting.tsx
+++ b/components/game/GameWaiting.tsx
@@ -1,0 +1,51 @@
+import type { GameParticipant, GameView } from '@/lib/schemas/api';
+
+/**
+ * 참가한 뒤부터 결과가 나오기 전까지입니다.
+ *
+ * 레이스는 그리지 않습니다. 물리 연산이 부동소수점이라 기기마다 결과가 갈리고, 작은
+ * 화면에 구슬 수십 개는 어차피 안 보입니다. 다들 프로젝터를 보게 하는 게 목적에도
+ * 맞습니다(#243).
+ *
+ * 내 닉네임을 크게 보여주는 이유는 프로젝터에서 자기를 찾기 위해서입니다.
+ */
+
+interface GameWaitingProps {
+  game: GameView;
+  /** 참가자 목록에서 찾은 나입니다. 못 찾음녀 `null`입니다. */
+  me: GameParticipant | null;
+}
+
+const GameWaiting = ({ game, me }: GameWaitingProps) => {
+  const isRunning = game.status === 'RUNNING';
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-1">
+        <h2 className="text-lg font-semibold leading-6 text-text-primary">
+          {isRunning ? '레이스 진행중이에요' : '프로젝터를 봐주세요'}
+        </h2>
+        <p className="text-sm font-normal leading-5 text-text-secondary">
+          {isRunning ? '곧 결과가 나와요' : '주최자가 시작하면 레이스가 열려요'}
+        </p>
+      </div>
+
+      {me ? (
+        <div className="flex flex-col gap-1 rounded-xl border border-border-subtle p-4">
+          <p className="text-xs font-normal leading-4 text-text-tertiary">내 이름</p>
+          <p className="text-xl font-semibold leading-7 text-text-primary">{me.nickname}</p>
+        </div>
+      ) : null}
+
+      {/*
+        인원은 폴링으로 늘어납니다. 숫자만 바뀌고 자리는 그대로여야 아래 내용이 안 밀립니다.
+      */}
+      <p className="text-sm font-normal leading-5 text-text-secondary">
+        지금 <span className="font-semibold text-text-primary">{game.participantCount}</span>명이
+        참가했아요
+      </p>
+    </section>
+  );
+};
+
+export { GameWaiting };

--- a/components/game/ParticipantGameView.tsx
+++ b/components/game/ParticipantGameView.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import Link from 'next/link';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { GameJoinForm } from '@/components/game/GameJoinForm';
+import { GameResult } from '@/components/game/GameResult';
+import { GameWaiting } from '@/components/game/GameWaiting';
+import { buttonStyle } from '@/components/ui/Button';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { useCurrentGame } from '@/hooks/useCurrentGame';
+import { joinGame } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import {
+  readNickname,
+  readParticipantId,
+  rememberNickname,
+  rememberParticipant,
+  subscribe,
+} from '@/lib/storage/gameParticipant';
+import type { GameView } from '@/lib/schemas/api';
+
+/**
+ * 참가자 게임 화면의 클라이언트 경계입니다.
+ *
+ * `app/e/[code]/game/page.tsx`가 서버에서 첫 게임을 받아 넘기고, 그다음부터는
+ * `useCurrentGame`의 폴링이 갱신을 맡습니다. 분기를 서버에 두면 주최자가 게임을 열거나
+ * 시작해도 참가자 화면이 새로고침 전까지 모릅니다(`EventEntryView`와 같은 이유).
+ */
+
+/**
+ * 참가 실패를 참가자가 읽을 수 있는 말로 바꿉니다.
+ *
+ * `GAME_NOT_OPEN`만 따로 잡는 이유는 이게 실패가 아니라 타이밍이기 때문입니다 — 닉네임을
+ * 쓰는 사이에 주최자가 레이스를 시작하면 여기 걸립니다. "다시 시도"를 권하면 안 됩니다.
+ */
+const joinErrorMessage = (error: Error | null): string | undefined => {
+  if (error === null) return undefined;
+  if (error instanceof ApiError && error.code === 'GAME_NOT_OPEN') {
+    return '방금 참가가 마감됐어요';
+  }
+  return '참가하지 못했어요. 잠시 후 다시 시도해주세요';
+};
+
+interface ParticipantGameViewProps {
+  eventCode: string;
+  initialGame: GameView | null;
+}
+
+const ParticipantGameView = ({ eventCode, initialGame }: ParticipantGameViewProps) => {
+  const { game } = useCurrentGame({ eventCode, initialGame });
+  const queryClient = useQueryClient();
+
+  const gameId = game?.id ?? null;
+
+  /*
+   * 서버에는 localStorage가 없습니다. 세 번째 인자가 SSR에서 쓰이는 값이라, 첫 HTML은
+   * "기록 없음"으로 그려지고 클라이언트가 붙으면서 실제 값으로 바뀝니다.
+   *
+   * effect에서 setState로 옮겨 담지 않는 이유는 React 19가 그걸 막기 때문입니다
+   * (react-hooks/set-state-in-effect). 이 훅이 바깥 저장소를 읽는 정식 통로입니다.
+   */
+  const defaultNickname = useSyncExternalStore(subscribe, readNickname, () => '');
+
+  const participantId = useSyncExternalStore(
+    subscribe,
+    () => (gameId === null ? null : readParticipantId(gameId)),
+    () => null,
+  );
+
+  const joinMutation = useMutation({
+    mutationFn: (variables: { gameId: number; nickname: string }) =>
+      joinGame(eventCode, variables.gameId, { nickname: variables.nickname }),
+    onSuccess: (participant, variables) => {
+      rememberParticipant(variables.gameId, participant.id);
+      rememberNickname(participant.nickname);
+      // 참가 인원이 바로 반영되게 합니다. 안 하면 다음 폴링까지 내가 빠진 숫자를 봅니다.
+      void queryClient.invalidateQueries({ queryKey: ['currentGame', eventCode] });
+    },
+  });
+
+  const handleJoin = (nickname: string) => {
+    if (gameId === null) return;
+    joinMutation.mutate({ gameId, nickname });
+  };
+
+  if (game === null) {
+    return (
+      <EmptyState title="열린 게임이 없어요" description="주최자가 열면 여기에서 참가할 수 있어요">
+        <Link href={`/e/${eventCode}`} className={buttonStyle('secondary')}>
+          소감 남기러 가기
+        </Link>
+      </EmptyState>
+    );
+  }
+
+  /*
+   * 공개 응답에 `clientId`가 없어서(계약대로) 명단에서 나를 골라낼 값이 이것뿐입니다.
+   * 로컬에 적어둔 id가 실제 명단에 있어야 참가한 것으로 봅니다 — 주최자가 게임을 다시
+   * 만들면 id가 남아 있어도 명단에는 없습니다.
+   */
+  const me = game.participants.find((participant) => participant.id === participantId) ?? null;
+
+  if (game.status === 'FINISHED') {
+    return <GameResult game={game} myParticipantId={participantId} />;
+  }
+
+  if (game.status === 'OPEN' && me === null) {
+    return (
+      <GameJoinForm
+        defaultNickname={defaultNickname}
+        participantCount={game.participantCount}
+        isPending={joinMutation.isPending}
+        submitError={joinErrorMessage(joinMutation.error)}
+        onSubmit={handleJoin}
+      />
+    );
+  }
+
+  return <GameWaiting game={game} me={me} />;
+};
+
+export { ParticipantGameView };

--- a/hooks/useCurrentGame.ts
+++ b/hooks/useCurrentGame.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchCurrentGame } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import { isClientError, type GameView } from '@/lib/schemas/api';
+
+/**
+ * 게임 화면(`/e/[code]/game`, `/events/[eventCode]/game`)이 보는 "지금 열린 게임"입니다.
+ *
+ * `useEventEntryFeed`에도 같은 쿼리가 있지만 그쪽은 이벤트·세션·리포트까지 함께 받습니다.
+ * 게임 화면은 그 셋이 필요 없어서 얇은 훅을 따로 뒀습니다. `queryKey`가 같아 TanStack
+ * Query 캐시는 공유되므로, 배너에서 넘어온 직후에는 요청 없이 화면이 바로 그려집니다.
+ *
+ * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을
+ * 아는 코드는 이 파일에만 둡니다. `refetchInterval`을 밖으로 내보내지 않습니다.
+ */
+
+/**
+ * 게스트 진입 화면과 같은 간격입니다(#237). 참가 인원이 늘어나는 걸 보여줘야 "지금
+ * 들어와야겠다"가 되는데, 그건 초 단위 정확도가 필요한 값이 아니고 게스트 요청은
+ * 참가자 수만큼 곱해집니다.
+ */
+const REFRESH_INTERVAL_MS = 5_000;
+
+/**
+ * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를
+ * 거르는 기준(4xx + `INVALID_RESPONSE`)과 같습니다.
+ *
+ * `useEventEntryFeed`·`useDashboardFeed`에도 같은 함수가 있습니다. 세 번째라 공용으로
+ * 빼는 게 맞아 보이는데, 이 PR 범위 밖이라 두고 갑니다.
+ */
+const isPermanentFailure = (error: Error | null): boolean =>
+  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+interface UseCurrentGameResult {
+  /** 열린 게임이 없으면 `null`입니다. 404가 정상 상태라 에러가 아닙니다. */
+  game: GameView | null;
+}
+
+interface UseCurrentGameParams {
+  eventCode: string;
+  /**
+   * 서버 컴포넌트가 이미 받아둔 값입니다. 넘기지 않으면 게스트가 완성된 화면을 받아놓고도
+   * 마운트 직후 빈 상태를 한 번 지나갑니다.
+   */
+  initialGame: GameView | null;
+}
+const useCurrentGame = ({ eventCode, initialGame }: UseCurrentGameParams): UseCurrentGameResult => {
+  const query = useQuery({
+    // `useEventEntryFeed`와 같은 키입니다. 다르게 두면 배너에서 넘어올 때 캐시를 못 씁니다.
+    queryKey: ['currentGame', eventCode],
+    queryFn: () => fetchCurrentGame(eventCode),
+    initialData: initialGame,
+    /*
+     * `FINISHED`에서 멈추지 않습니다. 주최자가 그 뒤에 새 게임을 열 수 있고, 그때
+     * `current`가 새 게임을 가리킵니다. 멈추면 참가자 화면이 지난 결과에 굳습니다.
+     *
+     * 이벤트가 끝났는지는 여기서 안 봅니다. 게임 화면은 이벤트 상태를 받지 않고,
+     * 행사가 끝나면 주최자가 게임을 안 열어서 `current`가 어차피 그대로입니다.
+     */
+    refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
+  });
+
+  return { game: query.data };
+};
+
+export { useCurrentGame };

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -9,6 +9,8 @@ import type {
   FeedbackSnapshot,
   FeedbackSubmitRequest,
   FeedbackView,
+  GameJoinRequest,
+  GameParticipant,
   GameView,
   LoginRequest,
   PublicReport,
@@ -27,6 +29,7 @@ import {
   feedbackSchema,
   feedbackSnapshotSchema,
   feedbackViewSchema,
+  gameParticipantSchema,
   gameViewSchema,
   listResponseSchema,
   publicReportSchema,
@@ -307,6 +310,10 @@ export const setReportPublic = async (eventCode: string, isPublic: boolean): Pro
   return parseResponse(reportSchema, data, 'PATCH /events/{eventCode}/report');
 };
 
+// ─────────────────────────────────────────────────────────────
+// game
+// ─────────────────────────────────────────────────────────────
+
 /**
  * 참가자 화면 배너가 쓰는 "지금 열린 게임"입니다(#243).
  *
@@ -329,4 +336,41 @@ export const fetchCurrentGame = async (eventCode: string): Promise<GameView | nu
     if (error instanceof ApiError && error.code === 'GAME_NOT_FOUND') return null;
     throw error;
   }
+};
+
+/**
+ * 게임 하나를 봅니다. `current`로 찾은 게임을 계속 따라갈 때 씁니다.
+ *
+ * `current`와 달리 404를 삼키지 않습니다. gameId를 알고 부르는 자리라, 없다는 건
+ * 정상 상태가 아니라 링크가 낡았거나 잘못된 것입니다.
+ */
+export const fetchGameById = async (eventCode: string, gameId: number): Promise<GameView> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games/${gameId}`, { skipAuth: true });
+  return parseResponse(gameViewSchema, data, 'GET /events/{eventCode}/games/{gameId}');
+};
+
+/**
+ * 게임에 참가합니다. 소감 제출과 같은 `X-Client-Id`로 사람을 가리므로, 같은 브라우저가
+ * 다시 부르면 새 참가자가 생기지 않고 닉네임만 갱신됩니다(#246).
+ *
+ * 응답의 `id`를 반드시 저장해야 합니다. 공개 응답에 `clientId`가 없어서, 저장해두지
+ * 않으면 새로고침 뒤에 참가자 목록에서 자기를 못 고릅니다. `RUNNING`이 되면 이
+ * 엔드포인트가 `GAME_NOT_OPEN`으로 막혀서 다시 물어볼 수도 없습니다.
+ */
+export const joinGame = async (
+  eventCode: string,
+  gameId: number,
+  body: GameJoinRequest,
+): Promise<GameParticipant> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games/${gameId}/participants`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    skipAuth: true,
+    headers: { 'X-Client-Id': getClientId() },
+  });
+  return parseResponse(
+    gameParticipantSchema,
+    data,
+    'POST /events/{eventCode}/games/{gameId}/participants',
+  );
 };

--- a/lib/storage/gameParticipant.test.ts
+++ b/lib/storage/gameParticipant.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  readNickname,
+  readParticipantId,
+  rememberNickname,
+  rememberParticipant,
+  subscribe,
+} from '@/lib/storage/gameParticipant';
+
+/**
+ * 화면 테스트를 못 쓰는 환경이라(vitest `environment: 'node'`) 저장소 규칙을 여기서 봅니다.
+ * 깨진 값·접근 차단·서버 렌더처럼 실제로 마주치지만 재현이 번거로운 경우가 대상입니다
+ * (`lib/storage/submitted.test.ts`와 같은 방식).
+ */
+
+const GAME_ID = 2;
+const OTHER_GAME_ID = 3;
+
+const stubBrowser = (initial: Record<string, string> = {}) => {
+  const map = new Map(Object.entries(initial));
+  vi.stubGlobal('window', {
+    localStorage: {
+      getItem: (k: string): string | null => map.get(k) ?? null,
+      setItem: (k: string, v: string): void => {
+        map.set(k, v);
+      },
+    },
+  });
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('참가 기록', () => {
+  it('기록한 participantId를 되찾는다', () => {
+    stubBrowser();
+    rememberParticipant(GAME_ID, 6);
+
+    expect(readParticipantId(GAME_ID)).toBe(6);
+  });
+
+  /*
+   * 참가는 게임 단위입니다. 한 행사에서 게임을 여러 번 하는데 기록이 섞이면, 새 게임에서
+   * 지난 게임의 id로 명단을 뒤지게 됩니다.
+   */
+  it('게임이 다르면 섞이지 않는다', () => {
+    stubBrowser();
+    rememberParticipant(GAME_ID, 6);
+
+    expect(readParticipantId(OTHER_GAME_ID)).toBeNull();
+  });
+
+  it('기록이 없으면 null이다', () => {
+    stubBrowser();
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+  });
+
+  /*
+   * 서버 응답이 계약과 다르거나 저장 값이 손상됐을 때입니다. 그대로 통과시키면 화면이
+   * NaN으로 명단을 뒤져서 아무도 못 찾고, 원인은 한참 뒤에 드러납니다.
+   */
+  it('숫자가 아닌 값이 들어 있으면 null로 떨어뜨린다', () => {
+    stubBrowser({ 'pulse:game-participant:2': 'abc' });
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+  });
+
+  it('0이나 음수는 저장하지 않는다', () => {
+    stubBrowser();
+    rememberParticipant(GAME_ID, 0);
+    rememberParticipant(GAME_ID, -1);
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+  });
+});
+
+describe('닉네임', () => {
+  /*
+   * 게임이 아니라 브라우저에 붙습니다. 한 행사에서 게임을 여러 번 하는데 매번 이름을
+   * 다시 치게 하면 들어오다 맙니다.
+   */
+  it('게임이 달라도 같은 이름을 준다', () => {
+    stubBrowser();
+    rememberNickname('초코송이');
+
+    expect(readNickname()).toBe('초코송이');
+  });
+
+  it('기록이 없으면 빈 문자열이다', () => {
+    stubBrowser();
+
+    expect(readNickname()).toBe('');
+  });
+
+  it('앞뒤 공백을 지우고 저장한다', () => {
+    stubBrowser();
+    rememberNickname('  감자  ');
+
+    expect(readNickname()).toBe('감자');
+  });
+
+  it('공백뿐이면 저장하지 않는다', () => {
+    stubBrowser({ 'pulse:game-nickname': '감자' });
+    rememberNickname('   ');
+
+    expect(readNickname()).toBe('감자');
+  });
+});
+
+describe('브라우저가 아닐 때', () => {
+  /*
+   * SSR에는 window가 없습니다. 던지면 서버 렌더가 통째로 실패하므로 "기록 없음"과 같게
+   * 취급합니다. `useSyncExternalStore`의 서버 스냅샷과 같은 값이어야 합니다.
+   */
+  it('서버에서는 읽어도 던지지 않는다', () => {
+    vi.stubGlobal('window', undefined);
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+    expect(readNickname()).toBe('');
+  });
+
+  it('서버에서는 읽어도 던지지 않는다', () => {
+    vi.stubGlobal('window', undefined);
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+    expect(readNickname()).toBe('');
+  });
+
+  it('서버에서는 써도 던지지 않는다', () => {
+    vi.stubGlobal('window', undefined);
+
+    expect(() => rememberParticipant(GAME_ID, 6)).not.toThrow();
+    expect(() => rememberNickname('감자')).not.toThrow();
+  });
+
+  /*
+   * Safari 시크릿 모드는 localStorage 접근 자체를 막습니다. 참가는 이미 서버에 들어갔으니
+   * 저장 실패로 화면을 세우면 안 됩니다.
+   */
+  it('저장소 접근이 막혀도 던지지 않는다', () => {
+    vi.stubGlobal('window', {
+      localStorage: {
+        getItem: () => {
+          throw new Error('denied');
+        },
+        setItem: () => {
+          throw new Error('denied');
+        },
+      },
+    });
+
+    expect(readParticipantId(GAME_ID)).toBeNull();
+    expect(() => rememberParticipant(GAME_ID, 6)).not.toThrow();
+  });
+});
+
+describe('구독', () => {
+  /*
+   * `useSyncExternalStore`가 이걸로 다시 읽습니다. 안 부르면 참가 직후 화면이 그대로
+   * 입력창에 머뭅니다 — 저장은 됐는데 화면만 모르는 상태가 됩니다.
+   */
+  it('기록하면 구독자에게 알린다', () => {
+    stubBrowser();
+    const listener = vi.fn();
+    subscribe(listener);
+
+    rememberParticipant(GAME_ID, 6);
+    rememberNickname('감자');
+
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('저장하지 않는 값이면 알리지 않는다', () => {
+    stubBrowser();
+    const listener = vi.fn();
+    subscribe(listener);
+
+    rememberParticipant(GAME_ID, 0);
+    rememberNickname('   ');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('구독을 끊으면 더 안 부른다', () => {
+    stubBrowser();
+    const listener = vi.fn();
+    const unsubscribe = subscribe(listener);
+
+    unsubscribe();
+    rememberNickname('감자');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/lib/storage/gameParticipant.ts
+++ b/lib/storage/gameParticipant.ts
@@ -1,0 +1,84 @@
+/**
+ * 게임 참가 기록입니다.
+ *
+ * 공개 응답에 `clientId`가 없어서(계약대로) 화면이 참가자 목록에서 자기를 못 고릅니다.
+ * 참가 응답의 `id`를 여기 적어두고, 그걸로 명단에서 자기 구슬을 찾습니다.
+ *
+ * `RUNNING`이 되면 `POST /participants`가 `GAME_NOT_OPEN`으로 막혀서 다시 물어볼 수도
+ * 없습니다. 저장을 빠뜨리면 레이스가 시작된 뒤 영영 못 찾습니다.
+ *
+ *   키   pulse:game-participant:{gameId}   값   participantId
+ *   키   pulse:game-nickname               값   닉네임 문자열
+ *
+ * 이 파일이 키 문자열을 아는 유일한 곳입니다. 화면에서 localStorage를 직접 부르지
+ * 마세요. 오타가 나도 에러가 아니라 "기록 없음"으로 조용히 읽혀서 찾기 어렵습니다
+ * (`lib/storage/submitted.ts`와 같은 규칙).
+ */
+const participantKey = (gameId: number) => `pulse:game-participant:${gameId}`;
+
+/**
+ * 닉네임은 게임이 아니라 브라우저에 붙습니다. 한 행사에서 게임을 여러 번 하는데 매번
+ * 이름을 다시 치게 하면 들어오다 맙니다. 다른 행사에 가도 쓰던 이름이 뜨는 게 자연스럽습니다.
+ */
+const NICKNAME_KEY = 'pulse:game-nickname';
+
+/**
+ * 서버에는 localStorage가 없어 항상 `null`입니다. 호출부는 첫 렌더에서 "기록 없음"으로
+ * 그렸다가 마운트 후 다시 그려야 합니다.
+ *
+ * Safari 시크릿 모드는 접근 자체를 막습니다. 던지는 대신 "기록 없음"과 같게 취급합니다.
+ */
+const readRaw = (key: string): string | null => {
+  if (typeof window === 'undefined') return null;
+
+  try {
+    return window.localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+};
+
+/** 저장 실패는 무시합니다. 참가 자체는 이미 서버에 들어갔습니다. */
+const writeRaw = (key: string, value: string): void => {
+  if (typeof window === 'undefined') return;
+
+  try {
+    window.localStorage.setItem(key, value);
+  } catch {
+    // 용량 초과 또는 시크릿 모드
+  }
+};
+
+/** 이 게임에 참가한 적이 있으면 그때 받은 participantId를 줍니다. */
+const readParticipantId = (gameId: number): number | null => {
+  const raw = readRaw(participantKey(gameId));
+  if (raw === null) return null;
+
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+/**
+ * 참가 성공 직후 부릅니다.
+ *
+ * 유한하지 않은 값은 저장하지 않습니다. 문자열로 굳으면 읽을 때 `Number('NaN')`이
+ * 다시 `NaN`이 되어 기록이 조용히 사라집니다.
+ */
+const rememberParticipant = (gameId: number, participantId: number): void => {
+  if (!Number.isInteger(participantId) || participantId <= 0) return;
+
+  writeRaw(participantKey(gameId), String(participantId));
+};
+
+/** 입력창 기본값으로 씁니다. 없으면 빈 문자열이라 그대로 넣으면 됩니다. */
+const readNickName = (): string => readRaw(NICKNAME_KEY) ?? '';
+
+/** 참가에 성공한 이름만 남깁니다. 입력 중인 값을 저장하면 욕설 검사를 통과 못 한 이름이 굳습니다. */
+const rememberNickname = (nickname: string): void => {
+  const trimmed = nickname.trim();
+  if (trimmed.length === 0) return;
+
+  writeRaw(NICKNAME_KEY, trimmed);
+};
+
+export { readNickName, readParticipantId, rememberNickname, rememberParticipant };

--- a/lib/storage/gameParticipant.ts
+++ b/lib/storage/gameParticipant.ts
@@ -23,6 +23,26 @@ const participantKey = (gameId: number) => `pulse:game-participant:${gameId}`;
 const NICKNAME_KEY = 'pulse:game-nickname';
 
 /**
+ * `useSyncExternalStore`용 구독입니다.
+ *
+ * `localStorage`는 React 밖에 있는 저장소라, 화면이 그 값을 읽으려면 "언제 바뀌는지"를
+ * 알려줘야 합니다. effect에서 `setState`로 옮겨 담는 방식은 React 19에서 막혔습니다
+ * (cascading render). 쓰는 쪽이 이 파일뿐이라 쓰기 함수가 직접 알립니다.
+ */
+const listeners = new Set<() => void>();
+
+const subscribe = (listener: () => void): (() => void) => {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+const emit = (): void => {
+  for (const listener of listeners) listener();
+};
+
+/**
  * 서버에는 localStorage가 없어 항상 `null`입니다. 호출부는 첫 렌더에서 "기록 없음"으로
  * 그렸다가 마운트 후 다시 그려야 합니다.
  *
@@ -68,10 +88,11 @@ const rememberParticipant = (gameId: number, participantId: number): void => {
   if (!Number.isInteger(participantId) || participantId <= 0) return;
 
   writeRaw(participantKey(gameId), String(participantId));
+  emit();
 };
 
 /** 입력창 기본값으로 씁니다. 없으면 빈 문자열이라 그대로 넣으면 됩니다. */
-const readNickName = (): string => readRaw(NICKNAME_KEY) ?? '';
+const readNickname = (): string => readRaw(NICKNAME_KEY) ?? '';
 
 /** 참가에 성공한 이름만 남깁니다. 입력 중인 값을 저장하면 욕설 검사를 통과 못 한 이름이 굳습니다. */
 const rememberNickname = (nickname: string): void => {
@@ -79,6 +100,7 @@ const rememberNickname = (nickname: string): void => {
   if (trimmed.length === 0) return;
 
   writeRaw(NICKNAME_KEY, trimmed);
+  emit();
 };
 
-export { readNickName, readParticipantId, rememberNickname, rememberParticipant };
+export { readNickname, readParticipantId, rememberNickname, rememberParticipant, subscribe };


### PR DESCRIPTION
> ⚠️ **base가 `dev`가 아니라 `feature/260-game-banner`입니다.**
> 배너 PR(#260) 위에 쌓았습니다. 그쪽이 머지되면 base를 `dev`로 바꾸겠습니다.
>
> **이 PR이 머지돼야 #260을 배포할 수 있습니다.** 배너가 가리키는 화면이 여기 있습니다.

## 변경 사항

참가자 게임 화면(`/e/[code]/game`)을 만듭니다. 게임 상태에 따라 안쪽만 바뀌는 화면 하나입니다.

| 상황 | 화면 |
|---|---|
| `OPEN` · 참가 전 | 닉네임 입력 + 참가 인원 |
| `OPEN` · 참가 후 | 「프로젝터를 봐주세요」 + 내 이름 + 인원 |
| `RUNNING` | 「레이스 진행 중이에요」 |
| `FINISHED` | 내 순위 + 상위 3명 |
| 게임 없음(404) | 빈 상태 + 소감 화면으로 |

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `58a781b` | 데이터 계층 — `fetchGameById`·`joinGame`·저장소·폴링 훅 |
| `54a5400` | 화면 — 참가 폼·대기·결과·클라이언트 경계·라우트 |
| `98ea2c1` | 저장소 테스트 16개 |

SSE 전환(#263)으로 base인 #264가 `dev` 위로 rebase되면서 이쪽도 따라 옮겼습니다.

## 레이스는 폰에 안 그립니다

물리 연산이 부동소수점이라 **기기마다 결과가 갈립니다.** 작은 화면에 구슬 수십 개는 어차피 안 보이고요. 폰은 참가와 결과만 맡고 **다들 프로젝터를 보게 하는 게 목적에도 맞습니다**(#243).

대기 화면에 내 닉네임을 크게 두는 것도 프로젝터에서 자기를 찾기 위해서입니다.

## ⚠️ 계약이 감춘 것을 화면이 다시 알아냅니다

공개 응답에 `clientId`가 없습니다. 계약대로고 그건 맞습니다 — 브라우저 식별자를 밖으로 내보내면 안 됩니다.

그런데 그러면 **화면이 참가자 목록에서 자기를 못 고릅니다.** 닉네임은 중복이 허용되고요.

참가 응답의 `id`를 로컬에 적어두는 걸로 풀었습니다.

```
pulse:game-participant:{gameId}   participantId
pulse:game-nickname               닉네임
```

**`RUNNING`이 되면 다시 물어볼 수도 없습니다.** `POST /participants`가 `GAME_NOT_OPEN`으로 막히므로, 저장을 빠뜨리면 레이스가 시작된 뒤 영영 못 찾습니다.

### 저장된 값만 믿지 않습니다

```tsx
const me = game.participants.find((participant) => participant.id === participantId) ?? null;
```

로컬의 id가 **실제 명단에 있어야** 참가한 것으로 봅니다. 저장값만 믿으면 주최자가 게임을 다시 만들었을 때 id는 남아 있는데 명단에는 없어서 화면이 「참가함」으로 굳습니다.

## `useSyncExternalStore`를 쓴 이유

처음엔 `useEffect`에서 `localStorage`를 읽어 `setState`로 옮겨 담았는데, **React 19가 그걸 막습니다.**

```
error  Calling setState synchronously within an effect can trigger cascading renders
       react-hooks/set-state-in-effect
```

에러 문구가 답도 알려줍니다 — *Subscribe for updates from some external system*. `localStorage`가 바로 그 external system입니다.

```ts
const participantId = useSyncExternalStore(
  subscribe,
  () => (gameId === null ? null : readParticipantId(gameId)),
  () => null,   // SSR 스냅샷
);
```

**상태를 두 벌로 안 들게 된 게 더 큰 이득입니다.** 전에는 `localStorage`와 React state를 같이 갱신해야 했고 한쪽만 고치는 실수가 열려 있었습니다. 지금은 저장소가 하나고 화면은 읽기만 합니다 — 쓰기 함수가 구독자에게 알리면 화면이 알아서 다시 읽습니다.

## `GAME_NOT_OPEN`만 문구를 가릅니다

```ts
if (error instanceof ApiError && error.code === 'GAME_NOT_OPEN') {
  return '방금 참가가 마감됐어요';
}
```

**이건 실패가 아니라 타이밍입니다.** 닉네임을 쓰는 사이에 주최자가 레이스를 시작하면 여기 걸립니다. 「다시 시도」를 권하면 안 됩니다.

## 욕설 검사는 모델 없이 돕니다

`isToxic` 하나로 끝납니다. **사전 기반 문자열 검사라 태깅 모델(13.9MB)을 안 받아도 됩니다** — 같은 파일에 있지만 부르는 함수가 다릅니다.

서버는 이 검사를 안 하기로 했으므로(#246) **여기가 유일한 방어선입니다.**

## 참가 전에 인원을 보여줍니다

참가를 망설이는 시점은 참가 전인데, 들어간 뒤에야 인원을 보면 늦습니다.

**0명이면 안 보여줍니다.** 「0명이 참가했어요」는 들어갈 이유를 만드는 게 아니라 없앱니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관, #256에서 들어옴)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
                ƒ /e/[code]/game 라우트 확인
npm run test    ✓ 7 files, 163 tests passed
```

테스트 16개가 늘었습니다(147 → 163).

| 묶음 | 확인하는 것 |
|---|---|
| 참가 기록 | 게임별 격리 · 깨진 값 → `null` · 0·음수 거부 |
| 닉네임 | 브라우저 단위 · 공백 처리 |
| 브라우저가 아닐 때 | SSR·시크릿 모드에서 안 던짐 |
| 구독 | 저장한 값만 알림 · 해제 동작 |

**구독 묶음이 이번 핵심입니다.** `emit()`을 `writeRaw` 앞에 두면 저장 안 한 값에도 알림이 가고 화면이 헛돕니다. 해제 함수를 안 돌려주면 언마운트돼도 리스너가 쌓이고요.

`npm run dev`로 배너 → 게임 화면 → 참가 → 대기까지 눈으로 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **새 라우트 하나** (`/e/[code]/game`)
- `localStorage` 키 두 개가 늘었습니다. 기존 `pulse:submitted:*`와 접두사가 같아 충돌하지 않습니다

## 트러블슈팅 및 참고 사항

### 새로고침하면 참가가 풀립니다 (목 한정)

MSW 목 저장소는 **브라우저 탭 단위 수명**입니다. 새로고침하면 시드로 돌아가서 내 참가자가 명단에서 사라지고, 화면이 입력창으로 돌아갑니다.

`localStorage`의 `participantId`는 남아 있는데 그 id가 명단에 없는 것이라, 위의 「저장된 값만 믿지 않습니다」가 의도대로 동작한 결과입니다. **실제 서버에서는 안 일어납니다.**

확인하려면 새로고침 대신 `Link` 이동으로 오가면 됩니다.

### 에디터 자동 임포트를 두 번 걸렀습니다

`lib/api/endpoints.ts`에 `@/mocks/data/store`가, `ParticipantGameView.tsx`에 `node:diagnostics_channel`의 `subscribe`가 딸려 들어왔습니다. 둘 다 지웠습니다.

`subscribe`·`emit` 같은 흔한 이름일수록 잘 생깁니다. `lib/`·`components/`가 `mocks/`를 임포트하는 걸 `no-restricted-imports`로 막을 수 있는데, 별개 변경이라 여기서는 안 했습니다.

## 관련 이슈

- Closes #274
- Refs #243, #260

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
