### PR TITLE
fix(layout): Header 로고 링크의 /events 프리페치를 끈다

### DIFF
--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -16,6 +16,7 @@ const Header = ({ email, onLogout, isEmailLoading = false }: HeaderProps) => {
     <header className="flex h-14 items-center justify-between border-b border-border-subtle bg-background-default px-5 md:h-16 md:px-20">
       <Link
         href="/events"
+        prefetch={false}
         aria-label="Pulse 홈으로"
         className="rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
       >


### PR DESCRIPTION
## 변경 사항

- Header 로고 링크(`/events` 화면 자기 자신을 가리키는 링크)에  
`prefetch={false}`를 추가해, 뷰포트에 보일 때마다 반복되던 `events?_rsc=...` 프리페치 요청을 없앴습니다.  
- 이렇게 바꾼 이유는 이슈 #152 를 조사한 결과입니다.  

### 이슈의 원인
- 원인은 Next.js `Link` 컴포넌트의 기본 프리페치 동작입니다. 
- `prefetch`를 지정하지 않으면(기본값 `auto`) 뷰포트에 들어올 때마다 프리페치가 실행되고, 
    데이터가 만료되면 다시 프리페치를 시도합니다 ([공식 문서](https://nextjs.org/docs/app/api-reference/components/link#prefetch)).  
- Header 로고 링크는 `(host)` 공통 레이아웃(`app/(host)/layout.tsx`)에 포함돼 있어, 
  `/events` 화면에 진입하자마자 뷰포트에 보입니다.  자기 자신을 가리키는 링크인데도 이 기본 동작 때문에 프리페치가 반복됐습니다.

### 이 PR의 목적
- 이 조치로 원래 보고된 "3G 환경 약 30초 지연" 자체가 해결되지는 않습니다.  
- **다만 `/events` 화면에 진입할 때마다 불필요하게 반복되던 네트워크 요청 자체를 줄이는 최적화**입니다.


## 관련 이슈

- Refs #152

## 검증 방법

- `npm run lint`를 실행한 결과, 기존에 있던 무관한 warning 1건(`DashboardView.tsx`) 외에 에러는 없었습니다.
- Vercel Preview 배포(이 브랜치)에서 Chrome DevTools Network 탭을 3G로 설정하고 
 `/events`를 하드 리로드해서 확인했습니다.
 
  - **AS-IS:** 수정 전에는 로컬·프로덕션 두 환경 모두 동일하게, `events?_rsc=...` 요청이 매번 5개, 
     서로 다른 값으로 반복 발생하고 있었습니다.
  - **TO-BE**: 이 브랜치의 Preview 배포에서 같은 절차로 재현한 결과, `events?_rsc=...` 요청이 한 건도 발생하지 않았습니다.
  - `dashboard?_rsc=...`·`new?_rsc=...` 요청은 이번 수정 범위 밖이라 그대로 반복됩니다.  
    이 두 링크에는 `prefetch={false}`를 적용하지 않았으므로 예상된 동작입니다.

## 영향 범위

- 새 환경 변수: 없습니다.
- 의존성 추가: 없습니다.
- Breaking Change: 없습니다.  
  다만 Header 로고를 클릭해 `/events`로 이동하는 순간에는 미리 준비된 데이터가 없어서, 그 시점부터 새로 요청을 시작하는 만큼 조금 느려집니다.  
  이미 `/events`에 있는 상태에서 자기 자신으로 돌아가는 링크라, 체감 영향은 낮을 것으로 예상합니다.

## 트러블슈팅 및 참고 사항

### 예전에 시도했던 프리페치 끄기와 다른 결과가 나왔습니다 (이슈 #152 참고)

이슈 본문에는 "이미 이 Header 로고 링크에 `prefetch={false}`를 테스트했지만 
`events?_rsc=...` 요청 개수가 줄지 않았다"고 기록되어 있었습니다.  
이번에 최신 `dev` 기준 깨끗한 브랜치에서 다시 테스트한 결과, 반복이 완전히 사라지는 것을 확인했습니다.  
예전 테스트가 정확히 어떤 코드 상태에서 이뤄졌는지는 확인되지 않았습니다.

### 이 PR은 원래 보고된 "3G 환경 약 30초 지연" 자체는 해결하지 않습니다(이슈 #152)

조사 결과 그 지연의 주된 원인은 이 프리페치 반복이 아니라, 
**클라이언트 사이드에서 렌더링되는 `/events` 화면이 JS 번들을 내려받는 시간**이었습니다.  
그래서 이 PR에서는 이슈를 `Refs`로만 연결했고, 이슈 자체는 별도로 닫았습니다.

### dashboard·new 링크의 반복 프리페치는 이번 PR 범위 밖입니다

그 링크들은 실제로 곧 클릭할 가능성이 높습니다.  
그래서 `prefetch={false}`를 걸 경우의 트레이드오프(클릭 시 네비게이션이 느려짐)를 팀과 별도로 논의해야 합니다.

### 타입 체크 에러 4건은 이 PR과 무관합니다

`npx tsc --noEmit`에서 에러 4건이 나오지만, 전부 `dev`에 새로 병합된  deck-summary 기능이 추가한 
의존성(`pdfjs-dist`, `jszip`)이 로컬 `node_modules`에 아직 설치되지 않아서 나는 것입니다.  
이 PR이 건드린 `Header.tsx`와는 무관합니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 로그 표 생략)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
