### PR TITLE
fix(game): 프로젝터 게임 화면 비율과 여백을 맞춘다

### DIFF
--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -63,7 +63,7 @@ const GameFinished = ({
       {/* 본문만 남는 공간에서 가운데 정렬합니다. 제목은 화면마다 같은 높이에 있어야 합니다. */}
       <div className="flex flex-1 flex-col items-center gap-12">
         {podium.length > 0 ? (
-          <ol className="flex flex-wrap items-end justify-center gap-16 pt-[6dvh]">
+          <ol className="flex flex-wrap items-end justify-center gap-16">
             {podium.map((entry) => {
               const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
 

--- a/components/game/host/pinball/PinballCanvas.tsx
+++ b/components/game/host/pinball/PinballCanvas.tsx
@@ -188,7 +188,7 @@ const PinballCanvas = ({ participants, seed, onFinish }: PinballCanvasProps) => 
         ref={canvasRef}
         width={BOARD.width}
         height={BOARD.height}
-        className="max-h-[55dvh] w-full max-w-[70vw] rounded-xl"
+        className="h-[55dvh] w-auto max-w-[70vw] rounded-xl object-contain"
         aria-label="핀볼 레이스"
       />
 


### PR DESCRIPTION
## 변경 사항

프로젝터 게임 화면 두 곳이 어긋나 있었습니다. 8/31 실서버 테스트에서 확인했습니다.

- `components/game/host/pinball/PinballCanvas.tsx` — 캔버스 비율 고정
- `components/game/host/GameFinished.tsx` — 시상대 위 여백 제거

## 개발 과정 로그

| 커밋 | 내용 |
|---|---|
| `a1b81c1` | 레이스 화면 비율 |
| `a390e97` | 결과 화면 여백 |

## 1. 레이스 화면이 찌부됐습니다

전체화면에서 구슬도 닉네임도 가로로 늘어났습니다.

```diff
- className="max-h-[55dvh] w-full max-w-[70vw] rounded-xl"
+ className="h-[55dvh] w-auto max-w-[70vw] rounded-xl object-contain"
```

캔버스 비트맵은 `BOARD` 값대로 **1400×1000(1.4:1)** 고정인데, CSS가 폭과 높이를 따로 정하고 있었습니다. 화면이 넓어지면 `w-full`은 늘어나고 `max-h-[55dvh]`가 높이를 잡아서 박스가 2:1 넘게 납작해지고, 그 안에서 그림이 늘어납니다.

**닉네임까지 눌린 이유**는 그게 DOM 텍스트가 아니라 캔버스에 그린 글자이기 때문입니다. 구슬과 같은 좌표계라 같이 찌그러집니다. 폰트만 봐서는 원인을 못 찾습니다.

높이만 정하고 폭은 맡깁니다. canvas는 대체 요소라 `w-auto`면 비트맵 비율대로 폭을 잡습니다. `object-contain`은 세로가 긴 화면에서 `max-w-[70vw]`가 걸릴 때를 위한 안전장치입니다 — 그때도 늘리는 대신 여백을 둡니다.

## 2. 결과 화면 위 여백이 넓었습니다

```diff
- <ol className="flex flex-wrap items-end justify-center gap-16 pt-[6dvh]">
+ <ol className="flex flex-wrap items-end justify-center gap-16">
```

시상대가 이미 `justify-center`로 가운데에 있는데 `pt-[6dvh]`가 위에서 한 번 더 밀어냈습니다.

8/28에 고쳐놓고 커밋을 안 해서 **PR #296에 안 실렸습니다.** 그날 화면이 안 바뀌어 보였던 게 이것 때문입니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

전체화면(F11)으로 레이스 → 결과까지 눈으로 확인했습니다. 비율은 화면 크기에 따라 달라져서 창 크기로만 보면 놓칩니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- 프로젝터 화면(`/events/{code}/game`)에서만 보입니다. 참가자 화면은 안 건드렸습니다
- 물리 연산은 그대로입니다. 캔버스 비트맵 크기가 아니라 CSS 박스만 바뀌었습니다

## 관련 이슈

- Closes #303

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
