### PR TITLE
feat(game): 프로젝터 게임 화면을 만든다

### DIFF
--- a/app/(host)/events/[eventCode]/game/page.tsx
+++ b/app/(host)/events/[eventCode]/game/page.tsx
@@ -1,0 +1,20 @@
+import { GameHostView } from '@/components/game/host/GameHostView';
+
+/**
+ * 행사장 프로젝터에 띄우는 화면입니다. 주최자 노트북에서 엽니다.
+ *
+ * 화면 전체가 클라이언트 아일랜드라 서버가 미리 받을 게 없습니다. `(host)` 그룹에 있어서
+ * 주최자 헤더가 붙고, 결과 확정 API가 요구하는 인증도 같은 경계에서 해결됩니다.
+ *
+ * 대시보드와 달리 `md:px-20`을 쓰지 않습니다. 멀리서 보는 화면이라 여백보다 글자 크기가
+ * 중요하고, 안쪽 컴포넌트가 각자 폭을 정합니다.
+ */
+const GameHostPage = () => {
+  return (
+    <main className="flex flex-col gap-6 p-5 py-10">
+      <GameHostView />
+    </main>
+  );
+};
+
+export default GameHostPage;

--- a/components/dashboard/DashboardHeader.tsx
+++ b/components/dashboard/DashboardHeader.tsx
@@ -2,9 +2,10 @@
 
 import type { ReactNode } from 'react';
 
+import Link from 'next/link';
 import { EVENT_STATUS_BADGE, type VisibleEventStatus } from '@/components/events/eventStatusBadge';
 import { Badge } from '@/components/ui/Badge';
-import { Button } from '@/components/ui/Button';
+import { Button, buttonStyle } from '@/components/ui/Button';
 import type { EventReportControls } from '@/hooks/useEventReport';
 import type { PulseEvent } from '@/lib/schemas/api';
 
