### PR TITLE
fix(events): 이벤트 시작 후 대시보드 상태 배지를 갱신한다

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -12,7 +12,7 @@ import { ChevronLeftIcon } from '@/components/ui/icons';
 import ReportPanel from '@/components/report/ReportPanel';
 import { showToast } from '@/hooks/useToast';
 import { eventCreateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
-import type { EventView, SessionView } from '@/lib/schemas/api';
+import type { EventView, PulseEvent, SessionView } from '@/lib/schemas/api';
 import {
   createEvent,
   createSession,
@@ -223,8 +223,24 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
 
   const { mutate: startEvent, isPending: isStarting } = useMutation({
     mutationFn: () => updateEvent(eventCode as string, { status: 'LIVE' }),
-    onSuccess: () => {
+    onSuccess: (started) => {
       queryClient.invalidateQueries({ queryKey: ['event', eventCode] });
+      /*
+       * 옮겨갈 대시보드는 상태를 이 단수 캐시가 아니라 내 이벤트 목록에서 코드로 찾아
+       * 씁니다(`DashboardView.tsx:151`, `:306`). 목록을 그대로 두면 방금 `LIVE`가 된
+       * 이벤트가 거기서는 여전히 `DRAFT`라, 배지가 "준비 중"으로 남고 그 상태에서만
+       * 나오는 QR·링크 복사·종료 버튼도 함께 사라집니다(#284).
+       *
+       * `invalidateQueries`가 아니라 응답을 직접 꽂는 이유는, 무효화는 stale 표시일 뿐이라
+       * 대시보드가 마운트되는 순간에는 여전히 캐시된 `DRAFT`를 한 번 그리기 때문입니다.
+       * 방금 받은 이벤트가 정답이라 다시 물어볼 것도 없습니다.
+       *
+       * 목록을 거치지 않고 들어온 경우에는 채울 칸 자체가 없습니다. 그때는 갱신자가
+       * `undefined`를 돌려주고, 대시보드가 마운트되면서 목록을 처음부터 받아옵니다.
+       */
+      queryClient.setQueryData<PulseEvent[]>(['myEvents'], (previous) =>
+        previous?.map((item) => (item.code === started.code ? started : item)),
+      );
       showToast('이벤트를 시작했어요');
       router.push(`/events/${eventCode}/dashboard`);
     },


### PR DESCRIPTION
## 변경 사항

- 이벤트 시작(`DRAFT → LIVE`)이 성공하면, `updateEvent`가 돌려주는 이벤트를 `setQueryData`로 `['myEvents']` 캐시의 해당 항목에 직접 꽂습니다.
- 기존에는 `startEvent`가 `['event', eventCode]`만 무효화했는데, 옮겨가는 대시보드는 상태를 그 단수 캐시가 아니라 내 이벤트 목록에서 코드로 찾아 씁니다(`DashboardView.tsx:151`, `:306`). 목록 캐시에는 `DRAFT`가 남고, `staleTime: 10_000`에 `refetchOnWindowFocus: false`라 마운트해도 재요청이 없어서 배지가 "준비 중"으로 굳었습니다. `LIVE`에서만 나오는 QR·링크 복사·이벤트 종료 버튼도 함께 사라졌습니다.
- `invalidateQueries`를 쓰지 않은 이유는 그것이 stale 표시일 뿐이라, 대시보드가 마운트되는 순간에는 여전히 캐시된 `DRAFT`를 한 프레임 그리고 지나가기 때문입니다. #193이 보고한 깜빡임이 형태만 바꿔 재발합니다. 방금 받은 응답이 정답이라 다시 물어볼 이유도 없습니다.

## 관련 이슈

- Closes #284
- Refs #193, #222

## 검증 방법

**자동 검증** (브랜치 `fix/284-my-events-cache-on-event-start`, 커밋 `9b84747`)

| 명령 | 결과 |
| --- | --- |
| `npx tsc --noEmit -p tsconfig.json` | exit 0 (에러 없음) |
| `npx eslint components/events/EventForm.tsx` | exit 0 (경고·에러 없음) |
| `npx prettier --check components/events/EventForm.tsx` | `All matched files use Prettier code style!` |
| `npm run test` | Test Files 10 passed (10) / Tests 185 passed (185) |

**수동 확인**

로컬 브라우저에서 아래 동선을 직접 확인했습니다.

1. `/events`(내 이벤트 목록)에 진입합니다. — 이 단계가 `['myEvents']` 캐시를 `DRAFT`로 데우는 재현 조건이라 반드시 거쳐야 합니다. 대시보드 주소로 바로 들어가면 캐시가 비어 있어 증상이 나지 않습니다.
2. 세션이 1개 이상 있는 `DRAFT` 이벤트 카드를 눌러 설정 화면으로 들어갑니다.
3. "이벤트 시작"을 누릅니다.
4. 이동한 대시보드에서 상태 배지가 `진행 중`으로 뜨고, QR·링크 복사·이벤트 종료 버튼이 함께 나오는 것을 확인했습니다. #193이 보고한 "이 이벤트를 볼 수 없어요" 배너 깜빡임도 재발하지 않았습니다.

`EventForm`에는 컴포넌트 테스트가 없어서 이 회귀는 자동 검증으로 잡히지 않습니다. `vitest`의 `environment`가 `node`이고 jsdom 계열 의존성이 없어, 테스트를 붙이려면 환경 설정부터 손봐야 합니다. 버그 픽스 한 건에 얹기에는 범위가 커서 이 PR에서는 다루지 않았습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### #193이 이미 짚은 원인인데 처방이 절반만 반영돼 있었습니다

[#193](https://github.com/HANCOM-E/pulse-frontend/issues/193)의 「원인」 첫 항목이 정확히 이 내용입니다.

> ### `startEvent`가 무효화하는 캐시와 대시보드가 읽는 캐시가 서로 다릅니다.
> TO-BE: `startEvent`가 무효화하는 캐시 키와 대시보드가 읽는 캐시 키가 일치해야 합니다.

그런데 머지된 [#222](https://github.com/HANCOM-E/pulse-frontend/pull/222)(`1d4759f`)는 `EventsListPage`의 키를 `['events', 'my']` → `['myEvents']`로 통일하는 한 줄에 그쳤고, `startEvent`의 `onSuccess`는 손대지 않았습니다.

그 결과 #193이 보고한 증상(에러 배너 깜빡임)은 사라졌지만, 이 증상은 오히려 상시화됐습니다.

| | 대시보드의 `['myEvents']` 캐시 | 결과 |
| --- | --- | --- |
| #222 이전 | 목록 화면이 `['events','my']`를 쓰므로 대시보드 첫 진입 시 비어 있음 → 새로 fetch | 배지는 `LIVE`로 맞게 뜸. 대신 목록이 없는 순간 "이 이벤트를 볼 수 없어요" 배너가 깜빡임(#193) |
| #222 이후 | 목록 화면이 같은 칸을 `DRAFT`로 데워둠 → `staleTime` 안이라 재요청 없음 | 배너는 사라졌지만 배지가 항상 "준비 중"으로 굳음 |

### 목록을 거치지 않고 들어온 경우

채울 칸 자체가 없습니다. 그때는 `setQueryData` 갱신자가 `undefined`를 돌려주고(TanStack Query는 이를 "갱신하지 않음"으로 처리합니다), 대시보드가 마운트되면서 목록을 처음부터 받아옵니다. 없는 캐시 칸을 새로 만들어 반쪽짜리 목록을 심지 않습니다.

### 반대 방향(이벤트 종료)은 이번에 다루지 않았습니다

`DashboardView.tsx:133`의 이벤트 종료는 `['myEvents']`만 무효화하고 `['event', eventCode]`를 두는데, 게스트 진입 화면(`useEventEntryFeed`)이 그 칸을 읽습니다. 다만 그쪽은 폴링이 걸려 있어 다음 주기에 스스로 회복되므로 사용자가 체감하는 증상이 없다고 보고, 별도 이슈로도 열지 않기로 했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
