### PR TITLE
fix(game): 참가자 게임 화면에서 소감 화면으로 돌아갈 길을 낸다

### DIFF
--- a/app/e/[code]/game/page.tsx
+++ b/app/e/[code]/game/page.tsx
@@ -29,15 +29,15 @@ const GamePage = async ({ params }: GamePageProps) => {
   });
 
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+    <main className="mx-auto flex w-full max-w-md flex-col gap-2 px-5 py-4">
       <Link
         href={`/e/${code}`}
         className="-ml-1 flex w-fit cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
         aria-label="소감 화면으로 돌아가기"
       >
         <ChevronLeftIcon className="h-6 w-6" />
-        <ParticipantGameView eventCode={code} initialGame={game} />
       </Link>
+      <ParticipantGameView eventCode={code} initialGame={game} />
     </main>
   );
 };

--- a/app/e/[code]/game/page.tsx
+++ b/app/e/[code]/game/page.tsx
@@ -1,3 +1,6 @@
+import Link from 'next/link';
+import { ChevronLeftIcon } from '@/components/ui/icons';
+
 import { notFound } from 'next/navigation';
 
 import { ParticipantGameView } from '@/components/game/ParticipantGameView';
@@ -27,7 +30,14 @@ const GamePage = async ({ params }: GamePageProps) => {
 
   return (
     <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
-      <ParticipantGameView eventCode={code} initialGame={game} />
+      <Link
+        href={`/e/${code}`}
+        className="-ml-1 flex w-fit cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
+        aria-label="소감 화면으로 돌아가기"
+      >
+        <ChevronLeftIcon className="h-6 w-6" />
+        <ParticipantGameView eventCode={code} initialGame={game} />
+      </Link>
     </main>
   );
 };

--- a/components/game/GameResult.tsx
+++ b/components/game/GameResult.tsx
@@ -1,3 +1,6 @@
+import Link from 'next/link';
+import { buttonStyle } from '@/components/ui/Button';
+
 import type { GameParticipant, GameView } from '@/lib/schemas/api';
 
 /**
@@ -19,9 +22,11 @@ interface GameResultProps {
   game: GameView;
   /** 참가자 목록에서 찾은 내 id입니다. 못 찾았으면 `null`입니다. */
   myParticipantId: number | null;
+  /** `GameView`에 `eventId`가 없어서(계약대로) 링크 주소를 밖에서 받습니다. */
+  eventCode: string;
 }
 
-const GameResult = ({ game, myParticipantId }: GameResultProps) => {
+const GameResult = ({ game, myParticipantId, eventCode }: GameResultProps) => {
   const byId = new Map(game.participants.map((participant) => [participant.id, participant]));
 
   /*
@@ -75,6 +80,14 @@ const GameResult = ({ game, myParticipantId }: GameResultProps) => {
           결과를 불러오지 못했어요
         </p>
       )}
+      {/*
+        레이스가 끝나면 참가자는 할 일이 없어집니다. 게임을 붙인 이유가 소감 참여율이라(#243)
+        여기서 다음 걸음을 안 알려주면 등수만 보고 화면을 닫습니다. 위 화살표와 따로 두는
+        이유는 저건 이동 수단이고 이건 권하는 행동이기 때문입니다.
+      */}
+      <Link href={`/e/${eventCode}`} className={buttonStyle('primary')}>
+        소감 남기러 가기
+      </Link>
     </section>
   );
 };

