### PR TITLE
fix(event): 세션 이름 입력창에서 엔터 시 이벤트 저장이 실행되는 문제를 고친다

### DIFF
--- a/components/events/SessionList.tsx
+++ b/components/events/SessionList.tsx
@@ -91,6 +91,12 @@ const SessionList = ({ sessions, eventCode }: SessionListProps) => {
                   placeholder="세션 이름 입력"
                   value={editingSessionTitle}
                   onChange={(event) => setEditingSessionTitle(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                      event.preventDefault();
+                      handleEditSessionConfirm(session.id);
+                    }
+                  }}
                 />
                 <Button type="button" variant="secondary" onClick={handleEditSessionCancel}>
                   취소
@@ -136,6 +142,12 @@ const SessionList = ({ sessions, eventCode }: SessionListProps) => {
               placeholder="세션 이름 입력"
               value={newSessionTitle}
               onChange={(event) => setNewSessionTitle(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.nativeEvent.isComposing) {
+                  event.preventDefault();
+                  handleAddSessionConfirm();
+                }
+              }}
               autoFocus
             />
             <Button type="button" variant="secondary" onClick={handleAddSessionCancel}>


### PR DESCRIPTION
## 변경 사항

세션 이름 입력창에서 엔터를 누르면 세션이 추가·수정되지 않고 이벤트 전체가 저장되던 문제를 고쳤습니다.

- **`SessionList.tsx`** 는 이벤트 수정 화면에서 세션 목록을 보여주고, 세션을 추가·수정·삭제하는 컴포넌트입니다.
  - AS-IS: 이 컴포넌트의 세션 이름 input(세션 추가용, 세션 수정용 두 곳)은 이벤트를 저장하는 폼(`EventForm.tsx`의 `<form onSubmit={handleFormSubmit}>`) 안에 있습니다.  
    그래서 지금은 이 input에서 엔터를 누르면 브라우저가 폼을 자동으로 제출하고 있습니다.
  - TO-BE: 두 input에 `onKeyDown` 핸들러를 추가했습니다.  
    엔터 키가 눌리면 폼 자동 제출을 막고, 세션 추가·수정 로직(`handleAddSessionConfirm`·`handleEditSessionConfirm`)을 직접 호출하도록 했습니다.

## 관련 이슈

- Fixes #298

## 검증 방법

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

아래 항목은 전부 이 PR이 머지된 이후를 기준으로 한 설명입니다.

- 세션 이름 input(추가·수정 둘 다)에 이름을 입력하고 엔터 키를 누르면, 세션이 1개만 추가·수정됩니다.
- 위 조작 이후 화면 이동이나 이벤트 저장 토스트("저장했어요")가 뜨지 않습니다.
- 세션 input이 아닌 "제목" 필드를 수정한 뒤 "저장" 버튼을 직접 클릭하면, 기존과 동일하게 "저장했어요" 토스트가 뜨고 저장됩니다.

### 실행한 명령과 결과

- `npx tsc --noEmit`: 에러 없이 통과했습니다.
- `npm run lint`: 이번 변경과 무관한 기존 경고 1개(`DashboardView.tsx`의 `react-hooks/exhaustive-deps`)만 있고, 에러는 없습니다.

### 수동으로 확인한 절차와 결과

- 이벤트 수정 화면에서 세션 추가 input에 한글로 이름을 입력하고 엔터를 눌렀습니다.  
  세션이 1개만 추가되는 것을 확인했습니다.
- 세션 수정 input에서도 이름을 한글로 바꾸고 엔터를 눌렀습니다.  
  세션 이름이 1번만 바뀌는 것을 확인했습니다.
- 두 경우 모두 화면 이동이나 이벤트 저장 토스트가 뜨지 않는 것을 확인했습니다.

### 스크린샷

아래 각 항목에 해당 화면의 스크린샷을 첨부했습니다.

**세션 이름을 입력하고 엔터를 눌러 세션을 추가**
> <img width="1654" height="1764" alt="2026-08-31 엔터키로 세션 추가" src="https://github.com/user-attachments/assets/93918a04-3944-45ea-9b39-bbbed00a20b2" />

**세션 이름을 수정하고 엔터를 눌러 세션을 수정**
> <img width="1654" height="1764" alt="2026-08-31 엔터키로 세션 수정" src="https://github.com/user-attachments/assets/8c0f7457-d70f-4d33-9857-d4ecc0d1d968" />


## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### 한글 입력 중 엔터를 누르면 세션이 중복 추가되는 문제가 있었습니다

**최초 구현(`event.key === 'Enter'`만 확인)에서는 한글로 세션 이름을 입력하고 엔터를 누르면 세션이 2개씩 중복 추가되는 문제가 있었습니다.**
이렇게 확인한 이유는 한글이 자음·모음을 조합해서 한 글자를 완성하는 입력 방식(IME 조합)이기 때문입니다.  
조합이 끝나는 시점과 엔터가 눌리는 시점이 겹칩니다.  
그래서 엔터 키 하나에 대해 브라우저의 `keydown` 이벤트가 두 번 발생했습니다.  
`KeyboardEvent`의 `nativeEvent.isComposing` 값을 확인하는 조건(`!event.nativeEvent.isComposing`)을 추가했습니다.  
조합이 아직 끝나지 않은 상태에서 발생한 이벤트는 이 조건으로 무시하도록 해서 해결했습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

