### PR TITLE
refactor(api): 다섯 곳에 복사된 재시도 판정을 한곳으로 모은다

### DIFF
--- a/components/providers/QueryProvider.tsx
+++ b/components/providers/QueryProvider.tsx
@@ -3,8 +3,8 @@
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useState, type ReactNode } from 'react';
 import { ApiError } from '@/lib/apiClient';
-import { isClientError } from '@/lib/schemas/api';
 import { useRouter } from 'next/navigation';
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
 
 interface QueryProviderProps {
   children: ReactNode;
@@ -27,17 +27,7 @@ const QueryProvider = ({ children }: QueryProviderProps) => {
         queries: {
           staleTime: 10_000,
           // 다시 물어봐도 같은 답이 오는 실패는 재시도하지 않습니다.
-          retry: (failureCount, error) => {
-            if (error instanceof ApiError) {
-              // 응답이 계약과 다른 경우. 같은 요청에 같은 응답이 옵니다.
-              if (error.code === 'INVALID_RESPONSE') return false;
-              // 4xx.
-              if (isClientError(error.code)) return false;
-            }
-
-            return failureCount < 2;
-          },
-          refetchOnWindowFocus: false,
+          retry: (failureCount, error) => (isPermanentFailure(error) ? false : failureCount < 2),
         },
       },
       queryCache: new QueryCache({

--- a/hooks/useCurrentGame.ts
+++ b/hooks/useCurrentGame.ts
@@ -3,8 +3,8 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { fetchCurrentGame } from '@/lib/api/endpoints';
-import { ApiError } from '@/lib/apiClient';
-import { isClientError, type GameView } from '@/lib/schemas/api';
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
+import { type GameView } from '@/lib/schemas/api';
 
 /**
  * 게임 화면(`/e/[code]/game`, `/events/[eventCode]/game`)이 보는 "지금 열린 게임"입니다.
@@ -23,16 +23,6 @@ import { isClientError, type GameView } from '@/lib/schemas/api';
  * 참가자 수만큼 곱해집니다.
  */
 const REFRESH_INTERVAL_MS = 5_000;
-
-/**
- * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를
- * 거르는 기준(4xx + `INVALID_RESPONSE`)과 같습니다.
- *
- * `useEventEntryFeed`·`useDashboardFeed`에도 같은 함수가 있습니다. 세 번째라 공용으로
- * 빼는 게 맞아 보이는데, 이 PR 범위 밖이라 두고 갑니다.
- */
-const isPermanentFailure = (error: Error | null): boolean =>
-  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
 
 interface UseCurrentGameResult {
   /** 열린 게임이 없으면 `null`입니다. 404가 정상 상태라 에러가 아닙니다. */

--- a/hooks/useDashboardFeed.ts
+++ b/hooks/useDashboardFeed.ts
@@ -5,9 +5,9 @@ import { useEffect, useRef, useState } from 'react';
 
 import { useAuth } from '@/hooks/useAuth';
 import { fetchModerationQueue } from '@/lib/api/endpoints';
-import { ApiError } from '@/lib/apiClient';
 import { API_BASE_URL } from '@/lib/env';
-import { feedbackListResponseSchema, isClientError, type Feedback } from '@/lib/schemas/api';
+import { feedbackListResponseSchema, type Feedback } from '@/lib/schemas/api';
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
 
 /**
  * 주최자 대시보드가 보는 소감 목록입니다. 갱신은 `GET /admin/feedbacks/stream`(SSE)이
@@ -57,13 +57,6 @@ const STREAM_TIMEOUT_MS = 5_000;
 
 /** 숨기기·삭제 뒤 목록을 다시 받을 때 쓰는 키 앞자리입니다. */
 const DASHBOARD_FEED_KEY = 'dashboardFeed';
-
-/**
- * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를 거르는
- * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴백도 하지 않습니다.
- */
-const isPermanentFailure = (error: Error | null): boolean =>
-  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
 
 /**
  * 스트림으로 들어온 한 건을 계약 스키마로 검사합니다.

--- a/hooks/useEventEntryFeed.ts
+++ b/hooks/useEventEntryFeed.ts
@@ -2,15 +2,14 @@
 
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { 
+import {
   fetchCurrentGame,
   fetchEventByCode,
   fetchPublicReport,
-  fetchSessionsByEventCode
+  fetchSessionsByEventCode,
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import {
-  isClientError,
   listResponseSchema,
   sessionViewSchema,
   type EventView,
@@ -19,7 +18,7 @@ import {
 } from '@/lib/schemas/api';
 import { useEffect, useState } from 'react';
 import { API_BASE_URL } from '@/lib/env';
-
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
 /**
  * 게스트 진입 화면(`/e/[code]`)이 보는 이벤트·세션·리포트·게임입니다.
  *
@@ -30,7 +29,7 @@ import { API_BASE_URL } from '@/lib/env';
  * 갱신 수단이 둘로 갈립니다. 세션만 SSE(`.../sessions/stream`)로 받고, 이벤트 상태와 리포트는
  * 폴링입니다. 명세에 스트림이 셋뿐이라 이벤트 상태에는 아예 없고, 리포트는 "실시간 push(SSE)는
  * 도입하지 않고 폴링으로 확정"이라고 명시적으로 배제됐습니다(2026-08-21).
- * 
+ *
  * 게임도 폴링입니다. 명세의 스트림 3종에 게임이 없어서 이벤트 상태와 같은 처지입니다.
  *
  * CLAUDE.md의 "실시간(클라이언트): 폴링 → SSE 승급, 훅으로 격리" 원칙에 따라 갱신 방식을 아는
@@ -71,16 +70,6 @@ const STREAM_TIMEOUT_MS = 5_000;
  * 그래서 리포트를 기다리며 열어둔 탭이 종일 서버를 두들기는 일은 생기지 않습니다.
  */
 const REPORT_REFRESH_INTERVAL_MS = 15_000;
-
-/**
- * 다시 물어봐도 같은 답이 오는 실패인지 봅니다. `QueryProvider`의 `retry`가 재시도를 거르는
- * 기준(4xx + `INVALID_RESPONSE`)과 같습니다. 재시도하지 않기로 한 실패는 폴링도 하지 않습니다.
- *
- * `useDashboardFeed`에 같은 함수가 있습니다. 아직 두 벌이라 옮기지 않았습니다 — 세 번째가
- * 생기면 그때 공용으로 빼는 편이 맞아 보입니다.
- */
-const isPermanentFailure = (error: Error | null): boolean =>
-  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
 
 /**
  * 스트림으로 들어온 한 건을 계약 스키마로 검사하고 봉투를 벗깁니다.

--- a/hooks/useHostGame.ts
+++ b/hooks/useHostGame.ts
@@ -9,8 +9,9 @@ import {
   submitGameResults,
   updateGameStatus,
 } from '@/lib/api/endpoints';
-import { ApiError } from '@/lib/apiClient';
-import { isClientError, type GameView, type SessionView } from '@/lib/schemas/api';
+import { type GameView, type SessionView } from '@/lib/schemas/api';
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
+
 /**
  * 프로젝터 화면(`/events/[eventCode]/game`)이 보는 게임과 주최자가 취할 수 있는 조치입니다.
  *
@@ -30,10 +31,6 @@ import { isClientError, type GameView, type SessionView } from '@/lib/schemas/ap
  * 참가자 수만큼 곱해지지만 프로젝터는 곱해지지 않습니다.
  */
 const REFRESH_INTERVAL_MS = 3000;
-
-/** `useEventEntryFeed`·`useDashboardFeed`와 같은 기준입니다. 넷째라 공용으로 뺄 때가 됐습니다. */
-const isPermanentFailure = (error: Error | null): boolean =>
-  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
 
 /**
  * 프로젝터가 띄울 게임 하나를 고릅니다.

--- a/lib/api/retryPolicy.test.ts
+++ b/lib/api/retryPolicy.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { isPermanentFailure } from '@/lib/api/retryPolicy';
+import { ApiError } from '@/lib/apiClient';
+
+/**
+ * 이 판정이 폴링을 멈출지 정합니다. 잘못 판정하면 화면이 조용히 굳습니다 — 에러도 안 나고
+ * 갱신만 멈춰서, 사용자는 낡은 값을 최신인 줄 알고 봅니다.
+ */
+
+describe('isPermanentFailure', () => {
+  /*
+   * 계약과 다른 응답입니다. 같은 요청에 같은 응답이 오므로 다시 물어볼 이유가 없습니다.
+   */
+  it('INVALID_RESPONSE는 영구 실패다', () => {
+    expect(isPermanentFailure(new ApiError('INVALID_RESPONSE', '계약과 다릅니다'))).toBe(true);
+  });
+
+  it('4xx는 영구 실패다', () => {
+    expect(isPermanentFailure(new ApiError('EVENT_NOT_FOUND', '없습니다'))).toBe(true);
+    expect(isPermanentFailure(new ApiError('UNAUTHORIZED', '로그인이 필요합니다'))).toBe(true);
+    expect(isPermanentFailure(new ApiError('GAME_NOT_OPEN', '모집 중이 아닙니다'))).toBe(true);
+  });
+
+  /*
+   * 5xx는 다음번에 성공할 수 있습니다. 여기서 멈추면 순간 장애 한 번에 화면이 영영
+   * 굳습니다 — 실제로 게임 목록 API가 500을 낸 적이 있고, 그때도 폴링은 살아 있어야
+   * 서버가 고쳐지는 순간 화면이 따라옵니다.
+   */
+  it('5xx는 영구 실패가 아니다', () => {
+    expect(isPermanentFailure(new ApiError('INTERNAL_ERROR', '서버 오류'))).toBe(false);
+    expect(isPermanentFailure(new ApiError('REPORT_GENERATION_FAILED', '요약 실패'))).toBe(false);
+  });
+
+  /*
+   * 네트워크가 끊긴 경우입니다. `ApiError`가 아니라 그냥 `Error`로 옵니다.
+   */
+  it('ApiError가 아니면 영구 실패가 아니다', () => {
+    expect(isPermanentFailure(new Error('Failed to fetch'))).toBe(false);
+    expect(isPermanentFailure(new TypeError('NetworkError'))).toBe(false);
+  });
+
+  it('에러가 없으면 영구 실패가 아니다', () => {
+    expect(isPermanentFailure(null)).toBe(false);
+  });
+});

--- a/lib/api/retryPolicy.ts
+++ b/lib/api/retryPolicy.ts
@@ -1,0 +1,32 @@
+import { ApiError } from '@/lib/apiClient';
+import { isClientError } from '@/lib/schemas/api';
+
+/**
+ * 다시 물어봐도 같은 답이 오는 실패인지 봅니다.
+ *
+ * 두 곳이 이 판정을 씁니다.
+ *
+ *   재시도  `QueryProvider`의 `retry` — 실패한 요청을 다시 보낼지
+ *   폴링    각 훅의 `refetchInterval` — 주기적 갱신을 멈출지
+ *
+ * 둘이 같은 기준을 봐야 합니다. 재시도하지 않기로 한 실패는 폴링도 할 이유가 없고,
+ * 어긋나면 "재시도는 포기했는데 폴링은 계속 도는" 상태가 됩니다.
+ *
+ * 원래 네 훅과 `QueryProvider`에 같은 코드가 다섯 벌 있었습니다(#299). 이 판정이
+ * 폴링을 멈출지 정하는 자리라, 한 곳만 고치면 그 화면만 조용히 굳습니다 — 에러도
+ * 안 나고 갱신만 멈춰서 찾기가 아주 어렵습니다.
+ */
+
+/**
+ * `INVALID_RESPONSE`는 응답이 계약과 다른 경우입니다. 같은 요청에 같은 응답이 오므로
+ * 다시 물어볼 이유가 없습니다.
+ *
+ * 4xx도 같습니다. 없는 이벤트를 다시 물어봐도 없고, 권한이 없으면 계속 없습니다.
+ *
+ * 5xx와 네트워크 실패는 **여기 안 들어갑니다.** 다음번에 성공할 수 있어서, 순간 장애
+ * 한 번에 화면이 영영 굳으면 안 됩니다.
+ */
+const isPermanentFailure = (error: Error | null): boolean =>
+  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
+
+export { isPermanentFailure };


### PR DESCRIPTION
## 변경 사항

`isPermanentFailure`가 **다섯 곳에 한 글자도 안 다른 채로** 있었습니다. 한곳으로 모읍니다.

```ts
const isPermanentFailure = (error: Error | null): boolean =>
  error instanceof ApiError && (error.code === 'INVALID_RESPONSE' || isClientError(error.code));
```

- `hooks/useEventEntryFeed.ts`
- `hooks/useDashboardFeed.ts`
- `hooks/useCurrentGame.ts`
- `hooks/useHostGame.ts`
- `components/providers/QueryProvider.tsx` — 함수가 아니라 인라인 조건이었을 뿐 판정은 같습니다

**동작은 안 바뀝니다.** 다섯 벌이 이미 같은 코드였습니다.

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `38dbb54` | `lib/api/retryPolicy.ts`로 모으고 다섯 곳에서 임포트 |
| `c39f767` | 판정 기준 테스트 5개 |

## 주석이 이미 세 번 말했습니다

복사할 때마다 「나중에 빼자」고 적어뒀는데, 그 나중이 안 왔습니다.

> `useDashboardFeed`에 같은 함수가 있습니다. 아직 두 벌이라 옮기지 않았습니다 — **세 번째가 생기면** 그때 공용으로 빼는 편이 맞아 보입니다.

> `useEventEntryFeed`·`useDashboardFeed`에도 같은 함수가 있습니다. **세 번째라 공용으로 빼는 게 맞아 보이는데**, 이 PR 범위 밖이라 두고 갑니다.

> `useEventEntryFeed`·`useDashboardFeed`와 같은 기준입니다. **넷째라 공용으로 뺄 때가 됐습니다.**

## 왜 이걸 지금 고치나

**이 판정이 폴링을 멈출지 정합니다.** 기준이 어긋나면 화면이 조용히 굳습니다 — 에러도 안 나고 갱신만 멈춰서, 사용자는 낡은 값을 최신인 줄 알고 봅니다.

다섯 벌이면 **한 곳만 고치는 실수**가 열려 있고, 그게 났을 때 어느 화면이 왜 안 도는지 찾기가 아주 어렵습니다.

## `lib/api/retryPolicy.ts`에 뒀습니다

`lib/apiClient.ts`가 `ApiError`를 정의하는 곳이라 자연스러워 보이는데, **그 파일은 요청을 보내는 일을 맡습니다.** 「재시도·폴링을 멈출 실패인가」라는 판단이 섞이면 역할이 흐려집니다.

## `QueryProvider`도 같은 함수를 봅니다

```ts
// 전
retry: (failureCount, error) => {
  if (error instanceof ApiError) {
    if (error.code === 'INVALID_RESPONSE') return false;
    if (isClientError(error.code)) return false;
  }
  return failureCount < 2;
},

// 후
retry: (failureCount, error) => (isPermanentFailure(error) ? false : failureCount < 2),
```

**재시도하지 않기로 한 실패는 폴링도 할 이유가 없습니다.** 전에는 두 정책이 각자 흉내 내고 있어서, 한쪽만 바뀌면 「재시도는 포기했는데 폴링은 계속 도는」 상태가 될 수 있었습니다.

## 테스트가 잡는 것

| | |
|---|---|
| `INVALID_RESPONSE` | 영구 실패 ✅ |
| 4xx | 영구 실패 ✅ |
| **5xx** | **영구 실패 아님** |
| **네트워크 실패**(`ApiError`가 아님) | **영구 실패 아님** |
| `null` | 영구 실패 아님 |

**5xx를 안 넣는 게 요점입니다.** 여기서 멈추면 순간 장애 한 번에 화면이 영영 굳습니다 — 실제로 게임 목록 API가 500을 냈고(#243 코멘트 참고), 그때도 폴링은 살아 있어야 서버가 고쳐지는 순간 화면이 따라옵니다.

네트워크 실패도 같습니다. 와이파이가 잠깐 끊긴 것만으로 화면이 죽으면 안 됩니다.

**이 판정이 잘못돼도 에러가 안 납니다.** 갱신만 멈춰서 눈으로 못 잡는 종류라 테스트로 뒀습니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

테스트 5개가 늘었습니다(225 → 230).

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **동작 변화 없음.** 다섯 벌이 같은 코드였고 그걸 한곳으로 옮긴 것뿐입니다
- `QueryProvider`의 `retry`는 코드가 바뀌었지만 판정 결과는 같습니다

## 관련 이슈

- Closes #299

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