--- a/components/game/ParticipantGameView.tsx
+++ b/components/game/ParticipantGameView.tsx
@@ -103,7 +103,7 @@ const ParticipantGameView = ({ eventCode, initialGame }: ParticipantGameViewProp
   const me = game.participants.find((participant) => participant.id === participantId) ?? null;
 
   if (game.status === 'FINISHED') {
-    return <GameResult game={game} myParticipantId={participantId} />;
+    return <GameResult game={game} myParticipantId={participantId} eventCode={eventCode} />;
   }
 
   if (game.status === 'OPEN' && me === null) {


### PR DESCRIPTION
## 변경 사항

참가자가 게임 화면(`/e/{code}/game`)에 들어가면 **소감 화면으로 돌아갈 방법이 없었습니다.** 8/31 실서버 테스트에서 확인했습니다.

- `app/e/[code]/game/page.tsx` — 본문 맨 위에 뒤로가기 링크
- `components/game/GameResult.tsx` — 「소감 남기러 가기」 버튼, `eventCode` prop 추가
- `components/game/ParticipantGameView.tsx` — `eventCode` 넘기기

## 결과 화면만의 문제가 아니었습니다

`ParticipantGameView`의 다섯 갈래 중 나갈 길이 있는 건 **한 갈래뿐**이었습니다.

| 상태 | 화면 | 전 | 후 |
|---|---|---|---|
| 열린 게임 없음 | `EmptyState` | ✅ | ✅ |
| `OPEN` · 참가 전 | `GameJoinForm` | ❌ | ✅ |
| `OPEN` · 참가 후 | `GameWaiting` | ❌ | ✅ |
| `RUNNING` | `GameWaiting` | ❌ | ✅ |
| `FINISHED` | `GameResult` | ❌ | ✅ + 버튼 |

닉네임을 넣고 프로젝터를 기다리는 동안에도 갇힙니다. 그사이 다음 세션이 열려도 참가자는 소감을 남기러 갈 수 없습니다.

## 화면마다 버튼을 넣지 않았습니다

**페이지 맨 위에 링크 하나**를 뒀습니다. 다섯 갈래가 전부 그 아래에 그려지므로 한 곳만 고치면 됩니다. 모양은 `GameHostView`·`EventForm`의 `ChevronLeftIcon` 링크를 그대로 가져왔습니다.

`router.back()`이 아니라 경로를 박았습니다. 게임 진입점이 소감 화면의 `GameBanner`뿐이라 목적지가 하나로 정해져 있고, **QR이나 링크로 게임 화면에 바로 들어오면 히스토리가 없어서** `back()`은 갈 데가 없습니다.

## 헤더가 아니라 본문에 뒀습니다

헤더는 `app/e/[code]/layout.tsx`에 있고 `/live`·`/report`·이벤트 홈이 같이 씁니다. 거기 화살표를 넣으면 **이벤트 홈에서 자기 자신을 가리킵니다.**

게임 화면일 때만 띄우려면 레이아웃이 자기 밑에 어떤 화면이 왔는지 알아야 하는데, 지금은 서버 컴포넌트라 `usePathname`을 쓰려면 클라이언트로 내려야 합니다. 참가자 화면 네 개가 전부 영향을 받는 변경이라 이 PR에서 하지 않았습니다.

본문에 두는 건 이 저장소의 기존 방식이기도 합니다 — `GameHostView`·`EventForm` 둘 다 헤더 아래 본문 맨 위입니다.

## 결과 화면에는 버튼도 넣었습니다

화살표는 「나갈 수 있다」만 알려줍니다. 결과 화면은 **소감을 남기라고 알려줘야 하는 자리**입니다.

레이스가 끝나면 참가자는 할 일이 없어진 채로 등수만 보고 있습니다. 여기가 소감으로 넘어갈 유일한 타이밍인데 안내가 없으면 그냥 화면을 닫습니다. **게임을 붙인 이유가 소감 참여율**이라(#243) 이 한 걸음이 빠지면 게임만 하고 끝납니다.

화살표(이동 수단)와 버튼(권하는 행동)은 역할이 달라서 둘 다 뒀습니다.

## `GameResult`가 `eventCode`를 받습니다

```tsx
interface GameResultProps {
  game: GameView;
  myParticipantId: number | null;
  /** `GameView`에 `eventId`가 없어서(계약대로) 링크 주소를 밖에서 받습니다. */
  eventCode: string;
}
```

`gameViewSchema`가 `eventId`를 `omit`하고 옵니다(2026-08-28 실서버 계약 반영). 컴포넌트 안에서는 링크 주소를 만들 수 없어 밖에서 내려줍니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

실서버(`pulse-backend-sg.onrender.com`)에서 눈으로 확인:

- 결과 화면 → 화살표 → 소감 화면
- 결과 화면 → 「소감 남기러 가기」 → 소감 화면
- 참가 대기 중(`OPEN`) 화살표 동작
- 게임 화면에 직접 주소를 치고 들어와도(히스토리 없음) 화살표가 동작

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `GameResult`에 필수 prop이 하나 늘었습니다. 부르는 곳은 `ParticipantGameView` 한 곳뿐입니다
- 게임 화면 밖은 건드리지 않았습니다

## 관련 이슈

- Closes #301

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
