### PR TITLE
refactor(event): EventForm을 책임 단위로 나눈다

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -1,29 +1,34 @@
 'use client';
 
-import { type ChangeEvent, type SubmitEvent, useState } from 'react';
-import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { Field } from '@/components/ui/Field';
-import { Textarea } from '@/components/ui/Textarea';
-import { Button } from '@/components/ui/Button';
-import { Banner } from '@/components/ui/Banner';
-import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
-import { ChevronLeftIcon } from '@/components/ui/icons';
+import { useRouter } from 'next/navigation';
+import { type ChangeEvent, type SubmitEvent, useState } from 'react';
+
+import SessionList from '@/components/events/SessionList';
+import rollbackEventDuplication from '@/components/events/rollbackEventDuplication';
 import ReportPanel from '@/components/report/ReportPanel';
+import { Banner } from '@/components/ui/Banner';
+import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { Field } from '@/components/ui/Field';
+import { ChevronLeftIcon } from '@/components/ui/icons';
+import { Textarea } from '@/components/ui/Textarea';
 import { showToast } from '@/hooks/useToast';
-import { eventCreateRequestSchema, sessionCreateRequestSchema } from '@/lib/schemas/api';
-import type { EventView, PulseEvent, SessionView } from '@/lib/schemas/api';
 import {
   createEvent,
   createSession,
   deleteEvent,
-  deleteSession,
   fetchEventByCode,
   fetchSessionsByEventCode,
   updateEvent,
-  updateSession,
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
+import {
+  eventCreateRequestSchema,
+  type EventView,
+  type PulseEvent,
+  type SessionView,
+} from '@/lib/schemas/api';
 
 interface EventFormProps {
   /** 있으면 수정 모드(기존 값 로드 + PATCH), 없으면 생성 모드(POST)입니다. */
@@ -59,33 +64,6 @@ const initialEventFormInputs: EventFormInputs = {
   description: '',
   eventDate: '',
 };
-
-/**
- * 세션 및 이벤트를 삭제하는 헬퍼 함수
- * @param deleteFn
- * @param maxRetries
- */
-const deleteWithRetry = async (
-  deleteFn: () => Promise<void>,
-  maxRetries: number,
-): Promise<boolean> => {
-  for (let attempt = 0; attempt < maxRetries; attempt++) {
-    try {
-      await deleteFn();
-      return true;
-    } catch (error) {
-      const isAlreadyDeleted =
-        error instanceof ApiError &&
-        (error.code === 'EVENT_ALREADY_DELETED' || error.code === 'SESSION_ALREADY_DELETED');
-
-      if (isAlreadyDeleted) {
-        return true;
-      }
-    }
-  }
-  return false;
-};
-
 const getUndeletedItems = (failure: IncompleteCleanup): UndeletedItem[] => {
   if (!failure) {
     return [];
@@ -118,12 +96,6 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
   const [eventFormInputs, setEventFormInputs] = useState<EventFormInputs>(initialEventFormInputs);
   const [eventFormErrors, setEventFormErrors] = useState<EventFormErrors>({});
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
-
-  const [isAddingSession, setIsAddingSession] = useState(false);
-  const [newSessionTitle, setNewSessionTitle] = useState('');
-  const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
-  const [editingSessionTitle, setEditingSessionTitle] = useState('');
-  const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null);
 
   const [incompleteCleanup, setIncompleteCleanup] = useState<IncompleteCleanup>(null);
 
@@ -185,18 +157,10 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
             });
           }
         } catch (error) {
-          const sessionDeleteResults = await Promise.all(
-            createdSessions.map(async (session) => ({
-              title: session.title,
-              succeeded: await deleteWithRetry(() => deleteSession(newEvent.code, session.id), 3),
-            })),
-          );
-
-          const eventDeleteResult = await deleteWithRetry(() => deleteEvent(newEvent.code), 3);
-
-          const failedSessionTitles = sessionDeleteResults
-            .filter((result) => !result.succeeded)
-            .map((result) => result.title);
+          const { eventDeleteResult, failedSessionTitles } = await rollbackEventDuplication({
+            newEvent,
+            createdSessions,
+          });
 
           if (failedSessionTitles.length > 0 || !eventDeleteResult) {
             setIncompleteCleanup({
@@ -256,34 +220,6 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
     onSuccess: () => router.push('/events'),
   });
 
-  const { mutate: addSession, isPending: isAddingSessionPending } = useMutation({
-    mutationFn: (title: string) =>
-      createSession(eventCode as string, { title, order: sessions.length + 1 }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
-      setIsAddingSession(false);
-      setNewSessionTitle('');
-    },
-  });
-
-  const { mutate: editSession, isPending: isEditingSessionPending } = useMutation({
-    mutationFn: ({ sessionId, title }: { sessionId: number; title: string }) =>
-      updateSession(eventCode as string, sessionId, { title }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
-      setEditingSessionId(null);
-    },
-  });
-
-  const { mutate: removeSession, isPending: isRemovingSession } = useMutation({
-    mutationFn: (sessionId: number) => deleteSession(eventCode as string, sessionId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
-      setDeletingSessionId(null);
-      showToast('세션이 삭제되었어요');
-    },
-  });
-
   const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
     setEventFormInputs((prev) => ({ ...prev, [name]: value }));
@@ -310,32 +246,6 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
     if (titleValidation.success && descriptionValidation.success && eventDateValidation.success) {
       saveEvent(eventFormInputs);
     }
-  };
-
-  const handleAddSessionConfirm = () => {
-    const validation = sessionCreateRequestSchema.shape.title.safeParse(newSessionTitle);
-    if (!validation.success) return;
-    addSession(newSessionTitle);
-  };
-
-  const handleEditSessionStart = (session: SessionView) => {
-    setEditingSessionId(session.id);
-    setEditingSessionTitle(session.title);
-  };
-
-  const handleEditSessionConfirm = (sessionId: number) => {
-    const validation = sessionCreateRequestSchema.shape.title.safeParse(editingSessionTitle);
-    if (!validation.success) return;
-    editSession({ sessionId, title: editingSessionTitle });
-  };
-
-  const handleEditSessionCancel = () => {
-    setEditingSessionId(null);
-  };
-
-  const handleAddSessionCancel = () => {
-    setIsAddingSession(false);
-    setNewSessionTitle('');
   };
 
   if (isEditMode && eventQuery.isPending) {
@@ -417,87 +327,7 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
           </p>
         </section>
 
-        {isEditMode ? (
-          <section className="flex flex-col gap-2">
-            <p className="text-xs font-normal leading-4 text-text-secondary">세션 목록</p>
-            {sessions.map((session, index) => (
-              <div
-                key={session.id}
-                className="flex items-center justify-between gap-2 rounded-lg border border-border-default px-4 py-3"
-              >
-                {editingSessionId === session.id ? (
-                  <>
-                    <input
-                      className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
-                      placeholder="세션 이름 입력"
-                      value={editingSessionTitle}
-                      onChange={(event) => setEditingSessionTitle(event.target.value)}
-                    />
-                    <Button type="button" variant="secondary" onClick={handleEditSessionCancel}>
-                      취소
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      disabled={isEditingSessionPending}
-                      onClick={() => handleEditSessionConfirm(session.id)}
-                    >
-                      확인
-                    </Button>
-                  </>
-                ) : (
-                  <>
-                    <span className="text-sm text-text-primary">
-                      {index + 1}. {session.title}
-                    </span>
-                    <div className="flex gap-2 text-xs text-text-secondary">
-                      <button
-                        type="button"
-                        className="cursor-pointer"
-                        onClick={() => handleEditSessionStart(session)}
-                      >
-                        수정
-                      </button>
-                      <button
-                        type="button"
-                        className="cursor-pointer"
-                        onClick={() => setDeletingSessionId(session.id)}
-                      >
-                        삭제
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
-            ))}
-            {isAddingSession ? (
-              <div className="flex items-center gap-2 rounded-lg border border-border-default px-4 py-3">
-                <input
-                  className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
-                  placeholder="세션 이름 입력"
-                  value={newSessionTitle}
-                  onChange={(event) => setNewSessionTitle(event.target.value)}
-                  autoFocus
-                />
-                <Button type="button" variant="secondary" onClick={handleAddSessionCancel}>
-                  취소
-                </Button>
-                <Button
-                  type="button"
-                  variant="secondary"
-                  disabled={isAddingSessionPending}
-                  onClick={handleAddSessionConfirm}
-                >
-                  확인
-                </Button>
-              </div>
-            ) : (
-              <Button type="button" variant="secondary" onClick={() => setIsAddingSession(true)}>
-                + 세션추가
-              </Button>
-            )}
-          </section>
-        ) : null}
+        {isEditMode ? <SessionList sessions={sessions} eventCode={eventCode} /> : null}
 
         {saveError ? (
           <Banner type="negative" className="w-full">
@@ -559,28 +389,6 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
               variant="danger"
               disabled={isDeleting}
               onClick={() => removeEvent()}
-            >
-              삭제
-            </Button>
-          </>
-        }
-      />
-
-      <ConfirmDialog
-        open={deletingSessionId !== null}
-        title="세션을 삭제할까요?"
-        description="삭제하면 되돌릴 수 없어요"
-        onClose={() => setDeletingSessionId(null)}
-        actions={
-          <>
-            <Button type="button" variant="secondary" onClick={() => setDeletingSessionId(null)}>
-              취소
-            </Button>
-            <Button
-              type="button"
-              variant="danger"
-              disabled={isRemovingSession}
-              onClick={() => deletingSessionId !== null && removeSession(deletingSessionId)}
             >
               삭제
             </Button>

--- a/components/events/SessionList.tsx
+++ b/components/events/SessionList.tsx
@@ -1,0 +1,185 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { showToast } from '@/hooks/useToast';
+import { createSession, deleteSession, updateSession } from '@/lib/api/endpoints';
+import { sessionCreateRequestSchema, type SessionView } from '@/lib/schemas/api';
+
+interface SessionListProps {
+  sessions: SessionView[];
+  eventCode: string | undefined;
+}
+
+const SessionList = ({ sessions, eventCode }: SessionListProps) => {
+  const [isAddingSession, setIsAddingSession] = useState(false);
+  const [newSessionTitle, setNewSessionTitle] = useState('');
+  const [editingSessionId, setEditingSessionId] = useState<number | null>(null);
+  const [editingSessionTitle, setEditingSessionTitle] = useState('');
+  const [deletingSessionId, setDeletingSessionId] = useState<number | null>(null);
+
+  const queryClient = useQueryClient();
+
+  const handleAddSessionConfirm = () => {
+    const validation = sessionCreateRequestSchema.shape.title.safeParse(newSessionTitle);
+    if (!validation.success) return;
+    addSession(newSessionTitle);
+  };
+
+  const handleEditSessionStart = (session: SessionView) => {
+    setEditingSessionId(session.id);
+    setEditingSessionTitle(session.title);
+  };
+
+  const handleEditSessionConfirm = (sessionId: number) => {
+    const validation = sessionCreateRequestSchema.shape.title.safeParse(editingSessionTitle);
+    if (!validation.success) return;
+    editSession({ sessionId, title: editingSessionTitle });
+  };
+
+  const handleEditSessionCancel = () => {
+    setEditingSessionId(null);
+  };
+
+  const handleAddSessionCancel = () => {
+    setIsAddingSession(false);
+    setNewSessionTitle('');
+  };
+
+  const { mutate: addSession, isPending: isAddingSessionPending } = useMutation({
+    mutationFn: (title: string) =>
+      createSession(eventCode as string, { title, order: sessions.length + 1 }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setIsAddingSession(false);
+      setNewSessionTitle('');
+    },
+  });
+
+  const { mutate: editSession, isPending: isEditingSessionPending } = useMutation({
+    mutationFn: ({ sessionId, title }: { sessionId: number; title: string }) =>
+      updateSession(eventCode as string, sessionId, { title }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setEditingSessionId(null);
+    },
+  });
+
+  const { mutate: removeSession, isPending: isRemovingSession } = useMutation({
+    mutationFn: (sessionId: number) => deleteSession(eventCode as string, sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions', eventCode] });
+      setDeletingSessionId(null);
+      showToast('세션이 삭제되었어요');
+    },
+  });
+
+  return (
+    <>
+      <section className="flex flex-col gap-2">
+        <p className="text-xs font-normal leading-4 text-text-secondary">세션 목록</p>
+        {sessions.map((session, index) => (
+          <div
+            key={session.id}
+            className="flex items-center justify-between gap-2 rounded-lg border border-border-default px-4 py-3"
+          >
+            {editingSessionId === session.id ? (
+              <>
+                <input
+                  className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
+                  placeholder="세션 이름 입력"
+                  value={editingSessionTitle}
+                  onChange={(event) => setEditingSessionTitle(event.target.value)}
+                />
+                <Button type="button" variant="secondary" onClick={handleEditSessionCancel}>
+                  취소
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  disabled={isEditingSessionPending}
+                  onClick={() => handleEditSessionConfirm(session.id)}
+                >
+                  확인
+                </Button>
+              </>
+            ) : (
+              <>
+                <span className="text-sm text-text-primary">
+                  {index + 1}. {session.title}
+                </span>
+                <div className="flex gap-2 text-xs text-text-secondary">
+                  <button
+                    type="button"
+                    className="cursor-pointer"
+                    onClick={() => handleEditSessionStart(session)}
+                  >
+                    수정
+                  </button>
+                  <button
+                    type="button"
+                    className="cursor-pointer"
+                    onClick={() => setDeletingSessionId(session.id)}
+                  >
+                    삭제
+                  </button>
+                </div>
+              </>
+            )}
+          </div>
+        ))}
+        {isAddingSession ? (
+          <div className="flex items-center gap-2 rounded-lg border border-border-default px-4 py-3">
+            <input
+              className="flex-1 rounded border border-border-default px-2 py-1 text-sm"
+              placeholder="세션 이름 입력"
+              value={newSessionTitle}
+              onChange={(event) => setNewSessionTitle(event.target.value)}
+              autoFocus
+            />
+            <Button type="button" variant="secondary" onClick={handleAddSessionCancel}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={isAddingSessionPending}
+              onClick={handleAddSessionConfirm}
+            >
+              확인
+            </Button>
+          </div>
+        ) : (
+          <Button type="button" variant="secondary" onClick={() => setIsAddingSession(true)}>
+            + 세션추가
+          </Button>
+        )}
+      </section>
+
+      <ConfirmDialog
+        open={deletingSessionId !== null}
+        title="세션을 삭제할까요?"
+        description="삭제하면 되돌릴 수 없어요"
+        onClose={() => setDeletingSessionId(null)}
+        actions={
+          <>
+            <Button type="button" variant="secondary" onClick={() => setDeletingSessionId(null)}>
+              취소
+            </Button>
+            <Button
+              type="button"
+              variant="danger"
+              disabled={isRemovingSession}
+              onClick={() => deletingSessionId !== null && removeSession(deletingSessionId)}
+            >
+              삭제
+            </Button>
+          </>
+        }
+      />
+    </>
+  );
+};
+
+export default SessionList;

--- a/components/events/rollbackEventDuplication.ts
+++ b/components/events/rollbackEventDuplication.ts
@@ -2,7 +2,7 @@ import { deleteEvent, deleteSession } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import type { PulseEvent } from '@/lib/schemas/api';
 
-type CreatedSession = { id: number; title: string }[];
+type CreatedSession = { id: number; title: string };
 
 const MAX_DELETE_RETRIES = 3;
 const deleteWithRetry = async (
@@ -31,7 +31,7 @@ const rollbackEventDuplication = async ({
   createdSessions,
 }: {
   newEvent: PulseEvent;
-  createdSessions: CreatedSession;
+  createdSessions: CreatedSession[];
 }) => {
   const sessionDeleteResults = await Promise.all(
     createdSessions.map(async (session) => ({

--- a/components/events/rollbackEventDuplication.ts
+++ b/components/events/rollbackEventDuplication.ts
@@ -1,0 +1,61 @@
+import { deleteEvent, deleteSession } from '@/lib/api/endpoints';
+import { ApiError } from '@/lib/apiClient';
+import type { PulseEvent } from '@/lib/schemas/api';
+
+type CreatedSession = { id: number; title: string }[];
+
+const MAX_DELETE_RETRIES = 3;
+const deleteWithRetry = async (
+  deleteFn: () => Promise<void>,
+  maxRetries: number,
+): Promise<boolean> => {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      await deleteFn();
+      return true;
+    } catch (error) {
+      const isAlreadyDeleted =
+        error instanceof ApiError &&
+        (error.code === 'EVENT_ALREADY_DELETED' || error.code === 'SESSION_ALREADY_DELETED');
+
+      if (isAlreadyDeleted) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+const rollbackEventDuplication = async ({
+  newEvent,
+  createdSessions,
+}: {
+  newEvent: PulseEvent;
+  createdSessions: CreatedSession;
+}) => {
+  const sessionDeleteResults = await Promise.all(
+    createdSessions.map(async (session) => ({
+      title: session.title,
+      succeeded: await deleteWithRetry(
+        () => deleteSession(newEvent.code, session.id),
+        MAX_DELETE_RETRIES,
+      ),
+    })),
+  );
+
+  const eventDeleteResult = await deleteWithRetry(
+    () => deleteEvent(newEvent.code),
+    MAX_DELETE_RETRIES,
+  );
+
+  const failedSessionTitles = sessionDeleteResults
+    .filter((result) => !result.succeeded)
+    .map((result) => result.title);
+
+  return {
+    eventDeleteResult,
+    failedSessionTitles,
+  };
+};
+
+export default rollbackEventDuplication;


### PR DESCRIPTION
## 변경 사항

`EventForm.tsx`의 세션 관리와 복제 롤백 로직을 두 개 파일로 분리했습니다.

`EventForm.tsx`가 594줄이었고, 서로 무관한 책임을 한 파일에서 처리하고 있었습니다.
WebStorm이 이 파일의 복잡도를 647%로 표시한 것이 계기가 됐습니다.

- 이벤트 폼: 제목·설명·날짜 입력과 등록/수정/복제 저장
- 세션 관리: 세션 추가·수정·삭제 인라인 편집
- 복제 롤백: 이벤트 복제 중 세션 생성이 실패했을 때 되돌리는 로직

나눈 결과는 다음과 같습니다.

- **`SessionList.tsx`** — 신규 파일입니다.
  - 세션 목록을 렌더링합니다.
  - 세션 추가·수정·삭제(상태 5개, mutation 3개, 핸들러 5개)를 처리합니다.
- **`rollbackEventDuplication.ts`** — 신규 파일입니다.
  - 이벤트 복제 중 세션 생성이 실패했을 때 되돌리는 로직을 담습니다.
  - 재시도하며 삭제하고, 정리 실패한 항목을 계산합니다.

동작 변경은 없습니다. 렌더 결과와 요청 횟수가 그대로입니다.

나누는 기준과 세부 설계는 이슈(#294)에 정리했습니다.

## 관련 이슈

- Closes #294

## 검증 방법

- `npm run lint`: 통과(경고 1건은 `DashboardView.tsx`의 기존 경고로 이번 변경과 무관).
- `npm run test`: 13개 파일, 216개 테스트 전부 통과.
- `npm run build`: 성공.
- 브라우저에서 아래 8가지를 직접 재현해 확인했습니다.
  1. 이벤트 수정 화면에서 세션 목록이 정상적으로 보입니다.
  2. 세션 추가가 정상 동작하고 목록에 반영됩니다.
  3. 세션 수정이 정상 동작하고 목록에 반영됩니다.
  4. 세션 삭제가 정상 동작하고 목록에서 사라집니다.
  5. 새 이벤트 등록 화면에는 세션 목록 섹션이 안 보입니다.
  6. 이벤트 복제 화면에도 세션 목록 섹션이 안 보입니다.
  7. 세션이 있는 이벤트를 정상적으로 복제하면 세션까지 그대로 복제됩니다.
  8. 이벤트 복제 중 세션 생성 요청이 실패하면(Chrome DevTools로 재현), 이미 만든 이벤트가 삭제됩니다.
- "정리 실패" 배너(세션·이벤트 삭제까지 실패했을 때 뜨는 배너)는 화면에서 직접 재현하지 않고 코드 리뷰로 대체했습니다. 이유는 아래 "트러블슈팅 및 참고 사항"에 적었습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### `useEventDuplication`이라는 이름이 Rules of Hooks 위반을 일으켰습니다

처음에 복제 롤백 로직을 `hooks/useEventDuplication.ts`(Hook 이름)로 만들었는데, 실제로는 `useState`·`useQueryClient` 같은 React Hook API를 쓰지 않는 평범한 비동기 함수였습니다.
그런데 `EventForm`의 mutation 함수 안 `catch` 블록에서 이 함수를 부르자 ESLint의 `react-hooks/rules-of-hooks` 규칙이 위반됐습니다.
React는 이름이 `use`로 시작하는 함수를 무조건 Hook으로 간주하고, Hook은 조건부 블록에서 호출할 수 없기 때문입니다.
`components/events/rollbackEventDuplication.ts`로 이름과 위치를 바꿔 해결했습니다(선례: `components/events/eventStatusBadge.ts`).

### 정리 실패 배너(9번 시나리오)는 화면 재현 대신 코드 리뷰로 확인했습니다

세션·이벤트를 지우는 요청까지 실패해서 "정리하지 못한 항목이 있다"는 배너가 뜨는 상황은 화면에서 직접 재현하지 않았습니다.
`incompleteCleanup` 상태에 따라 배너를 그리는 로직이 단순한 조건부 렌더링이라, 코드 리뷰로 확인하는 것으로 대신했습니다.
필요하다고 판단되면 알려주시면 추가로 재현해서 확인하겠습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그를 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
