### PR TITLE
feat(game): 핀볼 레이스 연출을 붙이고 실서버 계약에 맞춘다

### DIFF
--- a/app/(host)/events/[eventCode]/game/page.tsx
+++ b/app/(host)/events/[eventCode]/game/page.tsx
@@ -8,10 +8,13 @@ import { GameHostView } from '@/components/game/host/GameHostView';
  *
  * 대시보드와 달리 `md:px-20`을 쓰지 않습니다. 멀리서 보는 화면이라 여백보다 글자 크기가
  * 중요하고, 안쪽 컴포넌트가 각자 폭을 정합니다.
+ *
+ * 화면 높이를 다 씁니다. 프로젝터에 띄우는 화면이라 위아래가 비면 그만큼 글자가 작아
+ * 보입니다. `3.5rem`은 주최자 헤더 높이입니다.
  */
 const GameHostPage = () => {
   return (
-    <main className="flex flex-col gap-6 p-5 py-10">
+    <main className="flex min-h-[calc(100dvh-3.5rem)] flex-col p-5 md:min-h-[calc(100dvh-4rem)]">
       <GameHostView />
     </main>
   );

--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -1,10 +1,13 @@
-import { GameResultEntry, GameView } from '@/lib/schemas/api';
+import type { GameParticipant, GameView } from '@/lib/schemas/api';
 
 /**
  * 레이스가 끝난 뒤입니다.
  *
  * 내 순위를 먼저 보여주고 상위권을 그 아래 둡니다. 참가자가 제일 궁금한 건 자기
  * 등수라, 목록에서 자기를 찾게 하면 안 됩니다.
+ *
+ * 서버는 순위에 `participantId`만 담고 닉네임은 안 줍니다(2026-08-28 실서버 확인).
+ * 이름은 `participants`에서 찾아 붙입니다.
  */
 
 /** 화면에 담을 상위권 수입니다. 폰 화면이라 더 넣으면 스크롤이 생깁니다. */
@@ -19,13 +22,21 @@ interface GameResultProps {
 }
 
 const GameResult = ({ game, myParticipantId }: GameResultProps) => {
+  const byId = new Map(game.participants.map((participant) => [participant.id, participant]));
+
   /*
-   * 계약상 `FINISHED`면 `results`가 채워지지만 그 검사는 목에만 있습니다. 실제 서버가
-   * 빠뜨려도 화면이 통째로 비지 않게 빈 배열로 떨어뜨립니다.
+   * 순위를 이름과 짝지어 둡니다. 명단에 없는 id는 버립니다 — 주최자가 게임을 다시
+   * 만들었거나 서버가 이상한 값을 준 경우인데, 이름 없는 줄을 그리는 것보다 낫습니다.
    */
-  const results: GameResultEntry[] = game.results ?? [];
-  const mine = results.find((entry) => entry.participantId === myParticipantId);
-  const top = results.slice(0, TOP_LIMIT);
+  const ranked = game.ranking
+    .map((participantId, index) => ({ rank: index + 1, participant: byId.get(participantId) }))
+    .filter(
+      (entry): entry is { rank: number; participant: GameParticipant } =>
+        entry.participant !== undefined,
+    );
+
+  const mine = ranked.find((entry) => entry.participant.id === myParticipantId);
+  const top = ranked.slice(0, TOP_LIMIT);
 
   return (
     <section className="flex flex-col gap-4">
@@ -33,10 +44,12 @@ const GameResult = ({ game, myParticipantId }: GameResultProps) => {
 
       {mine ? (
         <div className="flex flex-col gap-1 rounded-xl bg-primary-subtle p-4">
-          <p className="text-xs font-normal leading-4 text-primary-darker">{mine.nickname}</p>
+          <p className="text-xs font-normal leading-4 text-primary-darker">
+            {mine.participant.nickname}
+          </p>
           <p className="text-2xl font-semibold leading-8 text-primary-darker">{mine.rank}등</p>
           <p className="text-xs font-normal leading-4 text-primary-darker">
-            {game.participantCount}
+            {game.participants.length}명 중
           </p>
         </div>
       ) : null}
@@ -45,14 +58,14 @@ const GameResult = ({ game, myParticipantId }: GameResultProps) => {
         <ul className="flex flex-col gap-2">
           {top.map((entry) => (
             <li
-              key={entry.participantId}
+              key={entry.participant.id}
               className="flex items-center gap-3 rounded-xl border border-border-subtle p-3"
             >
               <span className="text-sm font-normal leading-5 text-text-secondary">
                 {RANK_LABEL[entry.rank] ?? `${entry.rank}등`}
               </span>
               <span className="text-sm font-normal leading-5 text-text-primary">
-                {entry.nickname}
+                {entry.participant.nickname}
               </span>
             </li>
           ))}

--- a/components/game/GameWaiting.tsx
+++ b/components/game/GameWaiting.tsx
@@ -41,8 +41,8 @@ const GameWaiting = ({ game, me }: GameWaitingProps) => {
         인원은 폴링으로 늘어납니다. 숫자만 바뀌고 자리는 그대로여야 아래 내용이 안 밀립니다.
       */}
       <p className="text-sm font-normal leading-5 text-text-secondary">
-        지금 <span className="font-semibold text-text-primary">{game.participantCount}</span>명이
-        참가했아요
+        지금 <span className="font-semibold text-text-primary">{game.participants.length}</span>명이
+        참가했어요
       </p>
     </section>
   );

--- a/components/game/ParticipantGameView.tsx
+++ b/components/game/ParticipantGameView.tsx
@@ -110,7 +110,7 @@ const ParticipantGameView = ({ eventCode, initialGame }: ParticipantGameViewProp
     return (
       <GameJoinForm
         defaultNickname={defaultNickname}
-        participantCount={game.participantCount}
+        participantCount={game.participants.length}
         isPending={joinMutation.isPending}
         submitError={joinErrorMessage(joinMutation.error)}
         onSubmit={handleJoin}

--- a/components/game/gameBannerMessage.test.ts
+++ b/components/game/gameBannerMessage.test.ts
@@ -5,12 +5,11 @@ import type { GameView } from '@/lib/schemas/api';
 
 const build = (overrides: Partial<GameView>): GameView => ({
   id: 1,
-  title: '시작 전 몸 풀기',
+  title: '시작 전 몸풀기',
   gameType: 'PINBALL',
   status: 'OPEN',
-  participantCount: 0,
   participants: [],
-  results: null,
+  ranking: [],
   createdAt: '2026-08-05T04:00:00.000Z',
   ...overrides,
 });
@@ -28,35 +27,37 @@ describe('isVisibleGame', () => {
 
 describe('gameBannerMessage', () => {
   it('모집 중이면 인원을 같이 보여준다', () => {
-    const game = build({ status: 'OPEN', participantCount: 47 }) as VisibleGame;
+    const game = build({
+      status: 'OPEN',
+      participants: Array.from({ length: 47 }, (_, index) => ({
+        id: index + 1,
+        nickname: `참가자${index + 1}`,
+        joinedAt: '2026-08-05T04:00:00.000Z',
+      })),
+    }) as VisibleGame;
 
     expect(gameBannerMessage(game)).toBe('지금 게임이 열렸어요 · 47명 참가 중');
-  });
-
-  it('진행 중이면 참가가 마감됐다고 알린다', () => {
-    const game = build({ status: 'RUNNING' }) as VisibleGame;
-
-    expect(gameBannerMessage(game)).toBe('레이스 진행 중이에요 · 참가는 마감됐어요');
   });
 
   it('끝났으면 1등을 보여준다', () => {
     const game = build({
       status: 'FINISHED',
-      results: [{ rank: 1, participantId: 5, nickname: '커피' }],
+      participants: [{ id: 5, nickname: '커피', joinedAt: '2026-08-05T04:00:00.000Z' }],
+      ranking: [5],
     }) as VisibleGame;
 
     expect(gameBannerMessage(game)).toBe('결과가 나왔어요 · 1등 커피');
   });
 
   /*
-   * 계약상 FINISHED면 results가 채워집니다. 다만 그 검사는 목에만 있어서 실제 서버가
-   * 빠뜨릴 수 있고, 그때 배너가 통째로 터지면 안 됩니다.
+   * 계약상 FINISHED면 ranking이 채워집니다. 다만 명단에 없는 id가 오거나 ranking이 비어
+   * 있을 수 있어서, 그때 배너가 통째로 터지면 안 됩니다.
    */
-  it('끝났는데 결과가 비어있지도 터지지 않는다', () => {
-    expect(gameBannerMessage(build({ status: 'FINISHED', results: null }) as VisibleGame)).toBe(
+  it('1등을 못 찾아도 터지지 않는다', () => {
+    expect(gameBannerMessage(build({ status: 'FINISHED', ranking: [] }) as VisibleGame)).toBe(
       '결과가 나왔어요',
     );
-    expect(gameBannerMessage(build({ status: 'FINISHED', results: [] }) as VisibleGame)).toBe(
+    expect(gameBannerMessage(build({ status: 'FINISHED', ranking: [99] }) as VisibleGame)).toBe(
       '결과가 나왔어요',
     );
   });

--- a/components/game/gameBannerMessage.ts
+++ b/components/game/gameBannerMessage.ts
@@ -17,15 +17,21 @@ type VisibleGame = GameView & { status: VisibleGameStatus };
 const isVisibleGame = (game: GameView): game is VisibleGame => game.status !== 'DRAFT';
 
 const gameBannerMessage = (game: VisibleGame): string => {
-  if (game.status === 'OPEN') return `지금 게임이 열렸어요 · ${game.participantCount}명 참가 중`;
+  const count = game.participants.length;
+
+  if (game.status === 'OPEN') return `지금 게임이 열렸어요 · ${count}명 참가 중`;
   if (game.status === 'RUNNING') return '레이스 진행 중이에요 · 참가는 마감됐어요';
 
   /*
-   * 계약상 `FINISHED`면 `results`가 채워지지만, 목이 아니라 실제 서버가 빠뜨리면 여기서
-   * 터집니다. 1등 이름은 거들 뿐이라 없으면 문구만 바꿉니다.
+   * 1등 이름은 `ranking`의 첫 참가자를 명단에서 찾아 붙입니다. 서버가 순위에 id만 담고
+   * 닉네임은 안 주기 때문입니다(2026-08-28 실서버 확인).
+   *
+   * 못 찾아도 터지지 않게 둡니다. 이름은 거들 뿐이라 없으면 문구만 바꿉니다.
    */
-  const winner = game.results?.[0]?.nickname;
-  return winner ? `결과가 나왔어요 · 1등 ${winner}` : '결과가 나왔어요';
+  const winnerId = game.ranking[0];
+  const winner = game.participants.find((participant) => participant.id === winnerId);
+
+  return winner ? `결과가 나왔어요 · 1등 ${winner.nickname}` : '결과가 나왔어요';
 };
 
 export { gameBannerMessage, isVisibleGame, type VisibleGame };

--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -15,9 +15,9 @@ import type { GameResultEntry, GameView } from '@/lib/schemas/api';
 const PODIUM_LIMIT = 3;
 
 const RANK_STYLE: Record<number, { size: string; badge: string }> = {
-  1: { size: 'text-5xl', badge: 'bg-warning-subtle text-warning-darker' },
-  2: { size: 'text-3xl', badge: 'bg-neutral-subtle text-neutral-darker' },
-  3: { size: 'text-3xl', badge: 'bg-neutral-subtle text-neutral-darker' },
+  1: { size: 'text-8xl', badge: 'bg-warning-subtle text-warning-darker text-xl px-5 py-2' },
+  2: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
+  3: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
 };
 
 interface GameFinishedProps {
@@ -50,18 +50,18 @@ const GameFinished = ({
         {sessionTitle ? (
           <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
         ) : null}
-        <h1 className="text-4xl font-semibold leading-tight text-text-primary">결과가 나왔어요</h1>
+        <h1 className="text-6xl font-semibold leading-tight text-text-primary">
+          결과가 나왔어요
+        </h1>{' '}
       </div>
       {podium.length > 0 ? (
-        <ol className="flex flex-wrap items-end justify-center gap-10">
+        <ol className="flex flex-wrap items-end justify-center gap-16">
           {podium.map((entry) => {
             const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
 
             return (
-              <li key={entry.participantId} className="flex flex-col items-center gap-2">
-                <span
-                  className={`rounded-full px-3 py-1 text-base font-normal leading-6 ${style.badge}`}
-                >
+              <li key={entry.participantId} className="flex flex-col items-center gap-3">
+                <span className={`rounded-full font-normal leading-6 ${style.badge}`}>
                   {entry.rank}등
                 </span>
                 <span className={`${style.size} font-semibold leading-tight text-text-primary`}>

--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -21,13 +21,21 @@ const RANK_STYLE: Record<number, { size: string; badge: string }> = {
 };
 
 interface GameFinishedProps {
+  /** 지금 열린 세션 제목입니다. 게임 제목은 주최자용 메모라 참가자에게 안 보여줍니다. */
+  sessionTitle: string;
   game: GameView;
   eventCode: string;
   isPending: boolean;
   onCreateNext: () => void;
 }
 
-const GameFinished = ({ game, eventCode, isPending, onCreateNext }: GameFinishedProps) => {
+const GameFinished = ({
+  sessionTitle,
+  game,
+  eventCode,
+  isPending,
+  onCreateNext,
+}: GameFinishedProps) => {
   /*
    * 계약상 `FINISHED`면 `results`가 채워지지만 그 검사는 목에만 있습니다. 실제 서버가
    * 빠뜨려도 화면이 통째로 비지 않게 빈 배열로 떨어뜨립니다.
@@ -36,12 +44,14 @@ const GameFinished = ({ game, eventCode, isPending, onCreateNext }: GameFinished
   const podium = results.slice(0, PODIUM_LIMIT);
 
   return (
-    <section className="flex flex-col items-center gap-10">
+    <section className="flex flex-1 flex-col items-center justify-center gap-10">
+      {' '}
       <div className="flex flex-col items-center gap-1">
-        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
+        {sessionTitle ? (
+          <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
+        ) : null}
         <h1 className="text-4xl font-semibold leading-tight text-text-primary">결과가 나왔어요</h1>
       </div>
-
       {podium.length > 0 ? (
         <ol className="flex flex-wrap items-end justify-center gap-10">
           {podium.map((entry) => {
@@ -66,7 +76,6 @@ const GameFinished = ({ game, eventCode, isPending, onCreateNext }: GameFinished
           결과를 불러오지 못했어요
         </p>
       )}
-
       <div className="flex flex-col items-center gap-3">
         <div className="flex items-center gap-3">
           <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>

--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { Button, buttonStyle } from '@/components/ui/Button';
-import type { GameResultEntry, GameView } from '@/lib/schemas/api';
+import type { GameParticipant, GameView } from '@/lib/schemas/api';
 
 /**
  * 결과 화면입니다. 시상대 모양으로 1·2·3등을 보여줍니다.
@@ -37,57 +37,67 @@ const GameFinished = ({
   onCreateNext,
 }: GameFinishedProps) => {
   /*
-   * 계약상 `FINISHED`면 `results`가 채워지지만 그 검사는 목에만 있습니다. 실제 서버가
-   * 빠뜨려도 화면이 통째로 비지 않게 빈 배열로 떨어뜨립니다.
+   * 순위를 이름과 짝지어 둡니다. 서버는 `participantId`만 담고 닉네임은 안 줍니다
+   * (2026-08-28 실서버 확인). 명단에 없는 id는 버립니다 — 이름 없는 자리를 시상대에
+   * 올리는 것보다 낫습니다.
    */
-  const results: GameResultEntry[] = game.results ?? [];
-  const podium = results.slice(0, PODIUM_LIMIT);
+  const byId = new Map(game.participants.map((participant) => [participant.id, participant]));
+
+  const podium = game.ranking
+    .map((participantId, index) => ({ rank: index + 1, participant: byId.get(participantId) }))
+    .filter(
+      (entry): entry is { rank: number; participant: GameParticipant } =>
+        entry.participant !== undefined,
+    )
+    .slice(0, PODIUM_LIMIT);
 
   return (
-    <section className="flex flex-1 flex-col items-center justify-center gap-10">
-      {' '}
-      <div className="flex flex-col items-center gap-1">
+    <section className="flex flex-1 flex-col">
+      <div className="flex flex-col items-center gap-1 pt-[6dvh]">
         {sessionTitle ? (
           <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
         ) : null}
-        <h1 className="text-6xl font-semibold leading-tight text-text-primary">
-          결과가 나왔어요
-        </h1>{' '}
+        <h1 className="text-4xl font-semibold leading-tight text-text-primary">결과가 나왔어요</h1>
       </div>
-      {podium.length > 0 ? (
-        <ol className="flex flex-wrap items-end justify-center gap-16">
-          {podium.map((entry) => {
-            const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
 
-            return (
-              <li key={entry.participantId} className="flex flex-col items-center gap-3">
-                <span className={`rounded-full font-normal leading-6 ${style.badge}`}>
-                  {entry.rank}등
-                </span>
-                <span className={`${style.size} font-semibold leading-tight text-text-primary`}>
-                  {entry.nickname}
-                </span>
-              </li>
-            );
-          })}
-        </ol>
-      ) : (
-        <p className="text-xl font-normal leading-7 text-text-secondary">
-          결과를 불러오지 못했어요
-        </p>
-      )}
-      <div className="flex flex-col items-center gap-3">
-        <div className="flex items-center gap-3">
-          <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>
-            대시보드로
-          </Link>
-          <Button onClick={onCreateNext} disabled={isPending}>
-            새 게임 만들기
-          </Button>
+      {/* 본문만 남는 공간에서 가운데 정렬합니다. 제목은 화면마다 같은 높이에 있어야 합니다. */}
+      <div className="flex flex-1 flex-col items-center gap-12">
+        {podium.length > 0 ? (
+          <ol className="flex flex-wrap items-end justify-center gap-16 pt-[6dvh]">
+            {podium.map((entry) => {
+              const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
+
+              return (
+                <li key={entry.participant.id} className="flex flex-col items-center gap-3">
+                  <span className={`rounded-full font-normal leading-6 ${style.badge}`}>
+                    {entry.rank}등
+                  </span>
+                  <span className={`${style.size} font-semibold leading-tight text-text-primary`}>
+                    {entry.participant.nickname}
+                  </span>
+                </li>
+              );
+            })}
+          </ol>
+        ) : (
+          <p className="text-xl font-normal leading-7 text-text-secondary">
+            결과를 불러오지 못했어요
+          </p>
+        )}
+
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex items-center gap-3">
+            <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>
+              대시보드로
+            </Link>
+            <Button onClick={onCreateNext} disabled={isPending}>
+              새 게임 만들기
+            </Button>
+          </div>
+          <p className="text-sm font-normal leading-5 text-text-tertiary">
+            {game.participants.length}명이 참가했어요
+          </p>
         </div>
-        <p className="text-sm font-normal leading-5 text-text-tertiary">
-          {game.participantCount}명이 참가했어요
-        </p>
       </div>
     </section>
   );

--- a/components/game/host/GameHostView.tsx
+++ b/components/game/host/GameHostView.tsx
@@ -53,7 +53,7 @@ const GameHostView = () => {
           <ConfirmDialog
             open={isStartAsking}
             title="지금 시작할까요?"
-            description={`${game.participantCount}명이 참가했어요. 시작하면 더 참가할 수 없어요`}
+            description={`${game.participants.length}명이 참가했어요. 시작하면 더 참가할 수 없어요`}
             onClose={() => setIsStartAsking(false)}
             actions={
               <>
@@ -106,7 +106,7 @@ const GameHostView = () => {
         `router.back()`이 아니라 목적지를 박아둡니다. 주소를 직접 치고 들어오거나 행사
         내내 켜두는 화면이라 히스토리가 어디를 가리킬지 모릅니다.
       */}
-      <div className="w-full">
+      <div className="mx-auto w-full max-w-6xl">
         <Link
           href={`/events/${eventCode}/dashboard`}
           className="-ml-1 flex w-fit cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
@@ -115,7 +115,9 @@ const GameHostView = () => {
           <ChevronLeftIcon className="h-6 w-6" />
         </Link>
       </div>
-      <div className="flex flex-1 flex-col justify-center">{renderBody()}</div>{' '}
+      <div className="mx-auto flex w-full max-w-6xl flex-1 flex-col justify-center">
+        {renderBody()}
+      </div>
     </>
   );
 };

--- a/components/game/host/GameHostView.tsx
+++ b/components/game/host/GameHostView.tsx
@@ -23,7 +23,7 @@ import { useHostGame } from '@/hooks/useHostGame';
 
 const GameHostView = () => {
   const { eventCode } = useParams<{ eventCode: string }>();
-  const { game, isLoading, isError, isPending, create, open, start, finish } =
+  const { game, openSessionTitle, isLoading, isError, isPending, create, open, start, finish } =
     useHostGame(eventCode);
 
   /*
@@ -44,6 +44,7 @@ const GameHostView = () => {
       return (
         <>
           <GameRecruiting
+            sessionTitle={openSessionTitle}
             game={game}
             joinUrl={joinUrl}
             isPending={isPending}
@@ -75,7 +76,7 @@ const GameHostView = () => {
     }
 
     if (game.status === 'RUNNING') {
-      return <GameRunning game={game} onFinish={finish} />;
+      return <GameRunning sessionTitle={openSessionTitle} game={game} onFinish={finish} />;
     }
 
     /*
@@ -84,6 +85,7 @@ const GameHostView = () => {
      */
     return (
       <GameFinished
+        sessionTitle={openSessionTitle}
         game={game}
         eventCode={eventCode}
         isPending={isPending}
@@ -113,8 +115,7 @@ const GameHostView = () => {
           <ChevronLeftIcon className="h-6 w-6" />
         </Link>
       </div>
-
-      {renderBody()}
+      <div className="flex flex-1 flex-col justify-center">{renderBody()}</div>{' '}
     </>
   );
 };

--- a/components/game/host/GameRecruiting.tsx
+++ b/components/game/host/GameRecruiting.tsx
@@ -24,57 +24,68 @@ import type { GameView } from '@/lib/schemas/api';
 const NAME_TAG_LIMIT = 30;
 
 interface GameRecruitingProps {
+  sessionTitle: string;
   game: GameView;
-  /** 참가자가 찍을 주소입니다. 소감 화면을 가리킵니다. */
   joinUrl: string;
   isPending: boolean;
   onStart: () => void;
 }
 
-const GameRecruiting = ({ game, joinUrl, isPending, onStart }: GameRecruitingProps) => {
+const GameRecruiting = ({
+  sessionTitle,
+  game,
+  joinUrl,
+  isPending,
+  onStart,
+}: GameRecruitingProps) => {
   const showNames = game.participantCount <= NAME_TAG_LIMIT;
 
   return (
-    <section className="flex flex-col gap-8">
+    <section className="flex flex-1 flex-col justify-center gap-10">
       <div className="flex flex-col items-center gap-1">
-        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
+        {sessionTitle ? (
+          <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
+        ) : null}
         <h1 className="text-4xl font-semibold leading-tight text-text-primary">
           QR을 찍고 참가하세요
         </h1>
       </div>
 
-      <div className="flex flex-col items-center gap-8 md:flex-row md:items-start md:justify-center">
+      {/* QR과 인원만 가로로 둡니다. 명단은 아래에서 폭을 다 씁니다. */}
+      <div className="flex flex-col items-center gap-8 md:flex-row md:justify-center md:gap-16">
         <div className="flex flex-col items-center gap-3">
           <div className="rounded-xl bg-background-default p-4">
-            <QRCodeSVG value={joinUrl} title="참가자 진입 주소 QR 코드" className="h-64 w-64" />
+            <QRCodeSVG value={joinUrl} title="참가자 진입 주소 QR 코드" className="h-56 w-56" />
           </div>
           <p className="text-sm font-normal leading-5 text-text-tertiary">{joinUrl}</p>
         </div>
 
-        <div className="flex flex-col items-center gap-4 md:min-w-80">
-          <p className="text-6xl font-semibold leading-none text-text-primary">
-            {game.participantCount}
-            <span className="text-2xl font-normal text-text-secondary">명</span>
-          </p>
-
-          {showNames ? (
-            <ul className="flex flex-wrap justify-center gap-2">
-              {game.participants.map((participant) => (
-                <li
-                  key={participant.id}
-                  className="rounded-full bg-primary-subtle px-3 py-1 text-base font-normal leading-6 text-primary-darker"
-                >
-                  {participant.nickname}
-                </li>
-              ))}
-            </ul>
-          ) : (
-            <p className="text-base font-normal leading-6 text-text-secondary">
-              이름은 레이스에서 보여드릴게요
-            </p>
-          )}
-        </div>
+        <p className="text-7xl font-semibold leading-none text-text-primary">
+          {game.participantCount}
+          <span className="text-3xl font-normal text-text-secondary">명</span>
+        </p>
       </div>
+
+      {/*
+        명단은 전체 폭으로 펼칩니다. 좁은 칼럼에 두면 세로로 길게 늘어져서 프로젝터의
+        가로 공간이 비고, 뒤쪽 사람은 아래 이름을 못 읽습니다.
+      */}
+      {showNames ? (
+        <ul className="flex flex-wrap justify-center gap-3">
+          {game.participants.map((participant) => (
+            <li
+              key={participant.id}
+              className="rounded-full bg-primary-subtle px-5 py-2 text-2xl font-normal leading-8 text-primary-darker"
+            >
+              {participant.nickname}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-center text-xl font-normal leading-7 text-text-secondary">
+          이름은 레이스에서 보여드릴게요
+        </p>
+      )}
 
       <div className="flex justify-center">
         <Button onClick={onStart} disabled={isPending || game.participantCount === 0}>

--- a/components/game/host/GameRecruiting.tsx
+++ b/components/game/host/GameRecruiting.tsx
@@ -38,11 +38,11 @@ const GameRecruiting = ({
   isPending,
   onStart,
 }: GameRecruitingProps) => {
-  const showNames = game.participantCount <= NAME_TAG_LIMIT;
+  const showNames = game.participants.length <= NAME_TAG_LIMIT;
 
   return (
-    <section className="flex flex-1 flex-col justify-center gap-10">
-      <div className="flex flex-col items-center gap-1">
+    <section className="flex flex-1 flex-col">
+      <div className="flex flex-col items-center gap-1 pt-[6dvh]">
         {sessionTitle ? (
           <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
         ) : null}
@@ -51,46 +51,49 @@ const GameRecruiting = ({
         </h1>
       </div>
 
-      {/* QR과 인원만 가로로 둡니다. 명단은 아래에서 폭을 다 씁니다. */}
-      <div className="flex flex-col items-center gap-8 md:flex-row md:justify-center md:gap-16">
-        <div className="flex flex-col items-center gap-3">
-          <div className="rounded-xl bg-background-default p-4">
-            <QRCodeSVG value={joinUrl} title="참가자 진입 주소 QR 코드" className="h-56 w-56" />
+      {/* 본문만 남는 공간에서 가운데 정렬합니다. 제목은 화면마다 같은 높이에 있어야 합니다. */}
+      <div className="flex flex-1 flex-col justify-center gap-10">
+        {/* QR과 인원만 가로로 둡니다. 명단은 아래에서 폭을 다 씁니다. */}
+        <div className="flex flex-col items-center gap-8 md:flex-row md:justify-center md:gap-16">
+          <div className="flex flex-col items-center gap-3">
+            <div className="rounded-xl bg-background-default p-4">
+              <QRCodeSVG value={joinUrl} title="참가자 진입 주소 QR 코드" className="h-56 w-56" />
+            </div>
+            <p className="text-sm font-normal leading-5 text-text-tertiary">{joinUrl}</p>
           </div>
-          <p className="text-sm font-normal leading-5 text-text-tertiary">{joinUrl}</p>
+
+          <p className="text-7xl font-semibold leading-none text-text-primary">
+            {game.participants.length}
+            <span className="text-3xl font-normal text-text-secondary">명</span>
+          </p>
         </div>
 
-        <p className="text-7xl font-semibold leading-none text-text-primary">
-          {game.participantCount}
-          <span className="text-3xl font-normal text-text-secondary">명</span>
-        </p>
-      </div>
+        {/*
+          명단은 전체 폭으로 펼칩니다. 좁은 칼럼에 두면 세로로 길게 늘어져서 프로젝터의
+          가로 공간이 비고, 뒤쪽 사람은 아래 이름을 못 읽습니다.
+        */}
+        {showNames ? (
+          <ul className="flex flex-wrap justify-center gap-3">
+            {game.participants.map((participant) => (
+              <li
+                key={participant.id}
+                className="rounded-full bg-primary-subtle px-5 py-2 text-2xl font-normal leading-8 text-primary-darker"
+              >
+                {participant.nickname}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-center text-xl font-normal leading-7 text-text-secondary">
+            이름은 레이스에서 보여드릴게요
+          </p>
+        )}
 
-      {/*
-        명단은 전체 폭으로 펼칩니다. 좁은 칼럼에 두면 세로로 길게 늘어져서 프로젝터의
-        가로 공간이 비고, 뒤쪽 사람은 아래 이름을 못 읽습니다.
-      */}
-      {showNames ? (
-        <ul className="flex flex-wrap justify-center gap-3">
-          {game.participants.map((participant) => (
-            <li
-              key={participant.id}
-              className="rounded-full bg-primary-subtle px-5 py-2 text-2xl font-normal leading-8 text-primary-darker"
-            >
-              {participant.nickname}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p className="text-center text-xl font-normal leading-7 text-text-secondary">
-          이름은 레이스에서 보여드릴게요
-        </p>
-      )}
-
-      <div className="flex justify-center">
-        <Button onClick={onStart} disabled={isPending || game.participantCount === 0}>
-          {isPending ? '시작하는 중…' : '시작하기'}
-        </Button>
+        <div className="flex justify-center">
+          <Button onClick={onStart} disabled={isPending || game.participants.length === 0}>
+            {isPending ? '시작하는 중…' : '시작하기'}
+          </Button>
+        </div>
       </div>
     </section>
   );

--- a/components/game/host/GameRunning.tsx
+++ b/components/game/host/GameRunning.tsx
@@ -34,14 +34,14 @@ const GameRunning = ({ sessionTitle, game, onFinish }: GameRunningProps) => {
   }));
 
   return (
-    <section className="flex flex-col items-center gap-6">
+    <section className="flex flex-1 flex-col items-center justify-center gap-6">
+      {' '}
       <div className="flex flex-col items-center gap-1">
         {sessionTitle ? (
           <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
         ) : null}
         <h1 className="text-4xl font-semibold leading-tight text-text-primary">레이스 중이에요</h1>
       </div>
-
       <PinballCanvas participants={race.participants} seed={race.seed} onFinish={onFinish} />
     </section>
   );

--- a/components/game/host/GameRunning.tsx
+++ b/components/game/host/GameRunning.tsx
@@ -1,89 +1,48 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
+
+import { PinballCanvas } from './pinball/PinballCanvas';
 import type { GameView } from '@/lib/schemas/api';
-import { buildRevealOrder, toRanking } from '@/components/game/host/raceOrder';
 
 /**
- * 레이스 중 화면입니다. 1단계는 핀볼을 그리지 않고 이름을 꼴등부터 하나씩 드러냅니다(#243).
+ * 레이스 중 화면입니다. 핀볼을 그리고, 전원이 결승선을 지나면 순위를 올립니다.
  *
- * 물리 엔진은 2단계입니다. 계약을 먼저 돌려보려고 연출을 미뤘습니다 — 상태 전이와 결과
- * 확정이 실제로 도는 걸 확인한 뒤에 얹는 게 순서고, 연출을 갈아 끼워도 계약은 안 바뀝니다.
- *
- * 순위는 여기서 정합니다. 물리 시뮬레이션이 없으니 무작위로 섞습니다. 서버가 순위를
- * 검증하지 않기로 해서(#246) 계약을 어기지는 않습니다.
+ * 순차 공개 연출(1단계)을 여기서 걷어냈습니다. 계약은 안 바뀝니다 — `onFinish`가 받는
+ * 값의 모양이 같아서, 연출을 갈아 끼워도 위쪽은 그대로입니다(#243).
  */
 
-/** 한 명씩 드러나는 간격입니다. 너무 빠르면 긴장감이 없고 느리면 지루합니다. */
-const REVEAL_INTERVAL_MS = 800;
-
 interface GameRunningProps {
+  /** 지금 열린 세션 제목입니다. 게임 제목은 주최자용 메모라 참가자에게 안 보여줍니다. */
+  sessionTitle: string;
   game: GameView;
-  /** 전원이 드러나면 부릅니다. 1등부터 담은 `participantId` 배열입니다. */
   onFinish: (ranking: number[]) => void;
 }
 
-const GameRunning = ({ game, onFinish }: GameRunningProps) => {
+const GameRunning = ({ sessionTitle, game, onFinish }: GameRunningProps) => {
   /*
-   * 순서를 한 번만 뽑습니다. 렌더마다 다시 섞으면 폴링이 돌 때마다 순위가 바뀝니다.
-   * 초기화 함수를 넘겨서 첫 렌더에서만 실행되게 했습니다.
-   */
-  const [order] = useState(() => buildRevealOrder(game.participants));
-  const [revealed, setRevealed] = useState(0);
-
-  /*
-   * 결과를 한 번만 올립니다. `onFinish`는 렌더마다 새 함수라 deps에 넣으면 effect가 계속
-   * 다시 돕니다 — 올림 → 목록 무효화 → 리렌더 → 새 함수 → 다시 올림으로 무한히 갑니다.
+   * 참가자 목록과 시드를 마운트 시점에 고정합니다.
    *
-   * state가 아니라 ref인 이유는 이 값이 화면에 안 나오기 때문입니다. state로 두면 바꿀
-   * 때마다 렌더가 한 번 더 돌고, effect 안에서 setState를 부르는 게 되어 React 19가 막습니다.
+   * 프로젝터 화면이 3초마다 폴링해서 `game.participants`가 새 배열로 옵니다. 그대로
+   * 넘기면 `PinballCanvas`의 effect가 다시 돌아 레이스가 처음부터 시작합니다.
+   *
+   * 시드도 같은 이유로 여기서 한 번만 뽑습니다. 렌더마다 뽑으면 매번 다른 레이스가 됩니다.
    */
-  const hasSubmitted = useRef(false);
-
-  const isComplete = revealed >= order.length;
-
-  useEffect(() => {
-    if (isComplete) return;
-
-    const timer = setTimeout(() => setRevealed((count) => count + 1), REVEAL_INTERVAL_MS);
-    return () => clearTimeout(timer);
-  }, [revealed, isComplete]);
-
-  /*
-   * 전원이 드러나면 결과를 올립니다. 별도 effect로 뺀 이유는 위가 타이머만 맡게 하려는
-   * 것이고, `onFinish`가 여러 번 불리지 않도록 `isComplete`가 한 번만 참이 되게 했습니다.
-   */
-  useEffect(() => {
-    if (!isComplete || order.length === 0 || hasSubmitted.current) return;
-
-    hasSubmitted.current = true;
-    onFinish(toRanking(order));
-  }, [isComplete, order, onFinish]);
+  const [race] = useState(() => ({
+    participants: game.participants,
+    seed: Math.floor(Math.random() * 0xffffffff),
+  }));
 
   return (
-    <section className="flex flex-col items-center gap-8">
+    <section className="flex flex-col items-center gap-6">
       <div className="flex flex-col items-center gap-1">
-        <p className="text-base font-normal leading-6 text-text-secondary">{game.title}</p>
-        <h1 className="text-4xl font-semibold leading-tight text-text-primary">
-          {isComplete ? '결과를 정리하는 중이에요' : '레이스 중이에요'}
-        </h1>
+        {sessionTitle ? (
+          <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
+        ) : null}
+        <h1 className="text-4xl font-semibold leading-tight text-text-primary">레이스 중이에요</h1>
       </div>
 
-      <p className="text-xl font-normal leading-7 text-text-secondary">
-        {order.length - revealed}
-        <span className="text-base"> 명 남았어요</span>
-      </p>
-
-      <ul className="flex flex-wrap justify-center gap-2">
-        {order.slice(0, revealed).map((participant, index) => (
-          <li
-            key={participant.id}
-            className="rounded-full bg-neutral-subtle px-3 py-1 text-base font-normal leading-6 text-neutral-darker"
-          >
-            {order.length - index}등 {participant.nickname}
-          </li>
-        ))}
-      </ul>
+      <PinballCanvas participants={race.participants} seed={race.seed} onFinish={onFinish} />
     </section>
   );
 };

--- a/components/game/host/GameRunning.tsx
+++ b/components/game/host/GameRunning.tsx
@@ -34,15 +34,16 @@ const GameRunning = ({ sessionTitle, game, onFinish }: GameRunningProps) => {
   }));
 
   return (
-    <section className="flex flex-1 flex-col items-center justify-center gap-6">
-      {' '}
-      <div className="flex flex-col items-center gap-1">
+    <section className="flex flex-1 flex-col">
+      <div className="flex flex-col items-center gap-1 pt-[6dvh]">
         {sessionTitle ? (
           <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
         ) : null}
         <h1 className="text-4xl font-semibold leading-tight text-text-primary">레이스 중이에요</h1>
       </div>
-      <PinballCanvas participants={race.participants} seed={race.seed} onFinish={onFinish} />
+      <div className="flex flex-1 flex-col justify-center">
+        <PinballCanvas participants={race.participants} seed={race.seed} onFinish={onFinish} />
+      </div>
     </section>
   );
 };

--- a/components/game/host/GameSetup.tsx
+++ b/components/game/host/GameSetup.tsx
@@ -44,7 +44,7 @@ const GameSetup = ({ game, isPending, onCreate, onOpen }: GameSetupProps) => {
     return (
       <form
         onSubmit={handleSubmit}
-        className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-4"
+        className="mx-auto flex w-full max-w-md flex-1 flex-col gap-4 pt-[12dvh]"
       >
         {' '}
         <div className="flex flex-col gap-1">
@@ -73,7 +73,7 @@ const GameSetup = ({ game, isPending, onCreate, onOpen }: GameSetupProps) => {
   }
 
   return (
-    <section className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-6 text-center">
+    <section className="mx-auto flex w-full max-w-md flex-1 flex-col gap-6 pt-[12dvh] text-center">
       {' '}
       <div className="flex flex-col gap-1">
         <p className="text-sm font-normal leading-5 text-text-secondary">{game.title}</p>

--- a/components/game/host/GameSetup.tsx
+++ b/components/game/host/GameSetup.tsx
@@ -42,7 +42,11 @@ const GameSetup = ({ game, isPending, onCreate, onOpen }: GameSetupProps) => {
 
   if (game === null) {
     return (
-      <form onSubmit={handleSubmit} className="mx-auto flex w-full max-w-md flex-col gap-4">
+      <form
+        onSubmit={handleSubmit}
+        className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-4"
+      >
+        {' '}
         <div className="flex flex-col gap-1">
           <h1 className="text-2xl font-semibold leading-8 text-text-primary">게임 만들기</h1>
           <p className="text-sm font-normal leading-5 text-text-secondary">
@@ -69,7 +73,8 @@ const GameSetup = ({ game, isPending, onCreate, onOpen }: GameSetupProps) => {
   }
 
   return (
-    <section className="mx-auto flex w-full max-w-md flex-col gap-6 text-center">
+    <section className="mx-auto flex w-full max-w-md flex-1 flex-col justify-center gap-6 text-center">
+      {' '}
       <div className="flex flex-col gap-1">
         <p className="text-sm font-normal leading-5 text-text-secondary">{game.title}</p>
         <h1 className="text-2xl font-semibold leading-8 text-text-primary">준비됐어요</h1>

--- a/components/game/host/pinball/PinballCanvas.tsx
+++ b/components/game/host/pinball/PinballCanvas.tsx
@@ -84,7 +84,12 @@ const draw = (
   context.setLineDash([]);
 
   context.textAlign = 'center';
-  context.font = '500 36px system-ui, sans-serif';
+  /*
+   * 폰트 이름을 직접 씁니다. 캔버스 `font`는 CSS 변수를 해석하지 않아서 `var(--font-sans)`를
+   * 넣으면 문자열 전체가 무효가 되고 기본값 10px로 떨어집니다. `globals.css`의 `--font-sans`와
+   * 같은 값을 손으로 맞춰둔 것이라, 그쪽이 바뀌면 여기도 봐야 합니다.
+   */
+  context.font = "500 36px 'Pretendard Variable', system-ui, sans-serif";
 
   frame.balls.forEach((ball: Ball, index) => {
     context.fillStyle = palette.balls[index % palette.balls.length];
@@ -183,7 +188,7 @@ const PinballCanvas = ({ participants, seed, onFinish }: PinballCanvasProps) => 
         ref={canvasRef}
         width={BOARD.width}
         height={BOARD.height}
-        className="h-[60dvh] w-auto rounded-xl"
+        className="max-h-[55dvh] w-full max-w-[70vw] rounded-xl"
         aria-label="핀볼 레이스"
       />
 

--- a/components/game/host/pinball/PinballCanvas.tsx
+++ b/components/game/host/pinball/PinballCanvas.tsx
@@ -1,0 +1,226 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  BALL_RADIUS,
+  BOARD,
+  FINISH_Y,
+  NAME_TAG_LIMIT,
+  PEGS,
+  PEG_RADIUS,
+} from '@/components/game/host/pinball/board';
+import {
+  MAX_FRAMES,
+  createRace,
+  createRandom,
+  step,
+  type Ball,
+  type RaceFrame,
+} from '@/components/game/host/pinball/simulation';
+import type { GameParticipant } from '@/lib/schemas/api';
+
+/**
+ * 레이스를 캔버스에 그립니다. 물리는 `simulation.ts`가 맡고 여기는 그리기만 합니다.
+ *
+ * 프레임 상태를 React state로 두지 않습니다. 60fps로 `setState`를 부르면 초당 60번
+ * 리렌더가 돌아서 47개 구슬을 그리기 전에 화면이 먼저 멈춥니다. 캔버스에 직접 그리고,
+ * 상태는 **완주자가 늘어날 때만** 올립니다.
+ */
+
+/** 구슬 색입니다. 이름을 못 읽는 거리에서도 자기 구슬을 색으로 찾습니다. */
+const BALL_TOKENS = [
+  '--color-primary-lighter',
+  '--color-positive-lighter',
+  '--color-warning-lighter',
+  '--color-negative-lighter',
+  '--color-toxic-lighter',
+] as const;
+
+/**
+ * 캔버스는 CSS 클래스를 못 씁니다. 토큰 값을 읽어와야 하드코딩된 hex가 안 남습니다.
+ *
+ * `getComputedStyle`이 비싸서 한 번만 읽고 들고 다닙니다. 프레임마다 부르면 60fps에서
+ * 레이아웃 계산이 초당 60번 돕니다.
+ */
+const readPalette = (element: HTMLElement) => {
+  const styles = getComputedStyle(element);
+  const token = (name: string) => styles.getPropertyValue(name).trim();
+
+  return {
+    board: token('--color-background-inverse'),
+    peg: token('--color-neutral-default'),
+    finish: token('--color-neutral-lighter'),
+    label: token('--color-text-inverse'),
+    balls: BALL_TOKENS.map(token),
+  };
+};
+
+type Palette = ReturnType<typeof readPalette>;
+
+const draw = (
+  context: CanvasRenderingContext2D,
+  frame: RaceFrame,
+  palette: Palette,
+  showNames: boolean,
+) => {
+  context.fillStyle = palette.board;
+  context.fillRect(0, 0, BOARD.width, BOARD.height);
+
+  context.fillStyle = palette.peg;
+  for (const peg of PEGS) {
+    context.beginPath();
+    context.arc(peg.x, peg.y, PEG_RADIUS, 0, Math.PI * 2);
+    context.fill();
+  }
+
+  context.strokeStyle = palette.finish;
+  context.lineWidth = 4;
+  context.setLineDash([18, 12]);
+  context.beginPath();
+  context.moveTo(0, FINISH_Y);
+  context.lineTo(BOARD.width, FINISH_Y);
+  context.stroke();
+  context.setLineDash([]);
+
+  context.textAlign = 'center';
+  context.font = '500 36px system-ui, sans-serif';
+
+  frame.balls.forEach((ball: Ball, index) => {
+    context.fillStyle = palette.balls[index % palette.balls.length];
+    context.beginPath();
+    context.arc(ball.x, ball.y, BALL_RADIUS, 0, Math.PI * 2);
+    context.fill();
+
+    if (!showNames) return;
+
+    context.fillStyle = palette.label;
+    // 구슬 위에 답니다. 안에 넣으면 반지름 16에 12자가 안 들어갑니다.
+    context.fillText(ball.nickname, ball.x, ball.y - BALL_RADIUS - 12);
+  });
+};
+
+interface PinballCanvasProps {
+  /** 마운트 시점에 고정된 목록이어야 합니다. 바뀌면 레이스가 처음부터 다시 돕니다. */
+  participants: readonly GameParticipant[];
+  seed: number;
+  /** 완주 순서입니다. 1등부터 담은 `participantId` 배열입니다. */
+  onFinish: (ranking: number[]) => void;
+}
+
+const PinballCanvas = ({ participants, seed, onFinish }: PinballCanvasProps) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [finished, setFinished] = useState<GameParticipant[]>([]);
+
+  /*
+   * 최신 `onFinish`를 ref에 담아둡니다. deps에 넣으면 렌더마다 정체성이 바뀌어 effect가
+   * 다시 돌고 레이스가 처음부터 시작합니다. 프로젝터 화면이 3초마다 폴링하니 실제로
+   * 그렇게 됩니다.
+   */
+  const onFinishRef = useRef(onFinish);
+  useEffect(() => {
+    onFinishRef.current = onFinish;
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    const context = canvas?.getContext('2d');
+    if (!canvas || !context) return;
+
+    const palette = readPalette(canvas);
+    const showNames = participants.length <= NAME_TAG_LIMIT;
+    const random = createRandom(seed);
+
+    let frame = createRace(participants, seed);
+    let frames = 0;
+    let reported = 0;
+    let animationId = 0;
+
+    const loop = () => {
+      const isOver = frame.isComplete || frames >= MAX_FRAMES;
+
+      if (!isOver) {
+        frame = step(frame, random, BALL_RADIUS);
+        frames += 1;
+      }
+
+      draw(context, frame, palette, showNames);
+
+      /*
+       * 완주자가 늘어난 프레임에만 상태를 올립니다. 매 프레임 올리면 60fps 리렌더가 되고,
+       * 아예 안 올리면 옆 순위표가 안 채워집니다.
+       */
+      if (frame.finished.length !== reported) {
+        reported = frame.finished.length;
+        const byId = new Map(participants.map((participant) => [participant.id, participant]));
+        setFinished(
+          frame.finished
+            .map((id) => byId.get(id))
+            .filter((participant): participant is GameParticipant => participant !== undefined),
+        );
+      }
+
+      if (isOver) {
+        /*
+         * `MAX_FRAMES`에 걸려 끝난 경우 완주 못 한 구슬이 남습니다. 서버는 부분 순위를
+         * 허용하므로(#246) 남은 사람은 결과에서 빠집니다. 레이스가 안 끝나 화면이 굳는
+         * 것보다는 낫다고 봤습니다.
+         */
+        onFinishRef.current(frame.finished);
+        return;
+      }
+
+      animationId = requestAnimationFrame(loop);
+    };
+
+    animationId = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(animationId);
+  }, [participants, seed]);
+
+  return (
+    <div className="flex flex-col items-center gap-6 md:flex-row md:items-start md:justify-center">
+      <canvas
+        ref={canvasRef}
+        width={BOARD.width}
+        height={BOARD.height}
+        className="h-[60dvh] w-auto rounded-xl"
+        aria-label="핀볼 레이스"
+      />
+
+      <div className="flex w-full flex-col gap-4 md:w-80">
+        <p className="text-base font-normal leading-6 text-text-secondary">도착 순서</p>
+        <ol className="flex flex-col gap-3">
+          {/*
+            5칸을 미리 그려둡니다. 도착할 때마다 칸을 만들면 목록이 아래로 자라면서
+            옆 캔버스와 높이가 어긋나고, 프로젝터에서 화면이 들썩입니다.
+          */}
+          {Array.from({ length: 5 }, (_, index) => {
+            const participant = finished[index];
+
+            return (
+              <li
+                key={index}
+                className="flex items-center gap-4 rounded-xl border border-border-subtle px-5 py-4"
+              >
+                <span className="w-6 text-lg font-normal leading-7 text-text-tertiary">
+                  {index + 1}
+                </span>
+                <span
+                  className={
+                    participant
+                      ? 'text-2xl font-semibold leading-8 text-text-primary'
+                      : 'text-2xl font-normal leading-8 text-text-disabled'
+                  }
+                >
+                  {participant?.nickname ?? '—'}
+                </span>
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+    </div>
+  );
+};
+
+export { PinballCanvas };

--- a/components/game/host/pinball/board.ts
+++ b/components/game/host/pinball/board.ts
@@ -1,0 +1,64 @@
+/**
+ * 핀볼 보드의 모양입니다. 시뮬레이션과 렌더링이 같은 좌표계를 봐야 해서 상수를 한곳에 둡니다.
+ *
+ * 좌표는 보드 안쪽 기준이고 단위는 없습니다. 캔버스가 그릴 때 실제 픽셀로 늘립니다 —
+ * 프로젝터 해상도가 제각각이라 보드를 픽셀로 정하면 화면마다 물리가 달라집니다.
+ */
+
+/** 보드 안쪽 크기입니다. 세로로 긴 이유는 구슬이 위에서 아래로 떨어지기 때문입니다. */
+const BOARD = { width: 1000, height: 1400 } as const;
+
+/** 결승선입니다. 구슬 중심이 이 값을 넘으면 완주로 봅니다. */
+const FINISH_Y = 1320;
+
+/** 구슬이 출발하는 높이입니다. 보드 위쪽에 흩뿌립니다. */
+const START_Y = 60;
+
+const PEG_RADIUS = 9;
+
+/**
+ * 못을 지그재그로 놓습니다. 줄마다 반 칸씩 어긋나야 구슬이 좌우로 갈립니다.
+ *
+ * 줄 수가 레이스 길이를 정합니다. 지금 값으로 30초~1분을 노렸고, 실제로 띄워보고
+ * `GRAVITY`와 같이 조정합니다.
+ */
+const PEG_ROWS = 24;
+const PEG_COLUMNS = 9;
+const PEG_TOP = 180;
+const PEG_BOTTOM = 1240;
+const PEG_MARGIN = 90;
+
+/**
+ * 못 좌표를 미리 계산해 둡니다. 매 프레임 다시 만들면 47개 구슬 × 108개 못을 곱한 만큼
+ * 객체가 새로 생깁니다.
+ */
+const PEGS: readonly { x: number; y: number }[] = Array.from({ length: PEG_ROWS }, (_, row) => {
+  const y = PEG_TOP + ((PEG_BOTTOM - PEG_TOP) / (PEG_ROWS - 1)) * row;
+  // 홀수 줄을 반 칸 밀어 지그재그를 만듭니다. 밀린 줄은 못이 하나 적습니다.
+  const isOffset = row % 2 === 1;
+  const count = isOffset ? PEG_COLUMNS - 1 : PEG_COLUMNS;
+  const gap = (BOARD.width - PEG_MARGIN * 2) / (PEG_COLUMNS - 1);
+  const left = isOffset ? PEG_MARGIN + gap / 2 : PEG_MARGIN;
+
+  return Array.from({ length: count }, (_, column) => ({
+    x: left + gap * column,
+    y,
+  }));
+}).flat();
+
+/**
+ * 구슬 반지름입니다. 인원과 무관하게 고정입니다.
+ *
+ * 처음엔 인원이 적을 때 크게 그리려 했는데, 큰 구슬은 못 사이를 잘 못 빠져나가서
+ * 12명 레이스가 47명보다 5배 오래 걸렸습니다(측정값). 물리가 인원에 따라 달라지면
+ * 레이스 길이를 예측할 수 없습니다.
+ *
+ * 47개가 폭 1000에 나란히 서려면 하나가 10 이하여야 하지만, 출발 위치를 흩뿌리므로
+ * 겹쳐도 됩니다.
+ */
+const BALL_RADIUS = 16;
+
+/** 이름표를 다는 최대 인원입니다. `GameRecruiting`과 같은 기준입니다(#243·#288). */
+const NAME_TAG_LIMIT = 30;
+
+export { BOARD, FINISH_Y, START_Y, PEGS, PEG_RADIUS, NAME_TAG_LIMIT, BALL_RADIUS };

--- a/components/game/host/pinball/board.ts
+++ b/components/game/host/pinball/board.ts
@@ -5,14 +5,24 @@
  * 프로젝터 해상도가 제각각이라 보드를 픽셀로 정하면 화면마다 물리가 달라집니다.
  */
 
-/** 보드 안쪽 크기입니다. 세로로 긴 이유는 구슬이 위에서 아래로 떨어지기 때문입니다. */
-const BOARD = { width: 1000, height: 1400 } as const;
+/** 보드 안쪽 크기입니다. 프로젝터가 16:9라 가로를 넓게 씁니다. */
+const BOARD = { width: 1400, height: 1000 } as const;
 
 /** 결승선입니다. 구슬 중심이 이 값을 넘으면 완주로 봅니다. */
-const FINISH_Y = 1320;
+const FINISH_Y = 920;
 
 /** 구슬이 출발하는 높이입니다. 보드 위쪽에 흩뿌립니다. */
-const START_Y = 60;
+const START_Y = 50;
+
+/**
+ * 구슬이 출발하는 가로 폭입니다. 보드 전체가 아니라 가운데 60%만 씁니다.
+ *
+ * 전체 폭에 흩뿌리면 벽 근처 구슬이 못을 한 번도 안 만나고 흘러내립니다(측정값: 최소
+ * 충돌 0회). 그 구슬은 레이스에 참여하지 않고 순위만 차지해서 긴장감을 깎습니다.
+ *
+ * 60%면 최소 충돌이 14회 이상입니다. 실제 핀볼도 위쪽 한 지점에서 떨어뜨립니다.
+ */
+const START_SPREAD = 0.6;
 
 const PEG_RADIUS = 9;
 
@@ -22,10 +32,10 @@ const PEG_RADIUS = 9;
  * 줄 수가 레이스 길이를 정합니다. 지금 값으로 30초~1분을 노렸고, 실제로 띄워보고
  * `GRAVITY`와 같이 조정합니다.
  */
-const PEG_ROWS = 24;
-const PEG_COLUMNS = 9;
-const PEG_TOP = 180;
-const PEG_BOTTOM = 1240;
+const PEG_ROWS = 20;
+const PEG_COLUMNS = 15;
+const PEG_TOP = 140;
+const PEG_BOTTOM = 840;
 const PEG_MARGIN = 90;
 
 /**
@@ -61,4 +71,4 @@ const BALL_RADIUS = 16;
 /** 이름표를 다는 최대 인원입니다. `GameRecruiting`과 같은 기준입니다(#243·#288). */
 const NAME_TAG_LIMIT = 30;
 
-export { BOARD, FINISH_Y, START_Y, PEGS, PEG_RADIUS, NAME_TAG_LIMIT, BALL_RADIUS };
+export { BOARD, FINISH_Y, START_Y, START_SPREAD, PEGS, PEG_RADIUS, NAME_TAG_LIMIT, BALL_RADIUS };

--- a/components/game/host/pinball/simulation.test.ts
+++ b/components/game/host/pinball/simulation.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from 'vitest';
+
+import { BALL_RADIUS, BOARD, FINISH_Y } from '@/components/game/host/pinball/board';
+import {
+  MAX_FRAMES,
+  createRace,
+  createRandom,
+  step,
+  type RaceFrame,
+} from '@/components/game/host/pinball/simulation';
+import type { GameParticipant } from '@/lib/schemas/api';
+
+/**
+ * 물리는 눈으로 봐서는 맞는지 알 수 없습니다. 구슬 하나가 사라지거나 못을 뚫고 지나가도
+ * 47개가 굴러가는 화면에서는 티가 안 나고, 행사에서 드러나면 이미 늦습니다.
+ */
+
+const build = (count: number): GameParticipant[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: index + 1,
+    nickname: `참가자${index + 1}`,
+    joinedAt: '2026-08-05T04:00:00.000Z',
+  }));
+
+/** 끝날 때까지 돌립니다. 실제 화면은 프레임마다 그리지만 테스트는 결과만 봅니다. */
+const runToEnd = (participants: GameParticipant[], seed: number) => {
+  const random = createRandom(seed);
+
+  let frame: RaceFrame = createRace(participants, seed);
+  let frames = 0;
+
+  while (!frame.isComplete && frames < MAX_FRAMES) {
+    frame = step(frame, random, BALL_RADIUS);
+    frames += 1;
+  }
+
+  return { frame, frames };
+};
+
+describe('createRace', () => {
+  it('구슬이 보드 안에서 출발한다', () => {
+    const { balls } = createRace(build(20), 1);
+
+    for (const ball of balls) {
+      expect(ball.x).toBeGreaterThanOrEqual(0);
+      expect(ball.x).toBeLessThanOrEqual(BOARD.width);
+      expect(ball.y).toBeLessThan(FINISH_Y);
+      expect(ball.rank).toBeNull();
+    }
+  });
+
+  it('참가자가 없으면 곧바로 끝난 상태다', () => {
+    const frame = createRace([], 1);
+
+    expect(frame.balls).toHaveLength(0);
+    expect(frame.isComplete).toBe(true);
+  });
+});
+
+describe('step', () => {
+  /*
+   * 이게 이 파일의 요점입니다. `Math.random()`을 썼다면 여기서 걸립니다.
+   *
+   * 결정적이지 않으면 화면이 리렌더될 때마다 레이스가 흔들리고, 무엇보다 아래 검사들이
+   * 전부 "이번엔 우연히 통과"가 됩니다.
+   */
+  it('같은 시드면 같은 순서가 나온다', () => {
+    const participants = build(12);
+
+    const first = runToEnd(participants, 42).frame.finished;
+    const second = runToEnd(participants, 42).frame.finished;
+
+    expect(first).toEqual(second);
+  });
+
+  it('시드가 다르면 대체로 다른 순서가 나온다', () => {
+    const participants = build(12);
+
+    const a = runToEnd(participants, 1).frame.finished;
+    const b = runToEnd(participants, 2).frame.finished;
+
+    expect(a).not.toEqual(b);
+  });
+
+  /*
+   * 구슬이 하나라도 사라지면 `POST /results`의 `ranking`에서 빠집니다. 서버는 부분 순위를
+   * 허용하므로(#246) 에러 없이 통과하고, 그 참가자만 결과에서 조용히 없어집니다.
+   */
+  it('아무도 사라지거나 중복되지 않는다', () => {
+    const participants = build(30);
+    const { frame } = runToEnd(participants, 7);
+
+    expect(frame.isComplete).toBe(true);
+    expect([...frame.finished].sort((a, b) => a - b)).toEqual(participants.map((p) => p.id));
+  });
+
+  it('구슬이 보드 밖으로 나가지 않는다', () => {
+    const participants = build(30);
+    const radius = BALL_RADIUS;
+    const random = createRandom(3);
+
+    let frame = createRace(participants, 3);
+    for (let count = 0; count < MAX_FRAMES && !frame.isComplete; count += 1) {
+      frame = step(frame, random, radius);
+
+      for (const ball of frame.balls) {
+        expect(ball.x).toBeGreaterThanOrEqual(radius - 0.001);
+        expect(ball.x).toBeLessThanOrEqual(BOARD.width - radius + 0.001);
+        expect(ball.y).toBeLessThanOrEqual(FINISH_Y);
+      }
+    }
+  });
+
+  /*
+   * 47명이 이 게임의 상한입니다(#243의 규모 구간). 그보다 많으면 룰렛으로 가는 게
+   * 3단계인데, 그전까지는 47명이 실제로 완주해야 합니다.
+   */
+  it('47명도 전원 완주한다', () => {
+    const { frame, frames } = runToEnd(build(47), 11);
+
+    expect(frame.isComplete).toBe(true);
+    expect(frame.finished).toHaveLength(47);
+    expect(frames).toBeLessThan(MAX_FRAMES);
+  });
+
+  /*
+   * 30초~1분을 노렸습니다(#243). 60fps 기준 1800~3600 프레임입니다.
+   *
+   * 범위를 넓게 잡은 이유는 이 값이 못 줄 수·중력·구슬 크기에 다 걸려 있어서입니다.
+   * 너무 좁히면 상수를 조금만 만져도 깨지는 테스트가 됩니다. 여기서 보려는 건
+   * "몇 초 만에 끝나거나 몇 분씩 걸리지 않는다"입니다.
+   */
+  it('레이스가 너무 짧거나 길지 않다', () => {
+    const { frames } = runToEnd(build(20), 5);
+
+    expect(frames).toBeGreaterThan(600); // 10초
+    expect(frames).toBeLessThan(4_200); // 70초
+  });
+
+  /*
+   * 반지름을 인원에 따라 바꿨더니 12명 레이스가 47명보다 5배 오래 걸렸습니다. 큰 구슬이
+   * 못 사이를 잘 못 빠져나가서입니다. 물리가 인원에 따라 달라지면 레이스 길이를 예측할
+   * 수 없어서 반지름을 고정했고, 이 검사가 그 결정을 지킵니다.
+   */
+  it('인원이 달라도 레이스 길이가 비슷하다', () => {
+    const short = runToEnd(build(12), 3).frames;
+    const long = runToEnd(build(47), 11).frames;
+
+    expect(Math.max(short, long) / Math.min(short, long)).toBeLessThan(2);
+  });
+
+  it('원본 프레임을 건드리지 않는다', () => {
+    const participants = build(10);
+    const random = createRandom(9);
+    const frame = createRace(participants, 9);
+    const before = frame.balls.map((ball) => ball.y);
+
+    step(frame, random, BALL_RADIUS);
+
+    expect(frame.balls.map((ball) => ball.y)).toEqual(before);
+  });
+});

--- a/components/game/host/pinball/simulation.ts
+++ b/components/game/host/pinball/simulation.ts
@@ -1,0 +1,172 @@
+import {
+  BALL_RADIUS,
+  BOARD,
+  FINISH_Y,
+  PEGS,
+  PEG_RADIUS,
+  START_Y,
+} from '@/components/game/host/pinball/board';
+import type { GameParticipant } from '@/lib/schemas/api';
+
+/**
+ * 핀볼 레이스의 물리입니다. 캔버스도 React도 모르는 순수 계산이라 값을 직접 검사할 수
+ * 있습니다(`components/game/host/raceOrder.ts`와 같은 방식).
+ *
+ * `matter.js`를 안 쓴 이유는 필요한 게 원-원 충돌·중력·벽 반사 셋뿐이라서입니다. 90KB를
+ * 더 받는 것보다, 무엇보다 **결정성을 우리가 통제할 수 있는 게** 큽니다 — 라이브러리를
+ * 끼면 같은 시드에 같은 결과가 나오는지 보장할 방법이 없습니다.
+ */
+
+/** 한 프레임에 더해지는 속도입니다. 못 줄 수와 함께 레이스 길이를 정합니다. */
+const GRAVITY = 0.06;
+
+/** 자유낙하 속도 상한입니다. 없으면 아래로 갈수록 못을 뚫고 지나갑니다. */
+const MAX_FALL_SPEED = 5;
+
+/** 못에 부딪힌 뒤 남는 속도 비율입니다. 1이면 영원히 튕기고 0이면 붙어버립니다. */
+const BOUNCE = 0.6;
+
+/** 벽에 부딪힌 뒤 남는 속도 비율입니다. 못보다 더 많이 죽여야 구석에 갇히지 않습니다. */
+const WALL_BOUNCE = 0.45;
+
+/**
+ * 못에 부딪힐 때 좌우로 흔드는 세기입니다.
+ *
+ * 이게 0이면 같은 자리에서 출발한 구슬이 같은 길로만 갑니다. 물리적으로는 맞지만 실제
+ * 핀볼은 미세한 회전과 마찰로 갈리므로, 그 몫을 난수로 흉내 냅니다.
+ */
+const JITTER = 0.6;
+
+/**
+ * 무한 루프 방지선입니다. 구슬이 어딘가 끼면 프레임이 끝없이 돌아갑니다.
+ *
+ * 60fps 기준 90초입니다. 목표(30초~1분)보다 넉넉하게 뒀고, 여기 닿으면 남은 구슬을
+ * 지금 위치 순서대로 완주 처리합니다.
+ */
+const MAX_FRAMES = 5_400;
+
+/**
+ * 시드에서 난수를 만듭니다(mulberry32).
+ *
+ * `Math.random()`을 쓰면 같은 레이스를 두 번 돌릴 수 없어서 테스트가 불가능합니다.
+ * 화면이 리렌더될 때 레이스가 흔들리는 문제도 여기서 같이 막힙니다.
+ */
+const createRandom = (seed: number): (() => number) => {
+  let state = seed >>> 0;
+
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+interface Ball {
+  participantId: number;
+  nickname: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  /** 결승선을 통과한 순서입니다. 아직이면 `null`입니다. */
+  rank: number | null;
+}
+
+interface RaceFrame {
+  balls: Ball[];
+  /** 완주한 `participantId`를 1등부터 담습니다. */
+  finished: number[];
+  isComplete: boolean;
+}
+
+/**
+ * 출발 상태를 만듭니다. 구슬을 보드 위쪽에 가로로 흩뿌립니다.
+ *
+ * 시작 위치와 속도에 난수를 섞는 이유는, 같은 자리에서 같은 속도로 떨어지면 못에 맞는
+ * 각도까지 같아져서 여러 구슬이 겹쳐 다니기 때문입니다.
+ */
+const createRace = (participants: readonly GameParticipant[], seed: number): RaceFrame => {
+  const random = createRandom(seed);
+  const lane = (BOARD.width - BALL_RADIUS * 2) / Math.max(participants.length, 1);
+
+  return {
+    balls: participants.map((participant, index) => ({
+      participantId: participant.id,
+      nickname: participant.nickname,
+      x: BALL_RADIUS + lane * (index + 0.5) + (random() - 0.5) * lane * 0.6,
+      y: START_Y + random() * 40,
+      vx: (random() - 0.5) * 2,
+      vy: 0,
+      rank: null,
+    })),
+    finished: [],
+    isComplete: participants.length === 0,
+  };
+};
+
+/**
+ * 한 프레임을 진행합니다. 상태를 새로 만들어 돌려주고 인자를 건드리지 않습니다.
+ *
+ * `random`을 인자로 받는 이유는 프레임마다 같은 난수열을 이어 써야 하기 때문입니다.
+ * 안에서 새로 만들면 매 프레임 같은 값이 나와 구슬이 전부 같은 방향으로 흔들립니다.
+ */
+const step = (frame: RaceFrame, random: () => number, radius: number): RaceFrame => {
+  const finished = [...frame.finished];
+
+  const balls = frame.balls.map((ball) => {
+    if (ball.rank !== null) return ball;
+
+    let { x, y, vx, vy } = ball;
+
+    vy = Math.min(vy + GRAVITY, MAX_FALL_SPEED);
+    x += vx;
+    y += vy;
+
+    // 벽. 반지름만큼 안쪽에서 튕겨야 구슬이 테두리를 파고들지 않습니다.
+    if (x < radius) {
+      x = radius;
+      vx = Math.abs(vx) * WALL_BOUNCE;
+    } else if (x > BOARD.width - radius) {
+      x = BOARD.width - radius;
+      vx = -Math.abs(vx) * WALL_BOUNCE;
+    }
+
+    /*
+     * 못 충돌입니다. 겹친 만큼 밀어낸 뒤 법선 방향 속도를 뒤집습니다.
+     *
+     * 모든 못을 훑습니다. 108개 × 47구슬 = 5천 번인데 프레임당이라 60fps에서도 여유가
+     * 있습니다. 격자로 나누는 최적화는 실제로 느려지면 그때 합니다.
+     */
+    for (const peg of PEGS) {
+      const dx = x - peg.x;
+      const dy = y - peg.y;
+      const distance = Math.hypot(dx, dy);
+      const minimum = radius + PEG_RADIUS;
+
+      if (distance >= minimum || distance === 0) continue;
+
+      const nx = dx / distance;
+      const ny = dy / distance;
+      x = peg.x + nx * minimum;
+      y = peg.y + ny * minimum;
+
+      const dot = vx * nx + vy * ny;
+      vx = (vx - 2 * dot * nx) * BOUNCE + (random() - 0.5) * JITTER * 2;
+      vy = (vy - 2 * dot * ny) * BOUNCE;
+    }
+
+    if (y >= FINISH_Y) {
+      finished.push(ball.participantId);
+      return { ...ball, x, y: FINISH_Y, vx: 0, vy: 0, rank: finished.length };
+    }
+
+    return { ...ball, x, y, vx, vy };
+  });
+
+  return { balls, finished, isComplete: finished.length >= balls.length };
+};
+
+export { createRace, createRandom, step, MAX_FRAMES };
+export type { Ball, RaceFrame };

--- a/components/game/host/pinball/simulation.ts
+++ b/components/game/host/pinball/simulation.ts
@@ -1,9 +1,9 @@
 import {
-  BALL_RADIUS,
   BOARD,
   FINISH_Y,
   PEGS,
   PEG_RADIUS,
+  START_SPREAD,
   START_Y,
 } from '@/components/game/host/pinball/board';
 import type { GameParticipant } from '@/lib/schemas/api';
@@ -89,13 +89,20 @@ interface RaceFrame {
  */
 const createRace = (participants: readonly GameParticipant[], seed: number): RaceFrame => {
   const random = createRandom(seed);
-  const lane = (BOARD.width - BALL_RADIUS * 2) / Math.max(participants.length, 1);
+
+  /*
+   * 보드 전체가 아니라 가운데 `START_SPREAD` 폭에서 출발합니다. 벽 근처에서 시작하면
+   * 못 배치의 좌우 여백으로 곧장 떨어져서, 그 구슬은 못을 한 번도 안 만나고 끝납니다.
+   */
+  const usable = BOARD.width * START_SPREAD;
+  const offset = (BOARD.width - usable) / 2;
+  const lane = usable / Math.max(participants.length, 1);
 
   return {
     balls: participants.map((participant, index) => ({
       participantId: participant.id,
       nickname: participant.nickname,
-      x: BALL_RADIUS + lane * (index + 0.5) + (random() - 0.5) * lane * 0.6,
+      x: offset + lane * (index + 0.5) + (random() - 0.5) * lane * 0.6,
       y: START_Y + random() * 40,
       vx: (random() - 0.5) * 2,
       vy: 0,

--- a/hooks/useHostGame.ts
+++ b/hooks/useHostGame.ts
@@ -5,12 +5,12 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
   createGame,
   fetchGamesOfEvent,
+  fetchSessionsByEventCode,
   submitGameResults,
   updateGameStatus,
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import { isClientError, type GameView } from '@/lib/schemas/api';
-
+import { isClientError, type GameView, type SessionView } from '@/lib/schemas/api';
 /**
  * 프로젝터 화면(`/events/[eventCode]/game`)이 보는 게임과 주최자가 취할 수 있는 조치입니다.
  *
@@ -43,9 +43,29 @@ const isPermanentFailure = (error: Error | null): boolean =>
  */
 const pickCurrent = (games: GameView[]): GameView | null => games[0] ?? null;
 
+/**
+ * 프로젝터에 띄울 세션 제목을 고릅니다.
+ *
+ * 게임은 세션에 딸리지 않아서(#246) 어느 세션에서 하는 게임인지 계약이 모릅니다. 그래서
+ * 지금 열려 있는 세션 중에서 고릅니다.
+ *
+ * 여러 개가 `ACTIVE`일 수 있습니다(시드도 그렇습니다). 그중 `order`가 가장 큰 것을 씁니다 —
+ * 순서대로 진행하니 열린 것 중 마지막이 지금 진행 중일 가능성이 높습니다.
+ *
+ * 열린 세션이 없으면 빈 문자열입니다. 화면이 그때는 아무것도 안 그립니다.
+ */
+const pickOpenSessionTitle = (sessions: SessionView[]): string => {
+  const open = sessions.filter((session) => session.status === 'ACTIVE');
+  if (open.length === 0) return '';
+
+  return open.reduce((latest, session) => (session.order > latest.order ? session : latest)).title;
+};
+
 interface UseHostGameResult {
   /** 띄울 게임입니다. 하나도 없으면 `null`입니다. */
   game: GameView | null;
+  /** 지금 열린 세션 제목입니다. 없으면 빈 문자열입니다. */
+  openSessionTitle: string;
   isLoading: boolean;
   isError: boolean;
   /** 진행 중인 조치가 있으면 참입니다. 버튼을 잠그는 데 씁니다. */
@@ -67,6 +87,16 @@ const useHostGame = (eventCode: string): UseHostGameResult => {
      * `RUNNING`에서도 멈추지 않습니다. 참가는 마감됐지만 결과 확정이 남아 있고, 주최자가
      * 다른 창에서 뭘 했을 수도 있습니다. 멈춰야 하는 상태가 따로 없어서 실패 정지만 둡니다.
      */
+    refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
+  });
+
+  /*
+   * 세션은 게임과 무관하게 주최자가 열고 닫습니다. 레이스 도중에 바뀔 수 있어서
+   * 게임과 같은 리듬으로 따라갑니다.
+   */
+  const sessionsQuery = useQuery({
+    queryKey: ['sessions', eventCode],
+    queryFn: () => fetchSessionsByEventCode(eventCode),
     refetchInterval: ({ state }) => (isPermanentFailure(state.error) ? false : REFRESH_INTERVAL_MS),
   });
 
@@ -96,6 +126,7 @@ const useHostGame = (eventCode: string): UseHostGameResult => {
 
   return {
     game,
+    openSessionTitle: pickOpenSessionTitle(sessionsQuery.data ?? []),
     isLoading: gamesQuery.isLoading,
     isError: gamesQuery.isError,
     isPending: createMutation.isPending || statusMutation.isPending || resultsMutation.isPending,

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -447,35 +447,29 @@ export const gameParticipantSchema = z.object({
   joinedAt: isoDateTime,
 });
 
-export const gameResultEntrySchema = z.object({
-  rank: z.int().positive(),
-  participantId: id,
-  nickname: z.string().min(1),
-});
-
 export const gameSchema = z.object({
   id,
   eventId: id,
   title: z.string().min(1).max(GAME_TITLE_MAX),
   gameType: gameTypeSchema,
   status: gameStatusSchema,
-  /** `FINISHED` 전에는 `null`입니다. */
-  results: z.array(gameResultEntrySchema).nullable(),
+  /**
+   * 완주 순서입니다. 1등이 첫 원소이고 값은 `participantId`입니다.
+   * `FINISHED` 전에는 빈 배열입니다.
+   */
+  ranking: z.array(id),
   createdAt: isoDateTime,
 });
 
 /**
- * 공개 조회 응답입니다. 참가자와 결과를 함께 실어 화면이 한 번에 그립니다.
+ * 공개 조회 응답입니다. 참가자를 함께 실어 화면이 한 번에 그립니다.
  * `eventId`는 code로 조회한 것이라 중복이어서 뺐습니다.
  *
- * `participantCount`는 `participants.length`와 같은 값입니다. 중복이지만 남겨둡니다 —
- * 소감 화면 배너는 인원만 쓰고 명단은 안 씁니다. 대신 목은 배열에서 파생시켜서
- * 둘이 어긋날 수 없게 합니다. 실제 서버도 같아야 합니다.
+ * 인원은 `participants.length`로 셉니다. 서버가 `participantCount`를 따로 주지
+ * 않아서(2026-08-28 실서버 확인) 파생값을 만들지 않습니다.
  */
 export const gameViewSchema = gameSchema.omit({ eventId: true }).extend({
-  participantCount: count,
   participants: z.array(gameParticipantSchema),
-  /** `FINISHED` 전에는 `null`입니다. */
 });
 
 export const gameCreateRequestSchema = z.object({
@@ -517,7 +511,6 @@ export type GameType = z.infer<typeof gameTypeSchema>;
 export type Game = z.infer<typeof gameSchema>;
 export type GameView = z.infer<typeof gameViewSchema>;
 export type GameParticipant = z.infer<typeof gameParticipantSchema>;
-export type GameResultEntry = z.infer<typeof gameResultEntrySchema>;
 export type GameCreateRequest = z.input<typeof gameCreateRequestSchema>;
 export type GameUpdateRequest = z.infer<typeof gameUpdateRequestSchema>;
 export type GameJoinRequest = z.infer<typeof gameJoinRequestSchema>;

--- a/mocks/data/seed.ts
+++ b/mocks/data/seed.ts
@@ -78,12 +78,9 @@ export const seedGames: Game[] = [
     title: '쉬는 시간 몸풀기',
     gameType: 'PINBALL',
     status: 'FINISHED',
+    /** 1등부터 담습니다. 값은 `participantId`고 닉네임은 명단에서 찾습니다. */
+    ranking: [2, 1, 3],
     createdAt: '2026-08-05T01:00:00.000Z',
-    results: [
-      { rank: 1, participantId: 2, nickname: '감자' },
-      { rank: 2, participantId: 1, nickname: '초코송이' },
-      { rank: 3, participantId: 3, nickname: '눈사람' },
-    ],
   },
   {
     id: 2,
@@ -91,8 +88,8 @@ export const seedGames: Game[] = [
     title: '오후 세션 시작 전',
     gameType: 'PINBALL',
     status: 'OPEN',
+    ranking: [],
     createdAt: '2026-08-05T04:00:00.000Z',
-    results: null,
   },
 ];
 

--- a/mocks/data/seed.ts
+++ b/mocks/data/seed.ts
@@ -146,6 +146,62 @@ export const seedGameParticipants: MockGameParticipant[] = [
     clientId: 'seed-client-2',
     joinedAt: '2026-08-05T04:01:20.000Z',
   },
+  {
+    id: 6,
+    gameId: 2,
+    nickname: '붕어빵',
+    clientId: 'seed-client-6',
+    joinedAt: '2026-08-05T04:01:40.000Z',
+  },
+  {
+    id: 7,
+    gameId: 2,
+    nickname: '군고구마',
+    clientId: 'seed-client-7',
+    joinedAt: '2026-08-05T04:02:00.000Z',
+  },
+  {
+    id: 8,
+    gameId: 2,
+    nickname: '호빵',
+    clientId: 'seed-client-8',
+    joinedAt: '2026-08-05T04:02:20.000Z',
+  },
+  {
+    id: 9,
+    gameId: 2,
+    nickname: '떡볶이',
+    clientId: 'seed-client-9',
+    joinedAt: '2026-08-05T04:02:40.000Z',
+  },
+  {
+    id: 10,
+    gameId: 2,
+    nickname: '오뎅',
+    clientId: 'seed-client-10',
+    joinedAt: '2026-08-05T04:03:00.000Z',
+  },
+  {
+    id: 11,
+    gameId: 2,
+    nickname: '순대',
+    clientId: 'seed-client-11',
+    joinedAt: '2026-08-05T04:03:20.000Z',
+  },
+  {
+    id: 12,
+    gameId: 2,
+    nickname: '핫도그',
+    clientId: 'seed-client-12',
+    joinedAt: '2026-08-05T04:03:40.000Z',
+  },
+  {
+    id: 13,
+    gameId: 2,
+    nickname: '와플',
+    clientId: 'seed-client-13',
+    joinedAt: '2026-08-05T04:04:00.000Z',
+  },
 ];
 
 export const seedSessions: Session[] = [

--- a/mocks/data/store.ts
+++ b/mocks/data/store.ts
@@ -270,21 +270,22 @@ export const toGameParticipantView = (participant: MockGameParticipant): GamePar
 });
 
 /**
- * `eventId`를 떨구고 참가자·인원을 붙입니다.
+ * `eventId`를 떨구고 참가자 명단을 붙입니다.
  *
- * `participantCount`를 `participants.length`에서 파생시킵니다. 두 값을 따로 들면
- * 참가 처리에서 한쪽만 갱신했을 때 배너 숫자와 명단이 조용히 어긋납니다.
+ * 인원을 따로 안 내려줍니다. 실제 서버가 `participantCount`를 주지 않아서
+ * (2026-08-28 확인) 화면이 `participants.length`로 셉니다. 목이 없는 필드를
+ * 만들어주면 화면이 서버에 없는 값에 기대게 됩니다.
  */
 export const toGameView = (game: Game): GameView => {
   const participants = listParticipantsOfGame(game.id);
+
   return {
     id: game.id,
     title: game.title,
     gameType: game.gameType,
     status: game.status,
-    results: game.results,
+    ranking: game.ranking,
     createdAt: game.createdAt,
-    participantCount: participants.length,
     participants: participants.map(toGameParticipantView),
   };
 };

--- a/mocks/handlers.test.ts
+++ b/mocks/handlers.test.ts
@@ -999,25 +999,30 @@ describe('게임', () => {
     expect(JSON.stringify(body)).not.toContain('seed-client-');
   });
 
-  it('participantCount는 명단 길이와 같다', async () => {
+  /*
+   * 실제 서버는 `participantCount`를 주지 않습니다(2026-08-28 확인). 목이 없는 필드를
+   * 만들어주면 화면이 서버에 없는 값에 기대게 되고, 실서버에 붙이는 순간 터집니다.
+   */
+  it('인원을 따로 내려주지 않는다', async () => {
     const response = await call(`/events/${LIVE_EVENT_CODE}/games/${OPEN_GAME_ID}`);
-    const game = gameViewSchema.parse(await response.json());
+    const body = (await response.json()) as Record<string, unknown>;
 
-    expect(game.participantCount).toBe(game.participants.length);
+    expect(body).not.toHaveProperty('participantCount');
+    expect(gameViewSchema.parse(body).participants).toHaveLength(10);
   });
 
   /*
-   * 시드의 `results.nickname`은 손으로 적은 값이라 참가자 명단과 어긋날 수 있습니다.
-   * 어긋나면 목이 "이런 것도 온다"고 거짓말하게 되고, 그 오해가 서버로 넘어갑니다.
+   * 시드의 `ranking`은 손으로 적은 participantId 배열입니다. 명단에 없는 id가 들어가면
+   * 화면이 이름을 못 찾아 그 자리가 통째로 빠집니다 — 결과에서 한 명이 조용히 사라집니다.
    */
-  it('시드 결과의 닉네임이 참가자 명단과 일치한다', async () => {
+  it('시드 순위의 참가자가 전부 명단에 있다', async () => {
     const response = await call(`/events/${LIVE_EVENT_CODE}/games/${FINISHED_GAME_ID}`);
     const game = gameViewSchema.parse(await response.json());
-    const nicknameById = new Map(game.participants.map((p) => [p.id, p.nickname]));
+    const ids = new Set(game.participants.map((participant) => participant.id));
 
-    expect(game.results).not.toBeNull();
-    for (const entry of game.results ?? []) {
-      expect(entry.nickname).toBe(nicknameById.get(entry.participantId));
+    expect(game.ranking.length).toBeGreaterThan(0);
+    for (const participantId of game.ranking) {
+      expect(ids.has(participantId)).toBe(true);
     }
   });
 
@@ -1138,7 +1143,7 @@ describe('게임', () => {
     const after = gameViewSchema.parse(
       await (await call(`/events/${LIVE_EVENT_CODE}/games/${OPEN_GAME_ID}`)).json(),
     );
-    expect(after.participantCount).toBe(before.participantCount + 1);
+    expect(after.participants).toHaveLength(before.participants.length + 1);
   });
 
   /*
@@ -1165,10 +1170,7 @@ describe('게임', () => {
     const game = gameViewSchema.parse(await response.json());
 
     expect(game.status).toBe('FINISHED');
-    expect(game.results).toEqual([
-      { rank: 1, participantId: 5, nickname: '커피' },
-      { rank: 2, participantId: 4, nickname: '라면' },
-    ]);
+    expect(game.ranking).toEqual([5, 4]);
   });
 
   it('이 게임에 없는 참가자를 올리면 VALIDATION_ERROR를 준다', async () => {

--- a/mocks/handlers/game.ts
+++ b/mocks/handlers/game.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import type { Game, GameResultEntry, GameStatus } from '@/lib/schemas/api';
+import type { Game, GameStatus } from '@/lib/schemas/api';
 import {
   gameCreateRequestSchema,
   gameJoinRequestSchema,
@@ -104,7 +104,7 @@ export const gameHandlers = [
       gameType: body.data.gameType,
       // 만들자마자 열지 않습니다. 주최자가 시점을 정합니다.
       status: 'DRAFT',
-      results: null,
+      ranking: [],
       createdAt: new Date().toISOString(),
     };
     db.games.push(game);
@@ -217,19 +217,16 @@ export const gameHandlers = [
        *
        * 전원이 다 들어와야 하는 건 아닙니다. 인원이 많으면 상위 N명만 올릴 수 있습니다.
        */
-      const byId = new Map(listParticipantsOfGame(game.id).map((row) => [row.id, row]));
-      const entries: GameResultEntry[] = [];
+      const participantIds = new Set(
+        listParticipantsOfGame(game.id).map((participant) => participant.id),
+      );
 
-      for (let index = 0; index < body.data.ranking.length; index += 1) {
-        const participantId = body.data.ranking[index];
-        const participant = byId.get(participantId);
-        if (!participant) {
-          return errorResponse('VALIDATION_ERROR', `참가자 ${participantId}는 이 게임에 없습니다.`);
-        }
-        entries.push({ rank: index + 1, participantId, nickname: participant.nickname });
+      const unknown = body.data.ranking.find((participantId) => !participantIds.has(participantId));
+      if (unknown !== undefined) {
+        return errorResponse('VALIDATION_ERROR', `참가자 ${unknown}는 이 게임에 없습니다.`);
       }
 
-      game.results = entries;
+      game.ranking = body.data.ranking;
       game.status = 'FINISHED';
 
       return HttpResponse.json(toGameView(game));


### PR DESCRIPTION
## 변경 사항

`RUNNING` 화면의 순차 공개 연출을 **핀볼 레이스**로 갈아 끼웁니다(#243 2단계).

**계약은 안 바뀝니다.** `onFinish`가 받는 값의 모양이 같아서 위쪽 코드는 그대로입니다.

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `b584e34` | 보드 상수 + 물리 시뮬레이션 + 테스트 10개 |
| `4f7b25a` | 캔버스 렌더링 + 화면 연결 |
| `0765d25` | 띄워보고 고친 것들 — 보드 비율·출발 위치·색·폰트·여백 |
| `d4a0774` | **실서버 계약에 맞춤** — 아래 참고 |

> ⚠️ 마지막 커밋은 핀볼과 별개 변경입니다. 오늘 실서버에 붙여보고 계약 차이를 찾았는데, 마감이 월요일이라 **PR을 나누면 리뷰·머지 왕복이 한 번 더** 생겨서 여기 넣었습니다.

## 물리 엔진을 안 씁니다

`matter.js`가 90KB 넘게 붙는데 **필요한 건 원-원 충돌·중력·벽 반사 셋뿐**입니다.

더 큰 이유는 결정성입니다. 시드에서 난수를 만들면 같은 시드에 같은 결과가 나오고, 그러면 **「같은 시드로 두 번 돌리면 같은 순서」가 검사 가능한 문장**이 됩니다. 라이브러리를 끼면 그걸 보장할 방법이 없습니다.

```ts
const random = createRandom(seed);   // mulberry32
```

덤으로 화면이 리렌더돼도 레이스가 안 흔들립니다. `raceOrder`가 `useState(() => …)`로 막고 있던 문제가 구조적으로 사라집니다.

## 상수를 눈대중이 아니라 재서 정했습니다

첫 값(중력 0.42·낙하 상한 11·못 12줄)은 **20명 기준 6.7초**였습니다. 목표가 30초~1분인데 한참 짧습니다.

조합을 훑는 스크립트를 짜서 재봤고, 그 과정에서 **버그 두 개**를 같이 찾았습니다.

### 구슬이 끼어서 레이스가 안 끝난다

12명(반지름 26)일 때 20000 프레임 상한에 걸렸습니다.

벽에 붙은 구슬이 맨 끝 못과 영원히 겹칩니다. 밀어내면 벽에 밀리고, 벽에서 밀면 못에 겹치고, 무한히 반복됩니다. **에러도 안 나고 그냥 안 끝납니다.**

못 배치에 좌우 여백 90을 뒀습니다. 최소 조건은 `2 × 구슬반지름 + 못반지름`입니다.

### 인원이 적을수록 오래 걸린다

반지름을 인원에 따라 26/20/15로 바꿨더니 **12명이 47명보다 5배 오래 걸렸습니다.** 큰 구슬은 못 사이를 잘 못 빠져나갑니다.

물리가 인원에 따라 달라지면 레이스 길이를 예측할 수 없어서 **16으로 고정**했습니다.

### 최종값

| | 처음 | 최종 |
|---|---|---|
| 보드 | 1000×1400 | **1400×1000** |
| 중력 | 0.42 | **0.06** |
| 낙하 상한 | 11 | **5** |
| 못 | 12줄 × 9열 | **20줄 × 15열** |
| 구슬 반지름 | 26/20/15 | **16 고정** |
| 못 여백 | 없음 | **90** |

10~47명에서 21~30초가 나옵니다.

## ⚠️ 벽 근처 구슬이 그냥 흘러내렸습니다

화면에 띄우고 나서 찾은 문제입니다. 출발을 보드 **전체 폭**에 흩뿌리고 있었는데, 못 배치에 좌우 여백이 있어서 **벽 근처에서 시작한 구슬은 못을 한 번도 안 만나고** 결승선까지 갑니다.

측정해보니 최소 충돌이 **0회**였습니다. 그 구슬은 레이스에 참여하지 않고 순위만 차지합니다.

```ts
const START_SPREAD = 0.6;
```

가운데 60%에서만 출발하게 하니 최소 충돌이 14회 이상으로 올라갑니다. 실제 핀볼도 위쪽 한 지점에서 떨어뜨립니다.

## 캔버스에서 겪은 것 셋

**프레임을 React state로 안 둡니다.** 60fps로 `setState`를 부르면 초당 60번 리렌더가 돌아서 구슬을 그리기 전에 화면이 멈춥니다. 캔버스에 직접 그리고 **완주자가 늘어날 때만** 상태를 올립니다.

**`onFinish`를 ref에 담고 deps에서 뺐습니다.** 넣으면 렌더마다 정체성이 바뀌어 effect가 다시 돌고 **레이스가 처음부터 시작**합니다. 프로젝터가 3초마다 폴링하니 실제로 그렇게 됩니다.

**색과 폰트가 두 번 물렸습니다.**

- 글자를 `--color-text-primary`(#2c2c2a)로 뒀는데 배경이 `--color-background-inverse`(#2c2c2a)라 **검은 배경에 검은 글씨**였습니다. `--color-text-inverse`로 바꿨습니다
- 캔버스 `font`는 **CSS 변수를 해석하지 않습니다.** `var(--font-sans)`를 넣으면 문자열 전체가 무효가 되고 기본값 `10px`로 떨어집니다. 폰트 이름을 직접 적었고, `globals.css`와 손으로 맞춘 상태라 주석에 남겼습니다

## 화면도 같이 손봤습니다

- 네 화면에 `flex-1 justify-center`를 줘서 **화면 높이를 다 씁니다.** 프로젝터라 위아래가 비면 그만큼 글자가 작아 보입니다
- 참가자 명단을 **아래 전체 폭**으로 옮겼습니다. 좁은 칼럼에 두면 세로로 늘어져서 뒤쪽 사람이 못 읽습니다
- 결과 시상대에서 **1등을 `text-8xl`로** 키웠습니다. 셋 크기가 비슷하면 시선이 안 갑니다
- 프로젝터 화면들이 띄우던 **게임 제목을 세션 제목으로** 바꿨습니다. 게임 제목은 주최자가 게임을 구분하려고 붙인 메모라 참가자에게 의미가 없습니다

게임은 세션에 딸리지 않아서(#246) 어느 세션의 게임인지 계약이 모릅니다. `ACTIVE` 세션 중 `order`가 가장 큰 것을 씁니다 — 순서대로 진행하니 열린 것 중 마지막이 지금 진행 중일 가능성이 높습니다.

## ⚠️ 실서버 계약에 맞췄습니다 (`d4a0774`)

오늘 프론트를 실서버(`pulse-backend-sg.onrender.com`)에 붙여보고 두 군데가 다른 걸 확인했습니다.

| | 우리 목(어제까지) | 실서버 |
|---|---|---|
| 결과 | `results: [{ rank, participantId, nickname }]` | **`ranking: number[]`** |
| 인원 | `participantCount` | **없음** |
| 게임 id | 숫자 | 숫자 ✅ |

목이 계약의 단일 소스지만 **서버가 이미 만든 뒤**라, 마감 사흘 전에 백엔드를 고치는 것보다 프론트를 맞추는 게 낫다고 봤습니다.

### 닉네임을 안 받아도 됩니다

우리가 결과에 닉네임을 박아둔 이유는 「나중에 이름을 바꿔도 결과는 그 시점 값」이었는데, **`RUNNING`이 되면 참가가 막혀서 이름을 바꿀 수가 없습니다.** 걱정이 성립하지 않아서 서버 방식이 더 단순합니다.

이름은 `participants`에서 찾아 붙입니다. **명단에 없는 id는 버립니다** — 주최자가 게임을 다시 만들었거나 서버가 이상한 값을 준 경우인데, 이름 없는 줄을 그리는 것보다 낫습니다.

### 테스트 하나가 아무것도 검사하지 않고 있었습니다

「시드 결과의 닉네임이 참가자 명단과 일치한다」가 `game.results`를 돌았는데, 그 필드가 사라져 `undefined`가 되면서 `?? []`로 빈 배열이 됐습니다. **루프가 0바퀴 돌고 초록불이 켜졌습니다.**

`ranking` 기준으로 다시 쓰고 **길이 검사를 앞에** 뒀습니다.

```ts
expect(game.ranking.length).toBeGreaterThan(0);
for (const participantId of game.ranking) { … }
```

같은 종류를 오늘만 두 번 만났습니다. 아침에 「다른 이벤트의 게임은 섞이지 않는다」도 섞일 게 없어서 통과했었습니다. **루프를 도는 테스트는 몇 번 도는지를 먼저 확인해야 합니다.**

### 화면 구조도 손봤습니다

세 화면이 각자 `justify-center`를 쓰다 보니 내용 높이가 달라 **제목이 제각각 다른 자리**에 왔습니다. 제목을 `pt-[6dvh]`로 고정하고 본문만 가운데 두니 맞습니다.

`GameHostView`에 `max-w-6xl`을 줘서 네 화면이 같은 열을 쓰게 했고, 결과 제목을 `text-6xl` → `text-4xl`로 줄였습니다. 1등과 크기로 경쟁하고 있었습니다.

## ⚠️ 실서버 게임은 아직 안 됩니다

계약은 맞췄는데 **서버가 500을 냅니다.**

```
GET /api/v1/events/{code}/games   →   500

게임 0개일 땐 200, 1개 만들고 나서 부르면 500
POST 는 성공하므로 저장은 되는 것 같습니다
```

백엔드에 전달했습니다. 이 PR과 무관한 서버 문제이고, **목으로는 전부 정상 동작**합니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 12 files, 197 tests passed
```

테스트가 188 → 197입니다. 핀볼 시뮬레이션으로 10개가 늘고, 계약 변경으로 `participantCount` 테스트 하나가 성격이 바뀌면서 `gameBannerMessage` 쪽이 하나 줄었습니다.

| 테스트 | 확인하는 것 |
|---|---|
| **같은 시드면 같은 순서** | 결정성. 이게 통과해야 나머지가 「우연히」가 아닙니다 |
| 아무도 사라지거나 중복되지 않는다 | 구슬 하나가 빠지면 그 참가자만 결과에서 조용히 없어집니다 |
| 47명도 전원 완주한다 | 상수를 조정할 때마다 끼임을 잡아주는 안전망 |
| 인원이 달라도 길이가 비슷하다 | 반지름 고정 결정을 지킵니다 |
| 레이스가 너무 짧거나 길지 않다 | 10~70초. 상수를 만져도 안 깨지게 넓게 |
| 보드 밖으로 안 나간다 · 원본 불변 등 | |

`npm run dev`로 10명 레이스를 여러 번 굴려봤습니다.

## 영향 범위

- 새 환경 변수: 없음
- **의존성 추가: 없음** (물리 엔진을 안 씁니다)
- Breaking Change: 없음
- 시드 게임 2의 참가자를 **10명으로 늘렸습니다.** 2명으로는 레이스가 어떻게 보이는지 확인할 수 없었습니다

## 트러블슈팅 및 참고 사항

### 상수만 만들고 쓰는 자리를 안 고쳤습니다

`board.ts`에 `START_SPREAD`를 넣어놓고 `simulation.ts`의 `createRace`가 그걸 안 쓰고 있었습니다.

스크립트로만 재고 실제 파일을 안 봐서, **측정값은 「여백 체류 0%」인데 화면에서는 계속 떨어졌습니다.** 두 번 헛짚은 뒤에 파일을 열어보고 찾았습니다.

### 3단계는 이 PR에 없습니다

100명이 넘을 때 룰렛으로 바꾸는 규모별 분기(#243 3단계)는 마감 뒤로 미룹니다. 지금 47명 상한에서 잘 돕니다.

## 관련 이슈

- Closes #292
- Refs #243

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