@@ -106,6 +107,9 @@ const DashboardHeader = ({
         )}
         {event.status === 'LIVE' && (
           <>
+            <Link href={`/events/${event.code}/game`} className={buttonStyle('secondary', 'sm')}>
+              게임 열기
+            </Link>
             <Button
               variant="secondary"
               size="sm"

--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import Link from 'next/link';
+import { Button, buttonStyle } from '@/components/ui/Button';
+import type { GameResultEntry, GameView } from '@/lib/schemas/api';
+
+/**
+ * 결과 화면입니다. 시상대 모양으로 1·2·3등을 보여줍니다.
+ *
+ * 멀리서 읽혀야 해서 1등을 크게 씁니다. 4등 아래는 안 보여줍니다 — 프로젝터에서
+ * 47명을 훑는 사람은 없고, 자기 등수는 각자 폰에 이미 떠 있습니다.
+ */
+
+/** 시상대에 올리는 인원입니다. */
+const PODIUM_LIMIT = 3;
+
+const RANK_STYLE: Record<number, { size: string; badge: string }> = {
+  1: { size: 'text-5xl', badge: 'bg-warning-subtle text-warning-darker' },
+  2: { size: 'text-3xl', badge: 'bg-neutral-subtle text-neutral-darker' },
+  3: { size: 'text-3xl', badge: 'bg-neutral-subtle text-neutral-darker' },
+};
+
+interface GameFinishedProps {
+  game: GameView;
+  eventCode: string;
+  isPending: boolean;
+  onCreateNext: () => void;
+}
+
+const GameFinished = ({ game, eventCode, isPending, onCreateNext }: GameFinishedProps) => {
+  /*
+   * 계약상 `FINISHED`면 `results`가 채워지지만 그 검사는 목에만 있습니다. 실제 서버가
+   * 빠뜨려도 화면이 통째로 비지 않게 빈 배열로 떨어뜨립니다.
+   */
+  const results: GameResultEntry[] = game.results ?? [];
+  const podium = results.slice(0, PODIUM_LIMIT);
+
+  return (
+    <section className="flex flex-col items-center gap-10">
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
+        <h1 className="text-4xl font-semibold leading-tight text-text-primary">결과가 나왔어요</h1>
+      </div>
+
+      {podium.length > 0 ? (
+        <ol className="flex flex-wrap items-end justify-center gap-10">
+          {podium.map((entry) => {
+            const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
+
+            return (
+              <li key={entry.participantId} className="flex flex-col items-center gap-2">
+                <span
+                  className={`rounded-full px-3 py-1 text-base font-normal leading-6 ${style.badge}`}
+                >
+                  {entry.rank}등
+                </span>
+                <span className={`${style.size} font-semibold leading-tight text-text-primary`}>
+                  {entry.nickname}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      ) : (
+        <p className="text-xl font-normal leading-7 text-text-secondary">
+          결과를 불러오지 못했어요
+        </p>
+      )}
+
+      <div className="flex flex-col items-center gap-3">
+        <div className="flex items-center gap-3">
+          <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>
+            대시보드로
+          </Link>
+          <Button onClick={onCreateNext} disabled={isPending}>
+            새 게임 만들기
+          </Button>
+        </div>
+        <p className="text-sm font-normal leading-5 text-text-tertiary">
+          {game.participantCount}명이 참가했어요
+        </p>
+      </div>
+    </section>
+  );
+};
+
+export { GameFinished };

--- a/components/game/host/GameHostView.tsx
+++ b/components/game/host/GameHostView.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+
+import { GameFinished } from '@/components/game/host/GameFinished';
+import { GameRecruiting } from '@/components/game/host/GameRecruiting';
+import { GameRunning } from '@/components/game/host/GameRunning';
+import { GameSetup } from '@/components/game/host/GameSetup';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { ChevronLeftIcon } from '@/components/ui/icons';
+import { useHostGame } from '@/hooks/useHostGame';
+
+/**
+ * 프로젝터 화면의 클라이언트 경계입니다.
+ *
+ * 화면 전체가 클라이언트 아일랜드입니다. 상태가 폴링 결과에서 나와서 서버가 미리 그릴 게
+ * 없고, `eventCode`도 `useParams`로 직접 읽습니다(`DashboardPage`와 같은 방식).
+ */
+
+const GameHostView = () => {
+  const { eventCode } = useParams<{ eventCode: string }>();
+  const { game, isLoading, isError, isPending, create, open, start, finish } =
+    useHostGame(eventCode);
+
+  /*
+   * 시작은 되돌릴 수 없습니다. `RUNNING`으로 넘기면 참가가 마감되고 `DRAFT`·`OPEN`으로
+   * 못 돌아갑니다. 실수로 누르는 걸 막으려고 한 번 물어봅니다.
+   */
+  const [isStartAsking, setIsStartAsking] = useState(false);
+
+  /** QR이 가리키는 주소입니다. 게임 화면이 아니라 소감 화면입니다(#243). */
+  const joinUrl = typeof window === 'undefined' ? '' : `${window.location.origin}/e/${eventCode}`;
+
+  const renderBody = () => {
+    if (game === null || game.status === 'DRAFT') {
+      return <GameSetup game={game} isPending={isPending} onCreate={create} onOpen={open} />;
+    }
+
+    if (game.status === 'OPEN') {
+      return (
+        <>
+          <GameRecruiting
+            game={game}
+            joinUrl={joinUrl}
+            isPending={isPending}
+            onStart={() => setIsStartAsking(true)}
+          />
+          <ConfirmDialog
+            open={isStartAsking}
+            title="지금 시작할까요?"
+            description={`${game.participantCount}명이 참가했어요. 시작하면 더 참가할 수 없어요`}
+            onClose={() => setIsStartAsking(false)}
+            actions={
+              <>
+                <Button variant="secondary" onClick={() => setIsStartAsking(false)}>
+                  취소
+                </Button>
+                <Button
+                  onClick={() => {
+                    setIsStartAsking(false);
+                    start();
+                  }}
+                >
+                  시작하기
+                </Button>
+              </>
+            }
+          />
+        </>
+      );
+    }
+
+    if (game.status === 'RUNNING') {
+      return <GameRunning game={game} onFinish={finish} />;
+    }
+
+    /*
+     * 새 게임을 만들면 `useHostGame`이 가장 최근 것을 고르므로 화면이 저절로 `DRAFT`로
+     * 넘어갑니다. 제목은 이전 것을 그대로 씁니다 — 프로젝터 앞에서 타이핑하게 하지 않습니다.
+     */
+    return (
+      <GameFinished
+        game={game}
+        eventCode={eventCode}
+        isPending={isPending}
+        onCreateNext={() => create(game.title)}
+      />
+    );
+  };
+
+  if (isLoading) return null;
+  if (isError) return <Banner type="negative">게임 정보를 불러올 수 없어요</Banner>;
+
+  return (
+    <>
+      {/*
+        프로젝터에 띄우는 화면이라 헤더 말고는 나갈 길이 없습니다. 행사 중에 주최자가
+        대시보드를 봐야 할 때가 있어서 둡니다. `EventForm`과 같은 모양입니다.
+
+        `router.back()`이 아니라 목적지를 박아둡니다. 주소를 직접 치고 들어오거나 행사
+        내내 켜두는 화면이라 히스토리가 어디를 가리킬지 모릅니다.
+      */}
+      <div className="w-full">
+        <Link
+          href={`/events/${eventCode}/dashboard`}
+          className="-ml-1 flex w-fit cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
+          aria-label="대시보드로 돌아가기"
+        >
+          <ChevronLeftIcon className="h-6 w-6" />
+        </Link>
+      </div>
+
+      {renderBody()}
+    </>
+  );
+};
+
+export { GameHostView };

--- a/components/game/host/GameRecruiting.tsx
+++ b/components/game/host/GameRecruiting.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import { QRCodeSVG } from 'qrcode.react';
+
+import { Button } from '@/components/ui/Button';
+import type { GameView } from '@/lib/schemas/api';
+
+/**
+ * 모집 중 화면입니다. QR과 참가자 명단이 절반씩 차지합니다.
+ *
+ * QR은 **소감 화면**(`/e/{code}`)을 가리킵니다. 게임으로 바로 보내면 게임만 하고
+ * 나갑니다 — 소감 화면에 떨어져야 배너를 거쳐 게임으로 가고, 그 과정에서 소감 화면을
+ * 한 번은 봅니다(#243). 인쇄된 QR과 같은 주소이기도 합니다.
+ *
+ * 멀리서 보는 화면이라 글자를 크게 씁니다. 참가자 폰의 `max-w-md` 열에 맞추지 않습니다.
+ */
+
+/**
+ * 이름표를 다는 최대 인원입니다. 넘으면 인원 숫자만 보여줍니다.
+ *
+ * 47명이 프로젝터에 다 뜨면 아무도 자기를 못 찾습니다. #243의 규모 경계값(30)을 그대로
+ * 썼고, 실제로 띄워보고 조정합니다.
+ */
+const NAME_TAG_LIMIT = 30;
+
+interface GameRecruitingProps {
+  game: GameView;
+  /** 참가자가 찍을 주소입니다. 소감 화면을 가리킵니다. */
+  joinUrl: string;
+  isPending: boolean;
+  onStart: () => void;
+}
+
+const GameRecruiting = ({ game, joinUrl, isPending, onStart }: GameRecruitingProps) => {
+  const showNames = game.participantCount <= NAME_TAG_LIMIT;
+
+  return (
+    <section className="flex flex-col gap-8">
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
+        <h1 className="text-4xl font-semibold leading-tight text-text-primary">
+          QR을 찍고 참가하세요
+        </h1>
+      </div>
+
+      <div className="flex flex-col items-center gap-8 md:flex-row md:items-start md:justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div className="rounded-xl bg-background-default p-4">
+            <QRCodeSVG value={joinUrl} title="참가자 진입 주소 QR 코드" className="h-64 w-64" />
+          </div>
+          <p className="text-sm font-normal leading-5 text-text-tertiary">{joinUrl}</p>
+        </div>
+
+        <div className="flex flex-col items-center gap-4 md:min-w-80">
+          <p className="text-6xl font-semibold leading-none text-text-primary">
+            {game.participantCount}
+            <span className="text-2xl font-normal text-text-secondary">명</span>
+          </p>
+
+          {showNames ? (
+            <ul className="flex flex-wrap justify-center gap-2">
+              {game.participants.map((participant) => (
+                <li
+                  key={participant.id}
+                  className="rounded-full bg-primary-subtle px-3 py-1 text-base font-normal leading-6 text-primary-darker"
+                >
+                  {participant.nickname}
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-base font-normal leading-6 text-text-secondary">
+              이름은 레이스에서 보여드릴게요
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="flex justify-center">
+        <Button onClick={onStart} disabled={isPending || game.participantCount === 0}>
+          {isPending ? '시작하는 중…' : '시작하기'}
+        </Button>
+      </div>
+    </section>
+  );
+};
+
+export { GameRecruiting };

--- a/components/game/host/GameRunning.tsx
+++ b/components/game/host/GameRunning.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-
-import type { GameParticipant, GameView } from '@/lib/schemas/api';
+import type { GameView } from '@/lib/schemas/api';
+import { buildRevealOrder, toRanking } from '@/components/game/host/raceOrder';
 
 /**
  * 레이스 중 화면입니다. 1단계는 핀볼을 그리지 않고 이름을 꼴등부터 하나씩 드러냅니다(#243).
@@ -17,21 +17,6 @@ import type { GameParticipant, GameView } from '@/lib/schemas/api';
 /** 한 명씩 드러나는 간격입니다. 너무 빠르면 긴장감이 없고 느리면 지루합니다. */
 const REVEAL_INTERVAL_MS = 800;
 
-/**
- * 도착 순서를 만듭니다. 꼴등부터 드러내려고 뒤집어 둡니다.
- *
- * Fisher–Yates입니다. `sort(() => Math.random() - 0.5)`는 균등하지 않아서 앞자리가
- * 원래 순서에 쏠립니다 — 참가 순서가 곧 순위가 되면 추첨이 아닙니다.
- */
-const shuffle = (participants: GameParticipant[]): GameParticipant[] => {
-  const shuffled = [...participants];
-  for (let index = shuffled.length - 1; index > 0; index -= 1) {
-    const swap = Math.floor(Math.random() * (index + 1));
-    [shuffled[index], shuffled[swap]] = [shuffled[swap], shuffled[index]];
-  }
-  return shuffled;
-};
-
 interface GameRunningProps {
   game: GameView;
   /** 전원이 드러나면 부릅니다. 1등부터 담은 `participantId` 배열입니다. */
@@ -43,7 +28,7 @@ const GameRunning = ({ game, onFinish }: GameRunningProps) => {
    * 순서를 한 번만 뽑습니다. 렌더마다 다시 섞으면 폴링이 돌 때마다 순위가 바뀝니다.
    * 초기화 함수를 넘겨서 첫 렌더에서만 실행되게 했습니다.
    */
-  const [order] = useState(() => shuffle(game.participants));
+  const [order] = useState(() => buildRevealOrder(game.participants));
   const [revealed, setRevealed] = useState(0);
 
   /*
@@ -72,8 +57,7 @@ const GameRunning = ({ game, onFinish }: GameRunningProps) => {
     if (!isComplete || order.length === 0 || hasSubmitted.current) return;
 
     hasSubmitted.current = true;
-    // `order`는 꼴등부터라 뒤집어서 1등부터 담습니다.
-    onFinish([...order].reverse().map((participant) => participant.id));
+    onFinish(toRanking(order));
   }, [isComplete, order, onFinish]);
 
   return (

--- a/components/game/host/GameRunning.tsx
+++ b/components/game/host/GameRunning.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import type { GameParticipant, GameView } from '@/lib/schemas/api';
+
+/**
+ * 레이스 중 화면입니다. 1단계는 핀볼을 그리지 않고 이름을 꼴등부터 하나씩 드러냅니다(#243).
+ *
+ * 물리 엔진은 2단계입니다. 계약을 먼저 돌려보려고 연출을 미뤘습니다 — 상태 전이와 결과
+ * 확정이 실제로 도는 걸 확인한 뒤에 얹는 게 순서고, 연출을 갈아 끼워도 계약은 안 바뀝니다.
+ *
+ * 순위는 여기서 정합니다. 물리 시뮬레이션이 없으니 무작위로 섞습니다. 서버가 순위를
+ * 검증하지 않기로 해서(#246) 계약을 어기지는 않습니다.
+ */
+
+/** 한 명씩 드러나는 간격입니다. 너무 빠르면 긴장감이 없고 느리면 지루합니다. */
+const REVEAL_INTERVAL_MS = 800;
+
+/**
+ * 도착 순서를 만듭니다. 꼴등부터 드러내려고 뒤집어 둡니다.
+ *
+ * Fisher–Yates입니다. `sort(() => Math.random() - 0.5)`는 균등하지 않아서 앞자리가
+ * 원래 순서에 쏠립니다 — 참가 순서가 곧 순위가 되면 추첨이 아닙니다.
+ */
+const shuffle = (participants: GameParticipant[]): GameParticipant[] => {
+  const shuffled = [...participants];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swap = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[swap]] = [shuffled[swap], shuffled[index]];
+  }
+  return shuffled;
+};
+
+interface GameRunningProps {
+  game: GameView;
+  /** 전원이 드러나면 부릅니다. 1등부터 담은 `participantId` 배열입니다. */
+  onFinish: (ranking: number[]) => void;
+}
+
+const GameRunning = ({ game, onFinish }: GameRunningProps) => {
+  /*
+   * 순서를 한 번만 뽑습니다. 렌더마다 다시 섞으면 폴링이 돌 때마다 순위가 바뀝니다.
+   * 초기화 함수를 넘겨서 첫 렌더에서만 실행되게 했습니다.
+   */
+  const [order] = useState(() => shuffle(game.participants));
+  const [revealed, setRevealed] = useState(0);
+
+  /*
+   * 결과를 한 번만 올립니다. `onFinish`는 렌더마다 새 함수라 deps에 넣으면 effect가 계속
+   * 다시 돕니다 — 올림 → 목록 무효화 → 리렌더 → 새 함수 → 다시 올림으로 무한히 갑니다.
+   *
+   * state가 아니라 ref인 이유는 이 값이 화면에 안 나오기 때문입니다. state로 두면 바꿀
+   * 때마다 렌더가 한 번 더 돌고, effect 안에서 setState를 부르는 게 되어 React 19가 막습니다.
+   */
+  const hasSubmitted = useRef(false);
+
+  const isComplete = revealed >= order.length;
+
+  useEffect(() => {
+    if (isComplete) return;
+
+    const timer = setTimeout(() => setRevealed((count) => count + 1), REVEAL_INTERVAL_MS);
+    return () => clearTimeout(timer);
+  }, [revealed, isComplete]);
+
+  /*
+   * 전원이 드러나면 결과를 올립니다. 별도 effect로 뺀 이유는 위가 타이머만 맡게 하려는
+   * 것이고, `onFinish`가 여러 번 불리지 않도록 `isComplete`가 한 번만 참이 되게 했습니다.
+   */
+  useEffect(() => {
+    if (!isComplete || order.length === 0 || hasSubmitted.current) return;
+
+    hasSubmitted.current = true;
+    // `order`는 꼴등부터라 뒤집어서 1등부터 담습니다.
+    onFinish([...order].reverse().map((participant) => participant.id));
+  }, [isComplete, order, onFinish]);
+
+  return (
+    <section className="flex flex-col items-center gap-8">
+      <div className="flex flex-col items-center gap-1">
+        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
+        <h1 className="text-4xl font-semibold leading-tight text-text-primary">
+          {isComplete ? '결과를 정리하는 중이에요' : '레이스 중이에요'}
+        </h1>
+      </div>
+
+      <p className="text-xl font-normal leading-7 text-text-secondary">
+        {order.length - revealed}
+        <span className="text-base"> 명 남았어요</span>
+      </p>
+
+      <ul className="flex flex-wrap justify-center gap-2">
+        {order.slice(0, revealed).map((participant, index) => (
+          <li
+            key={participant.id}
+            className="rounded-full bg-neutral-subtle px-3 py-1 text-base font-normal leading-6 text-neutral-darker"
+          >
+            {order.length - index}등 {participant.nickname}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export { GameRunning };

--- a/components/game/host/GameSetup.tsx
+++ b/components/game/host/GameSetup.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { Field } from '@/components/ui/Field';
+import { GameView } from '@/lib/schemas/api';
+
+/**
+ * 게임을 만들고 모집을 여는 자리입니다. 참가자가 아직 아무것도 못 하는 두 상태를
+ * 한 컴포넌트가 맡습니다 — 게임 없음과 `DRAFT`는 주최자가 할 일이 「다음 단계로
+ * 넘긴다」로 같습니다.
+ */
+
+/** `gameCreateRequestSchema`의 `max(50)`과 같은 값입니다. 서버가 거절하기 전에 화면이 막습니다. */
+const TITLE_MAX = 50;
+
+interface GameSetupProps {
+  /** `null`이면 아직 만들기 전입니다. */
+  game: GameView | null;
+  isPending: boolean;
+  onCreate: (title: string) => void;
+  onOpen: () => void;
+}
+
+const GameSetup = ({ game, isPending, onCreate, onOpen }: GameSetupProps) => {
+  const [title, setTitle] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+
+    const trimmed = title.trim();
+    if (trimmed.length === 0) {
+      setError('제목을 입력해주세요');
+      return;
+    }
+
+    setError('');
+    onCreate(trimmed);
+  };
+
+  if (game === null) {
+    return (
+      <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-md flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <h1 className="text-2xl font-semibold leading-8 text-text-primary">게임 만들기</h1>
+          <p className="text-sm font-normal leading-5 text-text-secondary">
+            제목은 참가자에게 보이지 않아요. 여러번 할 때 구분하려고 씁니다
+          </p>
+        </div>
+        <Field
+          label="제목"
+          value={title}
+          onChange={(event) => {
+            setTitle(event.target.value);
+            if (error) setError('');
+          }}
+          maxLength={TITLE_MAX}
+          placeholder="쉬는 시간 몸풀기"
+          error={error}
+          disabled={isPending}
+        />
+        <Button type="submit" disabled={isPending}>
+          {isPending ? '만드는 중...' : '만들기'}
+        </Button>
+      </form>
+    );
+  }
+
+  return (
+    <section className="mx-auto flex w-full max-w-md flex-col gap-6 text-center">
+      <div className="flex flex-col gap-1">
+        <p className="text-sm font-normal leading-5 text-text-secondary">{game.title}</p>
+        <h1 className="text-2xl font-semibold leading-8 text-text-primary">준비됐어요</h1>
+        <p className="text-sm font-normal leading-5 text-text-secondary">
+          모집을 시작하면 참가자 화면에 배너가 떠요
+        </p>
+      </div>
+      <Button onClick={onOpen} disabled={isPending}>
+        {isPending ? '여는 중…' : '모집 시작'}
+      </Button>
+    </section>
+  );
+};
+
+export { GameSetup };

--- a/components/game/host/raceOrder.test.ts
+++ b/components/game/host/raceOrder.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildRevealOrder, toRanking } from '@/components/game/host/raceOrder';
+import type { GameParticipant } from '@/lib/schemas/api';
+
+/**
+ * 셔플이 균등한지는 눈으로 못 봅니다. 먼저 들어온 사람이 자꾸 1등이어도 몇 판 돌려서는
+ * 티가 안 나고, 행사에서 드러나면 이미 늦습니다.
+ */
+
+const build = (count: number): GameParticipant[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    nickname: `참가자${index + 1}`,
+    joinedAt: '2026-08-05T04:00:00.000Z',
+  }));
+
+describe('buildRevealOrder', () => {
+  it('아무도 빠뜨리거나 더하지 않는다', () => {
+    const participants = build(20);
+    const order = buildRevealOrder(participants);
+
+    expect(order).toHaveLength(20);
+    expect([...order].map((p) => p.id).sort((a, b) => a - b)).toEqual(
+      participants.map((p) => p.id),
+    );
+  });
+
+  /*
+   * `game.participants`는 TanStack Query 캐시가 들고 있는 배열입니다. 제자리에서 섞으면
+   * 다른 화면이 보는 순서까지 바뀝니다.
+   */
+  it('원본을 건드리지 않는다', () => {
+    const participants = build(10);
+    const before = participants.map((p) => p.id);
+
+    buildRevealOrder(participants);
+
+    expect(participants.map((p) => p.id)).toEqual(before);
+  });
+
+  it('빈 목록과 한 명도 다루다', () => {
+    expect(buildRevealOrder([])).toEqual([]);
+    expect(buildRevealOrder(build(1))).toHaveLength(1);
+  });
+
+  /*
+   * 이게 이 파일의 요점입니다.
+   *
+   * `sort(() => Math.random() - 0.5)`는 비교 함수가 일관되지 않아서 원래 순서를 부분적으로
+   * 남깁니다. 참가 순서가 곧 순위가 되면 추첨이 아닙니다.
+   *
+   * 각 자리에 각 참가자가 나오는 횟수를 셉니다. 균등하면 1/n에 몰리고, 편향되면 대각선이
+   * 도드라집니다. 4명 6000판이면 자리당 기대값이 1500이고, 균등한 셔플이 이 범위를 벗어날
+   * 확률은 무시할 만합니다.
+   */
+  it('특정 참가자가 특정 자리에 쏠리지 않는다', () => {
+    const SIZE = 4;
+    const ROUNDS = 6_000;
+    const EXPECTED = ROUNDS / SIZE;
+
+    const participants = build(SIZE);
+    // counts[자리][참가자 index]
+    const counts = Array.from({ length: SIZE }, () => new Array<number>(SIZE).fill(0));
+
+    for (let round = 0; round < ROUNDS; round += 1) {
+      buildRevealOrder(participants).forEach((participant, position) => {
+        counts[position][participant.id - 1] += 1;
+      });
+    }
+
+    for (const row of counts) {
+      for (const count of row) {
+        expect(count).toBeGreaterThan(EXPECTED * 0.8);
+        expect(count).toBeLessThan(EXPECTED * 1.2);
+      }
+    }
+  });
+});
+
+describe('toRanking', () => {
+  /*
+   * 공개는 꼴등부터, 서버에 올리는 건 1등부터입니다. 방향이 반대라 한쪽만 고치면
+   * 프로젝터에 1등으로 뜬 사람이 참가자 폰에서는 꼴등이 됩니다.
+   */
+  it('공개 순서를 뒤집어 1등부터 담는다', () => {
+    const order = build(3); // 참가자1, 참가자2, 참가자3 순으로 공개 = 3등, 2등, 1등
+
+    expect(toRanking(order)).toEqual([3, 2, 1]);
+  });
+
+  it('원본을 건드리지 않는다', () => {
+    const order = build(3);
+
+    toRanking(order);
+
+    expect(order.map((p) => p.id)).toEqual([1, 2, 3]);
+  });
+
+  it('빈 목록이면 빈 배열이다', () => {
+    expect(toRanking([])).toEqual([]);
+  });
+});

--- a/components/game/host/raceOrder.ts
+++ b/components/game/host/raceOrder.ts
@@ -1,0 +1,48 @@
+import type { GameParticipant } from '@/lib/schemas/api';
+
+/**
+ * 1단계 레이스의 도착 순서를 만듭니다.
+ *
+ * 물리 시뮬레이션이 2단계라(#243) 그때까지 순서를 만들 게 없습니다. 서버가 순위를
+ * 검증하지 않기로 해서(#246) 프로젝터가 정해도 계약을 어기지 않습니다.
+ *
+ * 컴포넌트에서 뺀 이유는 테스트하기 위해서입니다. 셔플이 균등하지 않으면 「추첨」이
+ * 아니게 되는데, 눈으로는 절대 못 잡습니다(`components/dashboard/metrics.ts`와 같은 방식).
+ */
+
+/**
+ * Fisher–Yates입니다. 모든 순열이 같은 확률로 나옵니다.
+ *
+ * `sort(() => Math.random() - 0.5)`를 쓰지 않습니다. 비교 함수가 일관되지 않아서 정렬
+ * 알고리즘이 원래 순서를 부분적으로 남기고, 앞자리가 참가 순서에 쏠립니다. 먼저 들어온
+ * 사람이 자꾸 1등이면 추첨이 아닙니다.
+ *
+ * 원본을 안 건드립니다. `game.participants`는 TanStack Query 캐시가 들고 있는 배열이라
+ * 제자리에서 섞으면 다른 화면이 보는 순서까지 바뀝니다.
+ */
+const shuffle = <T>(values: readonly T[]): T[] => {
+  const shuffled = [...values];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swap = Math.floor(Math.random() * (index + 1));
+    [shuffled[index], shuffled[swap]] = [shuffled[swap], shuffled[index]];
+  }
+  return shuffled;
+};
+
+/**
+ * 화면에 드러낼 순서입니다. **꼴등이 앞**입니다 — 순위를 낮은 데서부터 공개해야
+ * 1등이 마지막에 나옵니다.
+ */
+const buildRevealOrder = (participants: readonly GameParticipant[]): GameParticipant[] =>
+  shuffle(participants);
+
+/**
+ * 서버에 올릴 순위입니다. **1등이 앞**입니다(`gameResultsRequestSchema`의 `ranking`).
+ *
+ * 공개 순서를 뒤집습니다. 두 방향을 한 함수에서 만들어야 어긋나지 않습니다 — 화면과
+ * 요청이 각자 뒤집으면 한쪽만 고치는 실수가 열립니다.
+ */
+const toRanking = (revealOrder: readonly GameParticipant[]): number[] =>
+  [...revealOrder].reverse().map((participant) => participant.id);
+
+export { buildRevealOrder, toRanking };

--- a/hooks/useHostGame.ts
+++ b/hooks/useHostGame.ts
@@ -1,0 +1,119 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  createGame,
+  fetchGamesOfEvent,
+  submitGameResults,
+  updateGameStatus,
+} from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import { isClientError, type GameView } from '@/lib/schemas/api';
+
+/**
+ * 프로젝터 화면(`/events/[eventCode]/game`)이 보는 게임과 주최자가 취할 수 있는 조치입니다.
+ *
+ * 조회·생성·상태 전이·결과 확정을 한 훅에 묶은 이유는 넷이 하나의 상태 머신이기 때문입니다.
+ * 조치가 성공하면 곧바로 목록을 다시 받아야 화면이 다음 단계로 넘어가는데, 그 조율이 화면으로
+ * 흘러나가면 "성공했는데 화면이 그대로"인 경우가 열립니다(`useEventReport`와 같은 이유).
+ *
+ * 참가자용 `useCurrentGame`과 다른 훅인 이유는 보는 게 달라서입니다. 참가자는 `DRAFT`를
+ * 못 보고(서버가 `current`에서 뺍니다) 주최자는 그걸 봐야 합니다 — 만들어두고 아직 안 연
+ * 게임을 다시 찾는 게 주최자 목록의 존재 이유입니다(#258).
+ */
+
+/**
+ * 참가 인원이 늘어나는 걸 프로젝터가 보여줘야 "지금 들어와야겠다"가 됩니다.
+ *
+ * 게스트 화면(5초)보다 촘촘한 이유는 이 화면이 **한 대뿐**이라서입니다. 게스트 요청은
+ * 참가자 수만큼 곱해지지만 프로젝터는 곱해지지 않습니다.
+ */
+const REFRESH_INTERVAL_MS = 3000;
+
+/** `useEventEntryFeed`·`useDashboardFeed`와 같은 기준입니다. 넷째라 공용으로 뺄 때가 됐습니다. */
+const isPermanentFailure = (error: Error | null): boolean =>
+  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+/**
+ * 프로젝터가 띄울 게임 하나를 고릅니다.
+ *
+ * 가장 최근에 만든 것입니다(목록이 id 내림차순). 주최자가 새 게임을 만들면 화면이 자동으로
+ * 그쪽으로 넘어가고, 지난 게임은 목록에만 남습니다.
+ */
+const pickCurrent = (games: GameView[]): GameView | null => games[0] ?? null;
+
+interface UseHostGameResult {
+  /** 띄울 게임입니다. 하나도 없으면 `null`입니다. */
+  game: GameView | null;
+  isLoading: boolean;
+  isError: boolean;
+  /** 진행 중인 조치가 있으면 참입니다. 버튼을 잠그는 데 씁니다. */
+  isPending: boolean;
+  create: (title: string) => void;
+  open: () => void;
+  start: () => void;
+  finish: (ranking: number[]) => void;
+}
+
+const useHostGame = (eventCode: string): UseHostGameResult => {
+  const queryClient = useQueryClient();
+  const queryKey = ['hostGames', eventCode];
+
+  const gamesQuery = useQuery({
+    queryKey,
+    queryFn: () => fetchGamesOfEvent(eventCode),
+    /*
+     * `RUNNING`에서도 멈추지 않습니다. 참가는 마감됐지만 결과 확정이 남아 있고, 주최자가
+     * 다른 창에서 뭘 했을 수도 있습니다. 멈춰야 하는 상태가 따로 없어서 실패 정지만 둡니다.
+     */
+    refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
+  });
+
+  const game = pickCurrent(gamesQuery.data ?? []);
+
+  /** 조치가 끝나면 목록을 다시 받습니다. 안 하면 다음 폴링까지 화면이 이전 단계에 머뭅니다. */
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey });
+  };
+
+  const createMutation = useMutation({
+    mutationFn: (title: string) => createGame(eventCode, { title }),
+    onSuccess: invalidate,
+  });
+
+  const statusMutation = useMutation({
+    mutationFn: (variables: { gameId: number; status: 'OPEN' | 'RUNNING' }) =>
+      updateGameStatus(eventCode, variables.gameId, { status: variables.status }),
+    onSuccess: invalidate,
+  });
+
+  const resultsMutation = useMutation({
+    mutationFn: (variables: { gameId: number; ranking: number[] }) =>
+      submitGameResults(eventCode, variables.gameId, { ranking: variables.ranking }),
+    onSuccess: invalidate,
+  });
+
+  return {
+    game,
+    isLoading: gamesQuery.isLoading,
+    isError: gamesQuery.isError,
+    isPending: createMutation.isPending || statusMutation.isPending || resultsMutation.isPending,
+    create: (title) => createMutation.mutate(title),
+    /*
+     * 셋 다 게임이 없으면 아무것도 안 합니다. 화면이 이미 버튼을 안 그리지만, 훅이 그걸
+     * 믿으면 화면을 고칠 때마다 여기까지 같이 봐야 합니다.
+     */
+    open: () => {
+      if (game) statusMutation.mutate({ gameId: game.id, status: 'OPEN' });
+    },
+    start: () => {
+      if (game) statusMutation.mutate({ gameId: game.id, status: 'RUNNING' });
+    },
+    finish: (ranking) => {
+      if (game) resultsMutation.mutate({ gameId: game.id, ranking });
+    },
+  };
+};
+
+export { useHostGame };

--- a/lib/api/endpoints.ts
+++ b/lib/api/endpoints.ts
@@ -9,8 +9,11 @@ import type {
   FeedbackSnapshot,
   FeedbackSubmitRequest,
   FeedbackView,
+  GameCreateRequest,
   GameJoinRequest,
   GameParticipant,
+  GameResultsRequest,
+  GameUpdateRequest,
   GameView,
   LoginRequest,
   PublicReport,
@@ -29,6 +32,7 @@ import {
   feedbackSchema,
   feedbackSnapshotSchema,
   feedbackViewSchema,
+  gameListResponseSchema,
   gameParticipantSchema,
   gameViewSchema,
   listResponseSchema,
@@ -373,4 +377,58 @@ export const joinGame = async (
     data,
     'POST /events/{eventCode}/games/{gameId}/participants',
   );
+};
+
+/**
+ * 주최자가 만든 게임 목록입니다(#258). `current`와 달리 `DRAFT`도 옵니다 — 만들어두고
+ * 아직 안 연 게임을 다시 찾는 게 이 목록의 존재 이유입니다.
+ */
+export const fetchGamesOfEvent = async (eventCode: string): Promise<GameView[]> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games`);
+  return parseResponse(gameListResponseSchema, data, 'GET /events/{eventCode}/games').items;
+};
+
+/** 게임을 만듭니다. `DRAFT`로 생깁니다 — 만들자마자 열지 않고 주최자가 시점을 정합니다. */
+export const createGame = async (eventCode: string, body: GameCreateRequest): Promise<GameView> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(gameViewSchema, data, 'POST /events/{eventCode}/games');
+};
+
+/**
+ * 상태를 한 칸 옮깁니다. `DRAFT → OPEN → RUNNING` 한 방향이고 되돌릴 수 없습니다.
+ *
+ * `RUNNING → FINISHED`는 여기로 못 갑니다. 결과 확정(`submitGameResults`)만 그 전이를
+ * 맡습니다 — 여기서 넘기면 `results`가 `null`인 채 `FINISHED`가 됩니다.
+ */
+export const updateGameStatus = async (
+  eventCode: string,
+  gameId: number,
+  body: GameUpdateRequest,
+): Promise<GameView> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games/${gameId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(gameViewSchema, data, 'PATCH /events/{eventCode}/games/{gameId}');
+};
+
+/**
+ * 순위를 확정하고 게임을 끝냅니다. `participantId`를 도착 순서대로 담습니다.
+ *
+ * 서버는 순위 자체를 검증하지 않습니다(#246). 소속과 중복만 봅니다 — 프로젝터가 물리
+ * 시뮬레이션으로 뽑은 결과라 서버가 재현할 수 없기 때문입니다.
+ */
+export const submitGameResults = async (
+  eventCode: string,
+  gameId: number,
+  body: GameResultsRequest,
+): Promise<GameView> => {
+  const data = await apiClient<unknown>(`/events/${eventCode}/games/${gameId}/results`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return parseResponse(gameViewSchema, data, 'POST /events/{eventCode}/games/{gameId}/results');
 };


### PR DESCRIPTION
## 변경 사항

행사장 프로젝터에 띄우는 화면(`/events/[eventCode]/game`)을 만듭니다. 주최자 노트북에서 엽니다.

지금까지는 게임을 만들 방법도, 열 방법도, 결과를 확정할 방법도 없었습니다. 목에 시드 게임이 깔려 있어서 참가자 화면이 동작했을 뿐입니다.

| 상태 | 화면 | 주최자가 하는 것 |
|---|---|---|
| 게임 없음 | 제목 입력 | `POST /games` |
| `DRAFT` | 「모집 시작」 | `PATCH` → `OPEN` |
| `OPEN` | **QR + 참가자 명단 + 인원** | `PATCH` → `RUNNING` |
| `RUNNING` | 이름 순차 공개 | 끝나면 `POST /results` |
| `FINISHED` | 1·2·3등 시상대 | 새 게임 또는 대시보드로 |

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `bc5bd23` | 데이터 계층 — 엔드포인트 4개 + `useHostGame` |
| `d7b1eed` | 화면 5개 + 라우트 + 진입·이탈 경로 |
| `c8c021d` | 레이스 순서 모듈 분리 + 테스트 7개 |

## ⚠️ 이슈에 없던 것 둘을 같이 넣었습니다

**대시보드에 「게임 열기」 버튼**과 **프로젝터에 대시보드로 돌아가는 길**입니다.

이슈의 「할 일」에 진입·이탈 경로가 빠져 있었습니다. **화면을 만들었는데 갈 수도 나올 수도 없으면 만든 게 아닙니다.**

`components/dashboard/DashboardHeader.tsx`를 건드렸습니다. 제 담당 파일이 아니라 밝힙니다 — QR 버튼 옆에 `Link` 하나 추가한 게 전부이고, `event.code`를 이미 props로 받고 있어서 타입은 안 늘렸습니다.

뒤로가기는 `EventForm`과 같은 모양·같은 자리로 맞췄습니다. 다만 `router.back()`이 아니라 목적지를 박아둡니다 — 주소를 직접 치고 들어오거나 행사 내내 켜두는 화면이라 히스토리가 어디를 가리킬지 모릅니다.

### 헤더로 모으는 건 별개입니다

주최자 화면마다 뒤로가기를 하나씩 다는 게 벌써 두 번째입니다(`EventForm`, 여기). `HostHeader`에 이동 경로를 두는 게 맞아 보이는데, 그건 대시보드·목록까지 영향을 받아서 이 PR 범위 밖입니다.

## 프로젝터라 참가자 화면과 정반대입니다

- **`max-w-md` 열에 안 맞춥니다.** 멀리서 보는 화면이라 여백보다 글자 크기가 중요합니다
- 인원을 `text-6xl`로 씁니다
- 아무도 만지지 않습니다. 주최자가 한 번씩 누르는 게 전부입니다

**QR이 화면의 절반입니다.** 참가자가 그걸 보고 들어옵니다.

### QR은 소감 화면을 가리킵니다

게임 화면이 아니라 `/e/{code}`입니다. 인쇄된 QR과 같은 주소예요.

게임으로 바로 보내면 **게임만 하고 나갑니다.** 소감 화면에 떨어져야 배너를 거쳐 게임으로 가고, 그 과정에서 소감 화면을 한 번은 봅니다(#243).

### 30명을 넘으면 이름표를 접습니다

47개가 프로젝터에 다 뜨면 아무도 자기를 못 찾습니다. #243의 규모 구간을 그대로 썼고, **실제로 띄워보고 조정**합니다.

## 1단계는 핀볼을 안 그립니다

`RUNNING` 화면은 이름을 꼴등부터 하나씩 드러냅니다. 물리 엔진은 2단계입니다(#243).

**계약을 먼저 돌려보려고 연출을 미뤘습니다.** 상태 전이와 결과 확정이 실제로 도는 걸 확인한 뒤에 얹는 게 순서고, 연출을 갈아 끼워도 계약은 안 바뀝니다.

순위는 프로젝터가 무작위로 만듭니다. 서버가 순위를 검증하지 않기로 해서(#246) 계약을 어기지는 않습니다.

### `sort(() => Math.random() - 0.5)`를 안 쓴 이유

비교 함수가 일관되지 않아서 **정렬 알고리즘이 원래 순서를 부분적으로 남깁니다.** 앞자리가 참가 순서에 쏠려요.

먼저 들어온 사람이 자꾸 1등이면 추첨이 아닙니다. Fisher–Yates는 모든 순열이 같은 확률입니다.

## ⚠️ 무한 루프를 하나 잡았습니다

결과를 올리는 effect가 계속 다시 돌았습니다.

```
finish 호출 → 결과 확정 → invalidate → 목록 다시 받음 → 리렌더
→ 새 onFinish 함수 → deps 바뀜 → effect 재실행 → …
```

브라우저에 `Maximum update depth exceeded`가 떴습니다.

`useCallback`으로도 안 됩니다 — `game`이 3초마다 바뀌어서 정체성이 또 달라집니다. **「이미 보냈나」를 컴포넌트가 직접 기억하는** 걸로 풀었습니다.

```tsx
const hasSubmitted = useRef(false);
```

state가 아니라 ref인 이유는 화면에 안 나오는 값이기 때문입니다. state로 두면 렌더가 한 번 더 돌고, effect 안에서 `setState`를 부르는 게 되어 React 19가 막습니다(`react-hooks/set-state-in-effect`).

## 폴링이 3초입니다

게스트 화면(5초)보다 촘촘합니다. **프로젝터가 한 대뿐**이라서요 — 게스트 요청은 참가자 수만큼 곱해지지만 프로젝터는 안 곱해집니다.

참가 인원이 늘어나는 걸 보여줘야 「지금 들어와야겠다」가 되는 화면이라 촘촘한 쪽이 낫습니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
                ƒ /events/[eventCode]/game 라우트 확인
npm run test    ✓ 11 files, 188 tests passed
```

테스트 7개가 늘었습니다(181 → 188).

| 테스트 | 확인하는 것 |
|---|---|
| `buildRevealOrder` 4건 | 누락·중복 없음 · 원본 불변 · 빈 목록 · **편향 없음** |
| `toRanking` 3건 | 방향 뒤집기 · 원본 불변 · 빈 목록 |

### 편향 테스트

각 **자리**에 각 **참가자**가 몇 번 나왔는지 세서 표를 만듭니다. 균등하면 전부 기대값 근처에 모이고, `sort` 방식을 쓰면 대각선이 도드라집니다.

**눈으로 못 잡는 것이라 테스트로 뒀습니다.** 먼저 들어온 사람이 자꾸 1등이어도 몇 판 돌려서는 티가 안 나고, 행사에서 드러나면 이미 늦습니다.

4명 6000판이면 자리당 기대값 1500입니다. ±20% 범위인데 균등한 셔플이 여기를 벗어날 확률은 사실상 0이라 깜빡이는 테스트가 되지 않습니다. 19ms에 끝납니다.

### 눈으로 확인한 것

`npm run dev`로 전체 흐름을 돌렸습니다.

```
대시보드 → 게임 열기 → 모집(QR·명단) → 시작하기 → 확인 → 순차 공개
→ 결과(1·2등) → 새 게임 만들기 → DRAFT
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음 (`qrcode.react`는 이미 있습니다)
- Breaking Change: 없음
- **새 라우트 하나** (`/events/[eventCode]/game`)
- **`DashboardHeader`에 버튼 하나가 늘었습니다.** 위 「이슈에 없던 것」 참고

## 트러블슈팅 및 참고 사항

### `isPermanentFailure`가 네 번째입니다

`useEventEntryFeed`·`useDashboardFeed`·`useCurrentGame`에 같은 함수가 있습니다. 공용으로 뺄 때가 됐는데 이 PR 범위 밖이라 주석만 남겼습니다.

### `/events/`를 `/event/`로 세 번 틀렸습니다

`fetchGameById`·`joinGame`·`fetchGamesOfEvent`입니다. 타입이 못 잡는 자리라 화면을 붙이고 나서야 「핸들러 없음」으로 터집니다.

경로를 만드는 자리를 하나로 모으면 막힙니다. 별개 변경이라 여기서는 안 했습니다.

```ts
const gamesPath = (eventCode: string) => `/events/${eventCode}/games`;
```

## 관련 이슈

- Closes #288
- Refs #243, #258

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
