### PR TITLE
feat(dashboard): 강연자 링크 모달에서 세션 리포트를 초기화한다

### DIFF
--- a/components/dashboard/DashboardView.tsx
+++ b/components/dashboard/DashboardView.tsx
@@ -41,6 +41,7 @@ import { showToast } from '@/hooks/useToast';
 import { fetchMyEvents, fetchSessionsByEventCode, updateEvent } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import type { Feedback } from '@/lib/schemas/api';
+import { SpeakerDialog } from './SpeakerDialog';
 
 /**
  * 주최자 실시간 모니터링 대시보드입니다.
@@ -71,6 +72,7 @@ const DashboardView = () => {
   /** `null`이 "전체"입니다. 시안의 기본 선택값입니다. */
   const [sessionId, setSessionId] = useState<number | null>(null);
 
+  const [isSpeakerLinkOpen, setIsSpeakerLinkOpen] = useState(false);
   const [isQrOpen, setIsQrOpen] = useState(false);
   const [isEndConfirmOpen, setIsEndConfirmOpen] = useState(false);
 
@@ -338,6 +340,10 @@ const DashboardView = () => {
    * 끊깁니다. 컴포넌트 맨 위로 올리면 그 보호가 사라지므로 옮기지 마세요.
    */
   const publicUrl = `${window.location.origin}/e/${event.code}`;
+  /* "전체"에는 대상 세션이 없어 빈 값입니다. 그때는 아래 모달이 아예 마운트되지 않습니다. */
+  const speakerUrl = sessionId
+    ? `${window.location.origin}/speaker/${event.code}/${sessionId}`
+    : '';
 
   /* 성공을 확인했을 때만 알립니다. 실패는 아래 배너가 받습니다. */
   const handleCopyLink = async () => {
@@ -376,43 +382,50 @@ const DashboardView = () => {
   const toMeta = (feedback: Feedback) =>
     `${toRelativeTime(feedback.createdAt)} · ${sessionTitle(feedback.sessionId)}`;
 
-  /* 칩에서 고른 세션입니다. "전체"(`null`)에는 켜고 끌 대상이 없어 아래 토글을 감춥니다. */
+  /* 칩에서 고른 세션입니다. "전체"(`null`)에는 대고 할 조작이 없어 아래 줄이 자리만 남습니다. */
   const selectedSession =
     sessionId === null ? null : (sessions.find((session) => session.id === sessionId) ?? null);
 
   /*
-   * 세션 토글은 데스크톱에선 헤더 안, 모바일에선 칩 줄 아래에 섭니다. 부모가 달라 CSS로는 옮길
-   * 수 없어서 자리마다 하나씩 두고 `className`으로 감춥니다. 조건과 넘기는 값이 같으므로
-   * 여기서 한 번만 만듭니다.
+   * 고른 세션에 대고 하는 조작 줄입니다. 데스크톱에선 헤더 안, 모바일에선 칩 줄 아래에 섭니다.
+   * 부모가 달라 CSS로는 옮길 수 없어서 자리마다 하나씩 두고 `className`으로 감춥니다. 조건과
+   * 넘기는 값이 같으므로 여기서 한 번만 만듭니다.
    *
-   * `LIVE`에서만 내놓습니다. 제출은 이벤트가 `LIVE`이고 세션이 `ACTIVE`여야 통과하는데,
-   * 시작 전이나 끝난 뒤에 세션만 열어두면 화면은 "소감 받는 중"이라고 하고 참가자는
-   * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다.
+   * `DRAFT`에서는 줄째로 빠집니다. 시작 전에는 건넬 링크도 켜고 끌 세션도 아직 의미가 없습니다.
+   *
+   * 그 안에서 토글만 `LIVE`로 한 번 더 좁힙니다. 제출은 이벤트가 `LIVE`이고 세션이 `ACTIVE`여야
+   * 통과하는데, 시작 전이나 끝난 뒤에 세션만 열어두면 화면은 "소감 받는 중"이라고 하고 참가자는
+   * `EVENT_NOT_LIVE`로 막히는 거짓말이 됩니다. 강연자 링크는 `ENDED` 뒤에도 남습니다 — 리포트는
+   * 세션을 마감한 뒤에 만드는 것이라 이벤트가 끝난 다음에야 할 일이 생깁니다.
    */
-  const renderSessionToggle = (className: string) => {
-    if (event.status !== 'LIVE') return null;
+  const renderSessionAction = (className: string) => {
+    if (event.status === 'DRAFT') return null;
 
     /*
-     * "전체"에는 켜고 끌 대상이 없지만 자리는 남겨둡니다. 비워두면 칩을 오갈 때마다 토글
-     * 한 줄이 통째로 생겼다 사라지면서, 데스크톱은 헤더가 접혀 아래 카드가 전부 밀리고
-     * 모바일은 칩 줄 높이가 바뀝니다.
+     * "전체"에는 대고 할 세션이 없지만 자리는 남겨둡니다. 비워두면 칩을 오갈 때마다 이 줄이
+     * 통째로 생겼다 사라지면서, 데스크톱은 헤더가 접혀 아래 카드가 전부 밀리고 모바일은 칩 줄
+     * 높이가 바뀝니다.
      *
-     * `h-9`는 토글의 높이입니다 — 안에서 가장 큰 게 `size="sm"` 버튼이라 그 높이가 그대로
-     * 줄 높이가 됩니다. 배지(`h-6`)는 가운데 정렬돼서 높이를 정하지 않습니다.
-     *
-     * `LIVE`가 아닐 때는 위에서 이미 빠져나갔습니다. 그 상태에서는 토글이 영영 나오지
-     * 않으므로 자리를 잡아봐야 빈 공간만 남습니다.
+     * `h-9`는 이 줄의 높이입니다 — 안에서 가장 큰 게 `size="sm"` 버튼이라 그 높이가 그대로 줄
+     * 높이가 됩니다. 배지(`h-6`)는 가운데 정렬돼서 높이를 정하지 않습니다.
      */
     if (selectedSession === null) return <div className={`h-9 ${className}`} aria-hidden />;
 
     return (
-      <SessionToggle
-        session={selectedSession}
-        isPaused={sessionControls.isPaused(selectedSession.id)}
-        isPending={sessionControls.isPending}
-        onToggle={(status) => sessionControls.toggle(selectedSession.id, status)}
-        className={className}
-      />
+      <div className={`items-center gap-2 ${className}`}>
+        {event.status === 'LIVE' && (
+          <SessionToggle
+            session={selectedSession}
+            isPaused={sessionControls.isPaused(selectedSession.id)}
+            isPending={sessionControls.isPending}
+            onToggle={(status) => sessionControls.toggle(selectedSession.id, status)}
+            className="flex"
+          />
+        )}
+        <Button variant="secondary" size="sm" onClick={() => setIsSpeakerLinkOpen(true)}>
+          강연자 링크
+        </Button>
+      </div>
     );
   };
 
@@ -422,7 +435,7 @@ const DashboardView = () => {
         event={event}
         publicUrl={publicUrl}
         report={report}
-        sessionToggle={renderSessionToggle('hidden md:flex')}
+        sessionToggle={renderSessionAction('hidden md:flex')}
         onOpenQr={() => setIsQrOpen(true)}
         onCopyLink={handleCopyLink}
         onEndEvent={() => setIsEndConfirmOpen(true)}
@@ -435,7 +448,7 @@ const DashboardView = () => {
         sessions={sessions}
         selectedSessionId={sessionId}
         onSelectSession={handleSelectSession}
-        sessionToggle={renderSessionToggle('flex w-full justify-between md:hidden')}
+        sessionToggle={renderSessionAction('flex w-full justify-between md:hidden')}
       />
 
       {isFeedError && <Banner type="negative">지금은 소감을 불러올 수 없어요</Banner>}
@@ -543,6 +556,21 @@ const DashboardView = () => {
       )}
 
       <QrCodeDialog open={isQrOpen} url={publicUrl} onClose={() => setIsQrOpen(false)} />
+      {/*
+       * 열 때만 마운트합니다. 세션 탭을 고르기만 해도 붙어 있으면 창을 한 번도 열지 않은 채
+       * 세션마다 리포트 GET이 나가고(대개 404), 초기화 성공 상태가 다음 세션 창까지 따라옵니다.
+       */}
+      {isSpeakerLinkOpen && selectedSession !== null && (
+        <SpeakerDialog
+          open={isSpeakerLinkOpen}
+          eventCode={eventCode}
+          eventDate={event.eventDate}
+          session={selectedSession}
+          isPaused={sessionControls.isPaused(selectedSession.id)}
+          url={speakerUrl}
+          onClose={() => setIsSpeakerLinkOpen(false)}
+        />
+      )}
 
       <ConfirmDialog
         open={isEndConfirmOpen}

--- a/components/dashboard/SpeakerDialog.tsx
+++ b/components/dashboard/SpeakerDialog.tsx
@@ -1,0 +1,297 @@
+'use client';
+
+import { useEffect, useId, useRef } from 'react';
+import type { MouseEvent } from 'react';
+
+import { Badge } from '@/components/ui/Badge';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { DuplicateIcon, XIcon } from '@/components/ui/icons';
+import { useCopyLink } from '@/hooks/useCopyLink';
+import { useSessionReport, type SessionReportResetErrorCode } from '@/hooks/useSessionReport';
+import formatEventDate from '@/lib/formatEventDate';
+import type { ReportStatus, SessionView } from '@/lib/schemas/api';
+
+/**
+ * 강연자에게 건넬 링크와 그 세션의 리포트를 다루는 모달입니다. 주최자 대시보드에서만 엽니다.
+ *
+ * `ConfirmDialog`를 재사용하지 않았습니다. `<dialog>` + `showModal()`이라는 재료는 같지만
+ * 그쪽은 되돌릴 수 없는 동작을 묻는 자리라 `role="alertdialog"`로 스크린리더가 하던 말을
+ * 끊고 즉시 읽고, 실수로 닫히지 않게 배경 클릭을 막아뒀습니다. 이 창도 되돌릴 수 없는 버튼을
+ * 하나 품고 있지만(리포트 초기화) 창을 여는 것도 닫는 것도 아무것도 실행하지 않아서, 하던 말을
+ * 끊을 이유도 배경 클릭을 막을 이유도 없습니다(`<dialog>`의 기본 역할인 `dialog`, 배경 클릭으로
+ * 닫힘).
+ *
+ * 포커스 가두기·ESC·배경 차단·딤은 그대로 브라우저가 처리하고, 뒤 배경 스크롤 잠금은
+ * `globals.css`의 `body:has(dialog[open])`가 함께 겁니다.
+ */
+
+/**
+ * 리포트 칸에 세우는 두 줄입니다. 주최자가 여기서 알아야 하는 것은 "강연자가 만들었는지"뿐이라,
+ * 상태 이름을 그대로 보여주지 않고 그 한 가지로 옮겨 적습니다.
+ */
+interface ReportState {
+  title: string;
+  /** 비면 줄 자체가 빠집니다. */
+  hint: string;
+}
+
+const REPORT_STATE: Record<ReportStatus, ReportState> = {
+  GENERATING: {
+    title: '강연자가 리포트를 만들고 있어요',
+    hint: '다 만들어지면 강연자 화면에 나타나요',
+  },
+  GENERATED: {
+    title: '강연자가 리포트를 만들었어요',
+    hint: '초기화하면 강연자가 발표 자료부터 다시 붙여 만들어야 해요',
+  },
+  FAILED: {
+    title: '리포트를 만들다가 실패했어요',
+    hint: '강연자가 같은 자리에서 다시 시도할 수 있어요',
+  },
+};
+
+const REPORT_STATE_NONE: ReportState = {
+  title: '아직 리포트가 없어요',
+  hint: '세션을 마감하면 강연자가 만들 수 있어요',
+};
+
+/** 조회가 끝나기 전입니다. 없다고 단정하면 리포트가 있는 세션에서 잠깐 틀린 말이 스칩니다. */
+const REPORT_STATE_UNKNOWN: ReportState = { title: '리포트 상태를 확인하고 있어요', hint: '' };
+
+/**
+ * 초기화 실패 문구입니다. 사유마다 다음 행동이 달라 하나로 뭉치지 않습니다 — 로그인이 풀린
+ * 것은 다시 로그인하면 되고, 이미 초기화된 리포트는 몇 번을 눌러도 같습니다
+ * (`SessionReportCard`의 생성 실패 문구와 같은 방식).
+ */
+const RESET_ERROR_MESSAGE: Record<SessionReportResetErrorCode, string> = {
+  REPORT_NOT_FOUND: '이미 초기화된 리포트예요',
+  UNAUTHORIZED: '로그인이 풀렸어요. 다시 로그인한 뒤 시도해주세요',
+  NOT_OWNER: '이 이벤트의 주최자만 초기화할 수 있어요',
+  RESET_FAILED: '초기화하지 못했어요. 잠시 후 다시 시도해주세요',
+};
+
+interface SpeakerDialogProps {
+  open: boolean;
+  eventCode: string;
+  /** 행사 당일 날짜(`YYYY-MM-DD`)입니다. 세션에는 시각이 없어 날짜만 답니다. */
+  eventDate: string;
+  session: SessionView;
+  /** 이 화면에서 멈춘 세션인지입니다. 배지 문구를 대시보드와 맞추는 데만 씁니다. */
+  isPaused: boolean;
+  /** 강연자가 열 진입 주소입니다. 복사 버튼과 화면의 글자가 같은 값을 씁니다. */
+  url: string;
+  onClose: () => void;
+}
+
+const SpeakerDialog = ({
+  open,
+  eventCode,
+  eventDate,
+  session,
+  isPaused,
+  url,
+  onClose,
+}: SpeakerDialogProps) => {
+  const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
+
+  const { copy, isCopied, isFailed } = useCopyLink();
+  const report = useSessionReport({
+    eventCode,
+    sessionId: session.id,
+    sessionStatus: session.status,
+  });
+
+  useEffect(() => {
+    const dialog = ref.current;
+    if (!dialog) return;
+
+    if (open && !dialog.open) dialog.showModal();
+    if (!open && dialog.open) dialog.close();
+  }, [open]);
+
+  /*
+   * 복사해도 창을 닫지 않습니다. 주소를 넘긴 뒤에도 리포트 상태를 보러 남는 자리라, 복사했다고
+   * 닫히면 다시 열어야 합니다. 대신 성공을 토스트로 알릴 수 없어서(모달에 가립니다 —
+   * `hooks/useCopyLink.ts`) 버튼 문구를 바꿉니다.
+   */
+  const handleCopyLink = async () => {
+    await copy(url);
+  };
+
+  const handleReset = () => {
+    report.reset();
+  };
+
+  const isActive = session.status === 'ACTIVE';
+
+  /*
+   * 대시보드 헤더의 배지와 같은 문구를 씁니다. 세션은 생성 시 `CLOSED`라 상태만으로는 "아직 열지
+   * 않았다"와 "열었다가 멈췄다"가 갈리지 않아서, 그 판정을 쥔 대시보드가 `isPaused`를 같이
+   * 넘깁니다(`SessionToggle`과 같은 이유).
+   */
+  const statusLabel = isActive ? '소감 받는 중' : isPaused ? '소감 멈춤' : '시작 전';
+
+  const reportState = report.isUnknown
+    ? REPORT_STATE_UNKNOWN
+    : report.status === null
+      ? REPORT_STATE_NONE
+      : REPORT_STATE[report.status];
+
+  /*
+   * 성공하면 리포트가 사라져 버튼이 그대로 잠깁니다. 잠긴 버튼에 남는 이 문구가 결과 표시입니다.
+   * 복사 쪽처럼 2초 뒤 되돌리지 않는 이유는, 초기화는 성공한 세션에서 다시 누를 일이 없어서
+   * 원래 문구로 돌아갈 자리가 없기 때문입니다.
+   */
+  const resetLabel = report.isResetting
+    ? '초기화하는 중'
+    : report.isResetSuccess
+      ? '초기화 완료'
+      : '리포트 초기화';
+
+  /*
+   * 배경 클릭 판정입니다. 딤은 별도 요소가 아니라 `<dialog>` 자신의 `::backdrop`이라, 배경을
+   * 눌러도 이벤트 대상은 `<dialog>`가 됩니다. 내용을 안쪽 `<div>`로 한 겹 싸고 padding도 그쪽에
+   * 준 이유가 이것입니다. 다이얼로그에 직접 padding을 주면 그 여백을 눌렀을 때도 대상이
+   * `<dialog>`라서, 창 안을 눌렀는데 닫힙니다.
+   */
+  const handleBackdropClick = (event: MouseEvent<HTMLDialogElement>) => {
+    if (event.target === ref.current) onClose();
+  };
+
+  return (
+    <dialog
+      ref={ref}
+      aria-labelledby={titleId}
+      className="m-auto w-90 max-w-[calc(100%-2rem)] md:w-128 rounded-xl bg-background-default p-0 shadow-dialog backdrop:bg-overlay"
+      onCancel={(event) => {
+        // 브라우저가 먼저 닫으면 React는 아직 열려 있다고 알고 있어서 둘이 어긋납니다.
+        event.preventDefault();
+        onClose();
+      }}
+      onClick={handleBackdropClick}
+    >
+      {/*
+       * `QrCodeDialog`와 달리 `items-center`를 걸지 않습니다. 저쪽은 QR 이미지가 주인공이라
+       * 가운데가 맞지만, 이 창은 제목·주소·상태가 줄줄이 서는 자리라 왼쪽에 붙어야 읽힙니다.
+       */}
+      <div className="flex flex-col gap-5 p-6">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex flex-col gap-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 id={titleId} className="text-lg leading-7 font-medium text-text-primary">
+                {session.title}
+              </h2>
+              <Badge tone={isActive ? 'positive' : 'neutral'}>{statusLabel}</Badge>
+            </div>
+
+            <p className="text-xs leading-4 font-normal text-text-tertiary">
+              {formatEventDate(eventDate)}
+            </p>
+          </div>
+
+          {/*
+           * 닫기가 아이콘 하나뿐이라 이름을 따로 답니다. 아이콘 자체는 `aria-hidden`이어서
+           * 이게 없으면 스크린리더에 이름 없는 버튼으로 읽힙니다.
+           */}
+          <button
+            type="button"
+            aria-label="닫기"
+            onClick={onClose}
+            className="-m-1 cursor-pointer rounded-lg p-1 text-text-tertiary transition-colors hover:bg-background-muted hover:text-text-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
+          >
+            <XIcon />
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <p className="text-sm leading-5 font-medium text-text-primary">강연자 링크</p>
+          <p className="text-xs leading-4 font-normal break-keep text-text-tertiary">
+            로그인 없이 열리는 주소예요. 강연자에게만 보내주세요
+          </p>
+
+          <div className="flex items-center gap-2">
+            {/*
+             * 주소를 잘라내지 않습니다. 복사가 막힌 환경에서는 이 글자가 주소를 가져가는 유일한
+             * 길이라(`hooks/useCopyLink.ts`), 줄이 늘더라도 다 보이는 편이 맞습니다.
+             */}
+            <p className="min-w-0 flex-1 rounded-lg border border-border-default bg-background-surface px-3 py-2 text-sm leading-5 font-normal break-all text-text-secondary">
+              {url}
+            </p>
+
+            <Button variant="primary" size="sm" onClick={handleCopyLink}>
+              <DuplicateIcon />
+              {isCopied ? '복사 완료' : '복사'}
+            </Button>
+          </div>
+
+          {/*
+           * 복사가 막힌 상황이라 다시 눌러도 소용없습니다. 위 주소를 직접 가져가야 합니다.
+           *
+           * `break-keep`이 없으면 좁은 창에서 「복사해주세 / 요」처럼 낱말 중간이 끊깁니다.
+           * CSS 기본값이 한글을 글자 단위로 끊기 때문입니다.
+           */}
+          {isFailed && (
+            <Banner type="negative" className="w-full break-keep">
+              복사하지 못했어요. 위 주소를 직접 복사해주세요
+            </Banner>
+          )}
+
+          {/*
+           * 버튼 문구가 바뀌는 것은 눈으로만 전달됩니다. 포커스가 그대로 머무는 버튼의 이름이
+           * 바뀌는 걸 읽어주는 스크린리더도 있지만 보장되지 않아서 따로 알립니다. 빈 상태로도
+           * 남겨두는 이유는 미리 존재하던 영역에 내용이 들어와야 읽히기 때문입니다
+           * (`ToastViewport`와 같은 이유).
+           */}
+          <p role="status" className="sr-only">
+            {isCopied ? '링크가 복사되었어요' : ''}
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <p className="text-sm leading-5 font-medium text-text-primary">AI 리포트</p>
+
+          {/*
+           * 점선 칸입니다. 만드는 쪽은 강연자고 주최자가 여기서 할 수 있는 일은 초기화뿐이라,
+           * 채워진 카드로 그리면 이 창이 리포트를 다루는 자리처럼 읽힙니다.
+           */}
+          <div className="flex flex-col items-center gap-1 rounded-xl border border-dashed border-border-default px-4 py-6">
+            <p className="text-sm leading-5 font-medium break-keep text-text-primary">
+              {reportState.title}
+            </p>
+
+            {reportState.hint !== '' && (
+              <p className="text-center text-xs leading-4 font-normal break-keep text-text-tertiary">
+                {reportState.hint}
+              </p>
+            )}
+
+            <Button
+              variant="danger"
+              size="sm"
+              className="mt-2"
+              disabled={report.isResetDisabled}
+              onClick={handleReset}
+            >
+              {resetLabel}
+            </Button>
+          </div>
+
+          {/* 위 복사 버튼과 같은 이유로 따로 알립니다. 두 메시지가 한 영역을 쓰면 서로를 덮습니다. */}
+          <p role="status" className="sr-only">
+            {report.isResetSuccess ? '리포트를 초기화했어요' : ''}
+          </p>
+
+          {report.resetErrorCode !== null && (
+            <Banner type="negative" className="w-full break-keep">
+              {RESET_ERROR_MESSAGE[report.resetErrorCode]}
+            </Banner>
+          )}
+        </div>
+      </div>
+    </dialog>
+  );
+};
+
+export { SpeakerDialog };

--- a/components/speaker/SessionReportCard.tsx
+++ b/components/speaker/SessionReportCard.tsx
@@ -13,7 +13,7 @@ import type { SessionStatus } from '@/lib/schemas/api';
  * 순서가 강제됩니다 — 발표 자료를 먼저 붙이고 그다음 리포트를 만듭니다. 뒤집을 수 없는 이유는
  * BE가 세션당 리포트를 하나만 허용하기 때문입니다. 자료 없이 만들면 그 리포트가 그대로 잠기고,
  * 나중에 자료만 덧붙이는 경로가 계약에 없습니다(pulse-backend#43). 되돌리려면 주최자가 리포트를
- * 회수해야 하는데 그 버튼은 이 화면에 없습니다.
+ * 초기화해야 하는데 그 버튼은 이 화면에 없습니다.
  *
  * 그래서 자료 없이 만들려고 하면 한 번 더 확인을 받습니다. 되돌릴 수 없는 조치를 실수로 한 번
  * 눌러 끝내지 않게 하는 유일한 방어입니다.
@@ -51,7 +51,7 @@ const DECK_ERROR_MESSAGE: Record<DeckSummaryErrorCode, string> = {
 const REPORT_ERROR_MESSAGE: Record<SessionReportErrorCode, string> = {
   SESSION_NOT_CLOSED: '소감을 마감한 뒤에 리포트를 만들 수 있어요',
   REPORT_ALREADY_EXISTS:
-    '이미 만들어진 리포트가 있어요. 다시 만들려면 주최자에게 회수를 요청해 주세요',
+    '이미 만들어진 리포트가 있어요. 다시 만들려면 주최자에게 초기화를 요청해 주세요',
   SESSION_NOT_FOUND: '세션을 찾을 수 없어요',
   GENERATE_FAILED: '리포트를 만들지 못했어요. 잠시 후 다시 시도해 주세요',
 };
@@ -154,7 +154,7 @@ const SessionReportCard = ({
                   : '리포트 만들기'}
           </Button>
           <Button variant="secondary" size="sm" onClick={handlePickFile} disabled={isDeckLocked}>
-            {deck.isPending ? '읽는 중…' : deck.text === null ? '자료 붙이기' : '다른 자료 고르기'}
+            {deck.isPending ? '읽는 중…' : deck.text === null ? '자료 첨부' : '다른 자료 고르기'}
           </Button>
           <input
             ref={fileInputRef}

--- a/hooks/useSessionReport.ts
+++ b/hooks/useSessionReport.ts
@@ -3,25 +3,30 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { ApiError } from '@/lib/apiClient';
-import { fetchSessionReport, generateSessionReport } from '@/lib/api/endpoints';
+import { fetchSessionReport, generateSessionReport, resetSessionReport } from '@/lib/api/endpoints';
 import type { ReportStatus, SessionStatus } from '@/lib/schemas/api';
 
 /**
- * 세션 하나의 AI 리포트입니다. 조회(폴링 포함)와 생성을 함께 묶습니다.
+ * 세션 하나의 AI 리포트입니다. 조회(폴링 포함)·생성·초기화를 함께 묶습니다.
+ *
+ * 셋이 같은 캐시 한 칸을 두고 움직여서 한 훅에 둡니다. 생성은 202로 받은 리포트를 그 칸에 꽂아
+ * 폴링을 시작시키고, 초기화는 그 칸을 비웁니다. 나눠두면 캐시 키가 두 곳에 복사됩니다
+ * (`useEventReport`와 같은 이유).
  *
  * 소감 요약도 집계도 전부 BE가 만듭니다(pulse-backend#43). 프론트가 보태는 것은 발표 자료
  * 요약 하나뿐이고, 그건 `useDeckSummary`가 만들어 이 훅의 `generate`에 실려 나갑니다.
  *
  * 이벤트 리포트(`useEventReport`)와 같은 모양이지만 셋이 다릅니다.
  *
- * 1. 인증이 없습니다. 강연자에게 계정이 없어서 생성·조회가 둘 다 공개 경로입니다.
+ * 1. 생성·조회에 인증이 없습니다. 강연자에게 계정이 없어서 둘 다 공개 경로입니다. 초기화만
+ *    주최자 전용이라 서버가 소유자를 확인합니다.
  * 2. 공개 전환(`isPublic`)이 없습니다. 세션 피드백 집계가 원래 공개입니다.
  * 3. 게이트가 이벤트 `ENDED`가 아니라 세션 `CLOSED`입니다.
  *
  * ── 한 번뿐이라는 점 ──
  * BE가 세션당 리포트를 하나만 허용합니다(`GENERATING`/`GENERATED`면 `REPORT_ALREADY_EXISTS`,
  * `FAILED`만 재시도). 그래서 자료 요약은 `generate`를 부르기 **전에** 준비돼 있어야 합니다.
- * 자료 없이 만들어버리면 나중에 덧붙일 방법이 계약에 없고, 되돌리는 길은 주최자의 리셋뿐입니다.
+ * 자료 없이 만들어버리면 나중에 덧붙일 방법이 계약에 없고, 되돌리는 길은 주최자의 초기화뿐입니다.
  */
 
 /**
@@ -34,7 +39,7 @@ const REPORT_POLL_INTERVAL_MS = 1_500;
 export type SessionReportErrorCode =
   /** 세션이 아직 `CLOSED`가 아닙니다. 주최자가 소감을 마감해야 합니다. */
   | 'SESSION_NOT_CLOSED'
-  /** 누군가 이미 만들었습니다. 회수는 주최자만 할 수 있습니다. */
+  /** 누군가 이미 만들었습니다. 초기화는 주최자만 할 수 있습니다. */
   | 'REPORT_ALREADY_EXISTS'
   /** 세션이 삭제됐거나 주소가 잘못됐습니다. */
   | 'SESSION_NOT_FOUND'
@@ -46,11 +51,23 @@ const KNOWN_ERROR_CODES = new Set<string>([
   'REPORT_ALREADY_EXISTS',
   'SESSION_NOT_FOUND',
 ]);
+export type SessionReportResetErrorCode =
+  | 'REPORT_NOT_FOUND' // 이미 초기화됐거나 애초에 없습니다
+  | 'UNAUTHORIZED' // 로그인이 풀렸습니다
+  | 'NOT_OWNER'
+  | 'RESET_FAILED';
 
 const toErrorCode = (error: unknown): SessionReportErrorCode =>
   error instanceof ApiError && KNOWN_ERROR_CODES.has(error.code)
     ? (error.code as SessionReportErrorCode)
     : 'GENERATE_FAILED';
+
+const KNOWN_RESET_ERROR_CODES = new Set<string>(['REPORT_NOT_FOUND', 'UNAUTHORIZED', 'NOT_OWNER']);
+
+const toResetErrorCode = (error: unknown): SessionReportResetErrorCode =>
+  error instanceof ApiError && KNOWN_RESET_ERROR_CODES.has(error.code)
+    ? (error.code as SessionReportResetErrorCode)
+    : 'RESET_FAILED';
 
 interface UseSessionReportParams {
   eventCode: string;
@@ -89,9 +106,37 @@ export interface SessionReportControls {
    * 한 번뿐이라, 잘못 눌린 한 번이 되돌릴 수 없는 결과를 만듭니다.
    */
   isGenerateDisabled: boolean;
+  /**
+   * 리포트 상태를 아직 모르는 구간입니다(조회 전, 또는 세션 상태를 모를 때). "리포트 없음"과
+   * 구분이 안 되므로, 화면이 없다고 단정하는 문구를 띄우지 않게 따로 알립니다.
+   */
+  isUnknown: boolean;
   /** 발표 자료 요약을 실어 보냅니다. 자료가 없으면 `null`을 넘깁니다. */
   generate: (materialSummary: string | null) => void;
   errorCode: SessionReportErrorCode | null;
+  /**
+   * 리포트를 초기화해 재생성을 열어줍니다. 주최자 전용이라(서버가 소유자를 확인합니다) 이 버튼은
+   * 대시보드에만 있고, 강연자 화면은 그리지 않습니다.
+   */
+  reset: () => void;
+  isResetting: boolean;
+  /**
+   * 방금 초기화했습니다. 성공하면 리포트가 사라져 버튼이 그대로 잠기므로, 호출부는 잠긴 버튼의
+   * 문구를 결과 표시로 씁니다. 모달 안이라 토스트를 쓸 수 없어서입니다 — `showModal()`로 연
+   * `<dialog>`가 최상위 레이어라 토스트가 그 뒤에 가립니다(`useCopyLink`와 같은 사정).
+   */
+  isResetSuccess: boolean;
+  /**
+   * 초기화 버튼을 잠글지입니다. 아직 만들어진 리포트가 없거나(첫 응답 전 포함), 이미 초기화를
+   * 보내는 중이면 잠깁니다. `isGenerateDisabled`와 같은 이유로 판정을 훅이 합니다 — 눌러봐야
+   * `REPORT_NOT_FOUND`만 받는 버튼을 열어두지 않습니다.
+   */
+  isResetDisabled: boolean;
+  /**
+   * 초기화 실패입니다. 생성 실패와 다음 행동이 달라 안내 문구를 나눌 수 있게 `errorCode`와
+   * 합치지 않습니다.
+   */
+  resetErrorCode: SessionReportResetErrorCode | null;
 }
 
 const useSessionReport = ({
@@ -143,6 +188,21 @@ const useSessionReport = ({
   /* `FAILED`는 BE가 같은 행을 재사용해 재시도를 받아줍니다. 나머지 상태에서만 잠급니다. */
   const isLockedByExisting = report !== null && report.status !== 'FAILED';
 
+  /*
+   * 응답이 204라 캐시에 꽂을 게 없습니다. 칸을 비워야 화면이 생성 전으로 돌아갑니다.
+   *
+   * `invalidateQueries`로 하면 안 됩니다. 다시 나간 GET이 404 `REPORT_NOT_FOUND`로 떨어지는데,
+   * TanStack은 재조회가 실패해도 직전 `data`를 남깁니다. 초기화한 리포트가 화면에 그대로 붙어
+   * 있게 됩니다.
+   */
+  const resetMutation = useMutation({
+    mutationFn: () => resetSessionReport(eventCode, sessionId),
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: reportQueryKey });
+      generateMutation.reset(); // 남아 있던 REPORT_ALREADY_EXISTS 배너를 걷습니다
+    },
+  });
+
   return {
     summaryText: report?.status === 'GENERATED' ? report.summaryText : null,
     materialSummary: report?.materialSummary ?? null,
@@ -151,10 +211,16 @@ const useSessionReport = ({
     isGenerating,
     isGenerated: report?.status === 'GENERATED',
     isFailed: report?.status === 'FAILED',
+    isUnknown,
     isGenerateDisabled:
       sessionStatus !== 'CLOSED' || isUnknown || isGenerating || isLockedByExisting,
     generate: (materialSummary) => generateMutation.mutate(materialSummary),
     errorCode: generateMutation.isError ? toErrorCode(generateMutation.error) : null,
+    reset: () => resetMutation.mutate(),
+    isResetting: resetMutation.isPending,
+    isResetSuccess: resetMutation.isSuccess,
+    isResetDisabled: report === null || resetMutation.isPending,
+    resetErrorCode: resetMutation.isError ? toResetErrorCode(resetMutation.error) : null,
   };
 };
 


### PR DESCRIPTION
## 변경 사항

주최자 대시보드에 **강연자 링크 모달**을 추가하고, 그 안에서 **세션 리포트를 초기화**할 수 있게 했습니다.

- **왜 필요했나** — 세션 리포트는 세션당 한 번만 만들 수 있습니다. BE가 `GENERATING`/`GENERATED`에서 `REPORT_ALREADY_EXISTS`로 막고 `FAILED`만 같은 행을 재사용합니다(pulse-backend 43번 이슈). 그래서 강연자가 발표 자료를 붙이지 않은 채 만들어버리면 그 리포트가 그대로 잠깁니다 — 나중에 자료만 덧붙이는 경로가 계약에 없습니다. 되돌리는 유일한 길이 주최자 전용 `POST /events/{eventCode}/sessions/{sessionId}/report/reset`인데, 엔드포인트·MSW 핸들러·계약 테스트는 #289에서 이미 들어와 있었고 **그걸 부르는 화면만 없었습니다.**
- `components/dashboard/SpeakerDialog.tsx`(신규) — 세션 제목·상태 배지·행사 날짜, 강연자 링크와 복사 버튼, AI 리포트 상태 칸과 초기화 버튼.
- `hooks/useSessionReport.ts` — `reset`·`isResetting`·`isResetSuccess`·`isResetDisabled`·`resetErrorCode`·`isUnknown`을 내보냅니다.
- `components/dashboard/DashboardView.tsx` — 세션 조작 줄에 「강연자 링크」 버튼을 두고 `renderSessionToggle`을 `renderSessionAction`으로 넓혔습니다. 토글은 `LIVE`에서만 나오지만 링크는 `ENDED` 뒤에도 남습니다. 리포트는 세션을 마감한 뒤에 만드는 것이라 이벤트가 끝난 다음에야 할 일이 생기기 때문입니다.
- `components/speaker/SessionReportCard.tsx` — 사용자에게 보이는 말을 「초기화」로 통일했습니다. 강연자 화면의 안내가 주최자 화면의 버튼 이름과 달라서는 안 됩니다.

### 설계 결정

**초기화 mutation을 별도 훅으로 빼지 않고 `useSessionReport`에 넣었습니다.** 조회·생성·초기화가 같은 캐시 한 칸(`['sessionReport', eventCode, sessionId]`)을 두고 움직여서, 나누면 캐시 키가 두 곳에 복사됩니다. `useEventReport`가 생성·공개전환을 한 훅에 둔 것과 같은 이유입니다.

**`canReset` 파라미터를 두었다가 뺐습니다.** 초기화가 주최자 전용이라 강연자 화면에 노출되지 않게 타입으로 막으려 했는데, 강연자 화면(`SessionReportCard`)이 애초에 그 버튼을 그리지 않고 권한은 서버가 `requireOwnedEvent`로 강제합니다. 가드가 값을 더하지 않아 지웠습니다.

**버튼을 감추는 축과 잠그는 축을 나눴습니다.** `isResetDisabled`는 초기화할 리포트가 없거나 요청이 나가 있는 동안 잠급니다. 눌러봐야 `REPORT_NOT_FOUND`만 받는 버튼을 열어두지 않는 것은 `isGenerateDisabled`와 같은 원칙입니다.

**리포트 칸은 CTA가 아니라 상태 서술입니다.** 만드는 쪽은 강연자고 주최자가 여기서 할 수 있는 일은 초기화뿐이라, 「아직 리포트가 없어요」 / 「강연자가 리포트를 만들고 있어요」 / 「강연자가 리포트를 만들었어요」 / 「리포트를 만들다가 실패했어요」 중 하나와 그 아래 한 줄만 보여줍니다.

## 개발 과정 로그

커밋이 1개라 표는 생략합니다(`038dafd` → amend). 위 「변경 사항」이 그 커밋의 내용 전부입니다.

## 관련 이슈

- Closes #290

## 검증 방법

실행한 명령과 결과입니다.

| 명령 | 결과 |
| --- | --- |
| `npx tsc --noEmit` | 통과 |
| `npm run lint` | 통과. 경고 1건(`DashboardView.tsx:171` `items` useMemo)은 이번 변경과 무관한 기존 경고입니다 |
| `npm run test` | 13개 파일 216개 통과 |
| `npm run build` | 통과 |

**리뷰어가 직접 볼 절차는 아래와 같습니다.
<img width="960" height="957" alt="스크린샷 2026-08-28 103938" src="https://github.com/user-attachments/assets/e6a47037-8a9a-46e5-9e17-97ec16d000bc" />
<img width="960" height="956" alt="스크린샷 2026-08-28 104152" src="https://github.com/user-attachments/assets/3f6dc97e-d89a-42e9-b0cd-f8245e477356" />
<img width="958" height="954" alt="스크린샷 2026-08-28 104202" src="https://github.com/user-attachments/assets/9cad1c7c-ab1a-4cce-95e7-d1847b713151" />

1. 대시보드에서 세션 칩을 하나 고르고 「강연자 링크」를 누릅니다.
2. 리포트를 만든 적 없는 세션이면 「아직 리포트가 없어요」와 함께 초기화 버튼이 잠겨 있어야 합니다.
3. 강연자 화면(`/speaker/{eventCode}/{sessionId}`)에서 세션을 마감한 뒤 리포트를 만들고, 다시 이 모달을 열면 「강연자가 리포트를 만들었어요」로 바뀌고 초기화 버튼이 열립니다.
4. 초기화를 누르면 버튼이 「초기화 완료」로 잠기고, 강연자 화면을 새로고침하면 리포트를 다시 만들 수 있습니다.


## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음 (`SpeakerDialog`는 신규 파일이고 다른 호출부가 없습니다. `useSessionReport`는 반환값만 늘었습니다)

## 트러블슈팅 및 참고 사항

**1. `invalidateQueries`로는 초기화 뒤에도 화면이 그대로였습니다.**
응답이 204라 캐시에 꽂을 것이 없고, 무효화 후 다시 나간 GET은 404 `REPORT_NOT_FOUND`로 떨어지는데 TanStack Query는 **재조회가 실패해도 직전 `data`를 남깁니다.** 그래서 지워진 리포트가 화면에 계속 붙어 있었습니다. `removeQueries`로 칸을 비워야 「생성 전」으로 돌아갑니다. 같은 함정이 아래 「알려진 한계」에서 한 번 더 나옵니다.

**2. 성공 토스트가 한 번도 보이지 않았습니다.**
`showModal()`로 연 `<dialog>`는 브라우저 최상위 레이어에 그려져서 토스트가 그 뒤에 가리고 `z-index`로도 못 넘습니다(`hooks/useCopyLink.ts`, `components/ui/README.md`에 이미 적혀 있던 사정입니다). 초기화를 부르는 곳이 이 모달뿐이라 훅의 `showToast`는 영영 보이지 않는 코드였습니다. 훅에서 걷어내고, 성공 뒤 영구히 잠기는 버튼의 문구(「초기화 완료」)를 결과 표시로 삼았습니다. 복사 성공을 버튼 문구로 알리는 것과 같은 방식입니다. 스크린리더에는 버튼 이름 변경이 보장되지 않아 `role="status"` sr-only 줄을 따로 뒀습니다.

**3. 모달이 세션 탭을 고르기만 해도 마운트돼 있었습니다.**
창을 한 번도 열지 않아도 세션마다 리포트 GET이 나갔고(대개 404), mutation 상태가 살아 있어서 A 세션을 초기화한 뒤 B 세션 창을 열면 그쪽 버튼도 「초기화 완료」로 떴습니다. 열 때만 마운트하도록 바꾸니 둘 다 사라졌습니다.

**4. 조회가 끝나기 전에 「아직 리포트가 없어요」가 잠깐 스쳤습니다.**
리포트 없음과 조회 전이 둘 다 `status === null`이라 구분되지 않았습니다. `useEventReport`처럼 `isUnknown`을 내보내 그동안에는 단정하지 않게 했습니다.

### 알려진 한계

**주최자가 초기화해도 강연자 화면은 새로고침 전까지 옛 리포트를 그대로 보여줍니다.** 폴링을 붙여도 고쳐지지 않습니다 — 초기화 뒤 GET이 404로 떨어지고, 위 1번과 같은 이유로 직전 `data`가 남기 때문입니다. 고치려면 `queryFn`이 `REPORT_NOT_FOUND`를 에러가 아니라 `null`로 받아야 합니다(주석에는 이미 그렇게 읽는다고 적혀 있지만 실제 동작은 다릅니다). 

**초기화 전 확인 단계는 넣지 않았습니다.** `SessionReportCard`가 자료 없이 생성할 때 쓰는 인라인 2단계 확인과 같은 모양이 어울리지만 이번에는 보류했고, 대신 누를 수 있을 때만 「초기화하면 강연자가 발표 자료부터 다시 붙여 만들어야 해요」를 함께 띄웁니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 해당 없음)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
