### PR TITLE
fix(game): 프로젝터 결과 화면 시상대를 정리한다

### DIFF
--- a/components/game/host/GameFinished.tsx
+++ b/components/game/host/GameFinished.tsx
@@ -14,11 +14,14 @@ import type { GameParticipant, GameView } from '@/lib/schemas/api';
 /** 시상대에 올리는 인원입니다. */
 const PODIUM_LIMIT = 3;
 
-const RANK_STYLE: Record<number, { size: string; badge: string }> = {
-  1: { size: 'text-8xl', badge: 'bg-warning-subtle text-warning-darker text-xl px-5 py-2' },
-  2: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
-  3: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
+const RANK_STYLE: Record<number, string> = {
+  1: 'bg-warning-subtle text-warning-darker',
+  2: 'bg-neutral-subtle text-neutral-darker',
+  3: 'bg-neutral-subtle text-neutral-darker',
 };
+
+/** 시상대에 세우는 순서입니다. 1등이 가운데 서야 화면이 안 쏠립니다. */
+const PODIUM_ORDER = [2, 1, 3] as const;
 
 interface GameFinishedProps {
   /** 지금 열린 세션 제목입니다. 게임 제목은 주최자용 메모라 참가자에게 안 보여줍니다. */
@@ -51,53 +54,64 @@ const GameFinished = ({
     )
     .slice(0, PODIUM_LIMIT);
 
+  /*
+   * 셋이 다 있을 때만 자리를 바꿉니다. 참가자가 적어 2등·3등이 비면 그대로 두어야
+   * 빈자리가 안 생깁니다.
+   */
+  const arranged =
+    podium.length === PODIUM_LIMIT ? PODIUM_ORDER.map((rank) => podium[rank - 1]) : podium;
+
   return (
     <section className="flex flex-1 flex-col">
-      <div className="flex flex-col items-center gap-1 pt-[6dvh]">
-        {sessionTitle ? (
-          <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
-        ) : null}
-        <h1 className="text-4xl font-semibold leading-tight text-text-primary">결과가 나왔어요</h1>
-      </div>
+      {/* 제목과 시상대는 한 덩어리입니다. 가운데 정렬로 떼어놓으면 사이가 벌어집니다. */}
+      <div className="flex flex-col items-center gap-10 pt-[6dvh]">
+        <div className="flex flex-col items-center gap-1">
+          {sessionTitle ? (
+            <p className="text-base font-normal leading-6 text-text-secondary">{sessionTitle}</p>
+          ) : null}
+          <h1 className="text-4xl font-semibold leading-tight text-text-primary">
+            결과가 나왔어요
+          </h1>
+          <p className="text-base font-normal leading-6 text-text-tertiary">
+            {game.participants.length}명이 참가했어요
+          </p>
+        </div>
 
-      {/* 본문만 남는 공간에서 가운데 정렬합니다. 제목은 화면마다 같은 높이에 있어야 합니다. */}
-      <div className="flex flex-1 flex-col items-center gap-12">
-        {podium.length > 0 ? (
+        {arranged.length > 0 ? (
           <ol className="flex flex-wrap items-end justify-center gap-16">
-            {podium.map((entry) => {
-              const style = RANK_STYLE[entry.rank] ?? RANK_STYLE[3];
-
-              return (
-                <li key={entry.participant.id} className="flex flex-col items-center gap-3">
-                  <span className={`rounded-full font-normal leading-6 ${style.badge}`}>
-                    {entry.rank}등
-                  </span>
-                  <span className={`${style.size} font-semibold leading-tight text-text-primary`}>
-                    {entry.participant.nickname}
-                  </span>
-                </li>
-              );
-            })}
+            {arranged.map((entry) => (
+              <li key={entry.participant.id} className="flex flex-col items-center gap-3">
+                <span
+                  className={`rounded-full px-4 py-1 text-base font-normal leading-6 ${RANK_STYLE[entry.rank] ?? RANK_STYLE[3]}`}
+                >
+                  {entry.rank}등
+                </span>
+                <span
+                  className={`${entry.rank === 1 ? 'text-8xl' : 'text-5xl'} font-semibold leading-tight text-text-primary`}
+                >
+                  {entry.participant.nickname}
+                </span>
+              </li>
+            ))}
           </ol>
         ) : (
           <p className="text-xl font-normal leading-7 text-text-secondary">
             결과를 불러오지 못했어요
           </p>
         )}
+      </div>
 
-        <div className="flex flex-col items-center gap-3">
-          <div className="flex items-center gap-3">
-            <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>
-              대시보드로
-            </Link>
-            <Button onClick={onCreateNext} disabled={isPending}>
-              새 게임 만들기
-            </Button>
-          </div>
-          <p className="text-sm font-normal leading-5 text-text-tertiary">
-            {game.participants.length}명이 참가했어요
-          </p>
-        </div>
+      {/*
+        주최자용 조작입니다. 관객이 보는 화면이라 결과와 같은 무게로 가운데 두지 않고
+        아래로 내립니다.
+      */}
+      <div className="mt-auto flex items-center justify-center gap-3 pb-[6dvh]">
+        <Link href={`/events/${eventCode}/dashboard`} className={buttonStyle('secondary')}>
+          대시보드로
+        </Link>
+        <Button onClick={onCreateNext} disabled={isPending}>
+          새 게임 만들기
+        </Button>
       </div>
     </section>
   );


### PR DESCRIPTION
## 변경 사항

프로젝터 게임 결과 화면(`GameFinished`)이 정신없어 보였습니다. 원인이 네 개 겹쳐 있었습니다.

`components/game/host/GameFinished.tsx` 한 파일입니다.

## 1. 1등이 가운데가 아니었습니다

`game.ranking` 순서대로 왼쪽부터 그려서 `1 2 3`이 됐습니다. 제일 큰 글씨(`text-8xl`)가 왼쪽 끝에 있으니 화면이 한쪽으로 쏠렸습니다.

```tsx
/** 시상대에 세우는 순서입니다. 1등이 가운데 서야 화면이 안 쏠립니다. */
const PODIUM_ORDER = [2, 1, 3] as const;

const arranged =
  podium.length === PODIUM_LIMIT ? PODIUM_ORDER.map((rank) => podium[rank - 1]) : podium;
```

**셋이 다 있을 때만 자리를 바꿉니다.** 참가자가 적어 2등·3등이 비면 그대로 둬야 빈자리가 안 생깁니다. 테스트하면서 참가자가 1~2명인 경우가 실제로 자주 났습니다.

## 2. 글씨 크기가 여섯 종류였습니다

이름 두 종류(`text-8xl`·`text-5xl`), 배지 두 종류(`text-xl`·`text-base`), 제목, 세션명이 한 화면에서 경쟁했습니다.

배지 크기를 통일하고 **1등만 색으로 구분**합니다. 등수는 이름 크기와 위치가 이미 말하고 있어서, 배지까지 크기를 달리할 이유가 없습니다.

```diff
- const RANK_STYLE: Record<number, { size: string; badge: string }> = {
-   1: { size: 'text-8xl', badge: 'bg-warning-subtle text-warning-darker text-xl px-5 py-2' },
-   2: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
-   3: { size: 'text-5xl', badge: 'bg-neutral-subtle text-neutral-darker text-base px-4 py-1' },
- };
+ const RANK_STYLE: Record<number, string> = {
+   1: 'bg-warning-subtle text-warning-darker',
+   2: 'bg-neutral-subtle text-neutral-darker',
+   3: 'bg-neutral-subtle text-neutral-darker',
+ };
```

2·3등의 이름 크기가 같은 값이라 등수별로 들고 있을 이유가 없어졌습니다. `rank === 1`로 가릅니다.

## 3. 주최자 버튼이 한가운데 있었습니다

「대시보드로」·「새 게임 만들기」가 시상대 바로 아래 정중앙에 있었습니다. **관객이 보는 화면인데 주최자용 조작이 결과와 같은 무게**로 놓여 있었습니다.

`mt-auto`로 바닥에 붙입니다.

## 4. 참가 인원이 버튼 밑에 떠 있었습니다

`{n}명이 참가했어요`가 버튼 아래에 있어서 버튼에 딸린 설명처럼 보였습니다. 결과에 딸린 정보이므로 제목 아래로 올립니다.

## 제목과 시상대를 한 덩어리로 묶었습니다

작업 중에 하나 더 나왔습니다. 시상대만 `flex-1 justify-center`로 남는 공간 가운데 놓으니 **제목 아래에 큰 공백**이 생겼습니다.

제목과 그 내용이 벌어지면 화면이 깨져 보이지만, 바닥 여백은 의도로 읽힙니다. 그래서 제목·인원·시상대를 한 블록(`gap-10`)으로 묶고 버튼만 바닥으로 내렸습니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

전체화면으로 눈으로 확인:

- 참가자 3명 이상 — `2 1 3` 배치
- 참가자 1명 · 2명 — 빈자리 없이 그려지는지
- 버튼이 바닥에 붙는지, 제목과 시상대가 붙어 있는지

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- 프로젝터 화면(`/events/{code}/game`)에서만 보입니다. 참가자 결과 화면(`GameResult`)은 안 건드렸습니다
- `RANK_STYLE`의 타입이 바뀌었지만 이 파일 안에서만 씁니다

## 관련 이슈

- Closes #305

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
