### PR TITLE
refactor(layout): 참가자 헤더를 화면별로 나눈다

### DIFF
--- a/app/e/[code]/game/page.tsx
+++ b/app/e/[code]/game/page.tsx
@@ -1,11 +1,9 @@
-import Link from 'next/link';
-import { ChevronLeftIcon } from '@/components/ui/icons';
-
 import { notFound } from 'next/navigation';
 
 import { ParticipantGameView } from '@/components/game/ParticipantGameView';
 import { fetchCurrentGame } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
+import { EventHeader } from '@/components/layout/EventHeader';
 
 export const dynamic = 'force-dynamic';
 
@@ -29,16 +27,12 @@ const GamePage = async ({ params }: GamePageProps) => {
   });
 
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-2 px-5 py-4">
-      <Link
-        href={`/e/${code}`}
-        className="-ml-1 flex w-fit cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary"
-        aria-label="소감 화면으로 돌아가기"
-      >
-        <ChevronLeftIcon className="h-6 w-6" />
-      </Link>
-      <ParticipantGameView eventCode={code} initialGame={game} />
-    </main>
+    <>
+      <EventHeader eventCode={code} title="미니게임" />
+      <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+        <ParticipantGameView eventCode={code} initialGame={game} />
+      </main>
+    </>
   );
 };
 

--- a/app/e/[code]/layout.tsx
+++ b/app/e/[code]/layout.tsx
@@ -1,50 +1,11 @@
-import Link from 'next/link';
-
-import { Logo } from '@/components/brand/Logo';
-
 /**
- * 참가자 공개 화면(`/e/[code]`, `/live`, `/report`)의 공통 레이아웃입니다.
+ * 참가자 공개 화면(`/e/[code]`, `/live`, `/report`, `/game`)의 공통 레이아웃입니다.
  *
- * `components/layout/Header`는 쓰지 않습니다. 그 컴포넌트는 `email`·`onLogout`을 필수로 받는
- * 호스트 전용이고, README도 참가자 화면에는 쓰지 말라고 명시하고 있습니다. 참가자는 로그인하지
- * 않아서 넘길 값 자체가 없습니다.
- *
- * `h-14`는 그 Header의 모바일 높이에서 가져온 값입니다(`components/layout/README.md` 스펙 표).
- * 반대로 반응형 단계(`md:h-16`·`md:px-20`)는 따라가지 않습니다. 현재 참가자 화면은 QR로 들어오는
- * 모바일 전용이라 넓은 화면을 위한 단계가 필요 없습니다. 대신 로고를 각 페이지 본문과 같은
- * `max-w-md`·`px-5` 열에 맞췄습니다.
- *
- * 여백은 바깥(`header`), 테두리는 안쪽(`div`)에 겁니다. 이래야 선이 화면 끝이 아니라 로고 왼쪽
- * 끝에서 시작해서 본문 오른쪽 끝에서 멈춥니다. 둘을 한 요소에 몰면 선이 `px-5`까지 덮습니다.
- *
- * `aria-label`에 `Pulse`를 남깁니다. 로고의 `Pulse`는 진짜 텍스트라 그냥 두면 접근 이름이 되는데
- * (`components/brand/README.md`), `aria-label`은 자식 텍스트를 덮어써서 빼면 사라집니다. 그러면
- * 음성 입력 사용자가 화면에 보이는 이름으로 이 링크를 지목할 수 없습니다. 뒷부분이 호스트 Header의
- * "Pulse 홈으로"와 다른 이유는 목적지가 서비스 홈이 아니라 그 이벤트의 홈이기 때문입니다.
- *
- * `not-found.tsx`도 이 레이아웃 안에서 그려집니다. 그때 로고는 방금 404를 낸 주소를 가리키지만
- * 그대로 뒀습니다. 참가자에게는 돌아갈 다른 홈이 없고, 막으려면 레이아웃이 자식이 `not-found`인지
- * 알아야 해서 장치가 더 붙습니다(#239).
+ * 헤더는 여기 없습니다. 화면마다 모양이 달라야 해서 각 페이지가 `EventHeader`를
+ * 직접 부릅니다(#308). 남은 건 바깥 틀뿐입니다.
  */
-const EventLayout = async ({ children, params }: LayoutProps<'/e/[code]'>) => {
-  const { code } = await params;
-
-  return (
-    <div className="flex flex-1 flex-col">
-      <header className="mx-auto w-full max-w-md px-5">
-        <div className="flex h-14 items-center border-b border-border-subtle">
-          <Link
-            href={`/e/${code}`}
-            aria-label="Pulse 이벤트 홈으로"
-            className="rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker"
-          >
-            <Logo />
-          </Link>
-        </div>
-      </header>
-      {children}
-    </div>
-  );
+const EventLayout = ({ children }: LayoutProps<'/e/[code]'>) => {
+  return <div className="flex flex-1 flex-col">{children}</div>;
 };
 
 export default EventLayout;

--- a/app/e/[code]/live/page.tsx
+++ b/app/e/[code]/live/page.tsx
@@ -3,6 +3,7 @@ import { Suspense } from 'react';
 
 import { LiveResult } from '@/components/live/LiveResult';
 import { LiveSkeleton } from '@/components/live/LiveSkeleton';
+import { EventHeader } from '@/components/layout/EventHeader';
 
 /**
  * 참가자용 실시간 결과 화면입니다.
@@ -45,11 +46,14 @@ const LivePage = async ({ params, searchParams }: PageProps<'/e/[code]/live'>) =
    * 로고도 `max-w-md`라, 여기만 넓히면 넓은 화면에서 로고와 본문의 왼쪽 끝이 어긋납니다.
    */
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
-      <Suspense fallback={<LiveSkeleton withHeading />}>
-        <LiveResult />
-      </Suspense>
-    </main>
+    <>
+      <EventHeader eventCode={code} title="실시간 반응" />
+      <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+        <Suspense fallback={<LiveSkeleton withHeading />}>
+          <LiveResult />
+        </Suspense>
+      </main>
+    </>
   );
 };
 

--- a/app/e/[code]/not-found.tsx
+++ b/app/e/[code]/not-found.tsx
@@ -1,13 +1,17 @@
+import { EventHeader } from '@/components/layout/EventHeader';
 import { EmptyState } from '@/components/ui/EmptyState';
 
 const EventNotFound = () => {
   return (
-    <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
-      <EmptyState
-        title="이벤트를 찾을 수 없어요"
-        description="링크가 올바른지 다시 확인해 주세요"
-      />
-    </main>
+    <>
+      <EventHeader />
+      <main className="mx-auto flex w-full max-w-md flex-col gap-6 px-5 py-4">
+        <EmptyState
+          title="이벤트를 찾을 수 없어요"
+          description="링크가 올바른지 다시 확인해 주세요"
+        />
+      </main>
+    </>
   );
 };
 

--- a/app/e/[code]/page.tsx
+++ b/app/e/[code]/page.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
 import { EventEntryView } from '@/components/feedback/EventEntryView';
+import { EventHeader } from '@/components/layout/EventHeader';
 
 export const dynamic = 'force-dynamic';
 interface EventEntryPageProps {
@@ -53,13 +54,16 @@ const EventEntryPage = async ({ params }: EventEntryPageProps) => {
       }));
 
   return (
-    <EventEntryView
-      eventCode={code}
-      initialEvent={event}
-      initialSessions={sessions}
-      initialHasReport={hasReport}
-      initialCurrentGame={currentGame}
-    />
+    <>
+      <EventHeader eventCode={code} />
+      <EventEntryView
+        eventCode={code}
+        initialEvent={event}
+        initialSessions={sessions}
+        initialHasReport={hasReport}
+        initialCurrentGame={currentGame}
+      />
+    </>
   );
 };
 

--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
+import { EventHeader } from '@/components/layout/EventHeader';
 
 interface ReportPageProps {
   params: Promise<{ code: string }>;
@@ -57,12 +58,15 @@ const ReportPage = async ({ params }: ReportPageProps) => {
 
   if (report === null) {
     return (
-      <main className={PAGE}>
-        <EmptyState
-          title="공개된 리포트가 없어요"
-          description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
-        />
-      </main>
+      <>
+        <EventHeader eventCode={code} title="리포트" />
+        <main className={PAGE}>
+          <EmptyState
+            title="공개된 리포트가 없어요"
+            description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
+          />
+        </main>
+      </>
     );
   }
 
@@ -87,69 +91,72 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   const positiveRate = toRates(counts).positive;
 
   return (
-    <main className={PAGE}>
-      <header className="flex flex-col gap-1">
-        {/*
-          행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
-          일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
+    <>
+      <EventHeader eventCode={code} title="리포트" />
+      <main className={PAGE}>
+        <header className="flex flex-col gap-1">
+          {/*
+            행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
+            일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
 
-          소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
-        */}
-        <p className="text-xs leading-4 text-text-tertiary">
-          <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
-          {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
-        </p>
+            소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
+          */}
+          <p className="text-xs leading-4 text-text-tertiary">
+            <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
+            {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
+          </p>
 
-        <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
-      </header>
+          <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
+        </header>
 
-      <div className="grid grid-cols-3 gap-3">
-        <Stat label="총 소감" value={`${submissionCount}`} />
-        <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
-        <Stat label="세션" value={`${sessions.length}`} />
-      </div>
+        <div className="grid grid-cols-3 gap-3">
+          <Stat label="총 소감" value={`${submissionCount}`} />
+          <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
+          <Stat label="세션" value={`${sessions.length}`} />
+        </div>
 
-      <section className={CARD}>
-        <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
-        <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
-      </section>
+        <section className={CARD}>
+          <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
+          <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
+        </section>
 
-      <section className={`${CARD} items-center`}>
-        {/*
-          분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
-          총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
-        */}
-        <h2 className="self-start text-xs leading-4 text-text-tertiary">
-          감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
-        </h2>
-        {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
-        <Donut {...counts} className="py-2" />
-      </section>
+        <section className={`${CARD} items-center`}>
+          {/*
+            분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
+            총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
+          */}
+          <h2 className="self-start text-xs leading-4 text-text-tertiary">
+            감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
+          </h2>
+          {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
+          <Donut {...counts} className="py-2" />
+        </section>
 
-      <section className="flex flex-col gap-3">
-        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
-        {/*
-          생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
-          이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
-        */}
-        {topKeywords.length === 0 ? (
-          <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
-        ) : (
-          /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
-          <ul className="flex flex-wrap gap-2">
-            {topKeywords.map(({ keyword, count }) => (
-              <li
-                key={keyword}
-                className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
-              >
-                {keyword}
-                <span className="text-text-tertiary">{count}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+          {/*
+            생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
+            이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
+          */}
+          {topKeywords.length === 0 ? (
+            <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
+          ) : (
+            /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
+            <ul className="flex flex-wrap gap-2">
+              {topKeywords.map(({ keyword, count }) => (
+                <li
+                  key={keyword}
+                  className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
+                >
+                  {keyword}
+                  <span className="text-text-tertiary">{count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+    </>
   );
 };
 

--- a/components/layout/EventHeader.tsx
+++ b/components/layout/EventHeader.tsx
@@ -1,0 +1,76 @@
+import Link from 'next/link';
+
+import { Logo } from '@/components/brand/Logo';
+import { ChevronLeftIcon } from '@/components/ui/icons';
+
+/**
+ * 참가자 공개 화면의 헤더입니다.
+ *
+ * 화면마다 모양이 달라야 해서 레이아웃이 아니라 각 페이지가 부릅니다. 레이아웃에 두면
+ * 다섯 화면이 한 헤더를 공유하게 되고, 게임·라이브·리포트에서만 뒤로가기를 띄우려면
+ * `usePathname`을 쓰려고 레이아웃을 클라이언트로 내려야 합니다(#308).
+ *
+ * `components/layout/Header`는 쓰지 않습니다. 그 컴포넌트는 `email`·`onLogout`을 필수로
+ * 받는 호스트 전용이고, 참가자는 로그인하지 않아서 넘길 값 자체가 없습니다.
+ *
+ * `h-14`는 그 Header의 모바일 높이에서 가져온 값입니다(`components/layout/README.md` 스펙 표).
+ * 반대로 반응형 단계(`md:h-16`·`md:px-20`)는 따라가지 않습니다. 참가자 화면은 QR로 들어오는
+ * 모바일 전용이라 넓은 화면을 위한 단계가 필요 없습니다.
+ *
+ * 여백은 바깥(`header`), 테두리는 안쪽(`div`)에 겁니다. 이래야 선이 화면 끝이 아니라 로고
+ * 왼쪽 끝에서 시작해서 본문 오른쪽 끝에서 멈춥니다. 둘을 한 요소에 몰면 선이 `px-5`까지 덮습니다.
+ */
+
+const FOCUS =
+  'rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker';
+
+interface EventHeaderProps {
+  /** 뒤로가기와 로고가 가리킬 이벤트 홈입니다. 404 화면처럼 코드를 모르면 넘기지 않습니다. */
+  eventCode?: string;
+  /** 넘기면 로고 대신 「← 이름」이 됩니다. */
+  title?: string;
+}
+
+const EventHeader = ({ eventCode, title }: EventHeaderProps) => {
+  return (
+    <header className="mx-auto w-full max-w-md px-5">
+      <div className="flex h-14 items-center gap-2 border-b border-border-subtle">
+        {title !== undefined && eventCode !== undefined ? (
+          <>
+            <Link
+              href={`/e/${eventCode}`}
+              aria-label="소감 화면으로 돌아가기"
+              className={`-ml-1 flex cursor-pointer items-center rounded p-1 text-text-secondary hover:bg-background-secondary ${FOCUS}`}
+            >
+              <ChevronLeftIcon className="h-6 w-6" />
+            </Link>
+            {/*
+              `h1`이 아닙니다. 세 화면 다 본문에 제목이 이미 있어서, 여기를 제목 요소로 만들면
+              스크린리더에서 제목이 둘로 갈립니다.
+            */}
+            <p className="text-base font-semibold leading-6 text-text-primary">{title}</p>
+          </>
+        ) : eventCode !== undefined ? (
+          /*
+            `aria-label`에 `Pulse`를 남깁니다. 로고의 `Pulse`는 진짜 텍스트라 그냥 두면 접근
+            이름이 되는데, `aria-label`은 자식 텍스트를 덮어써서 빼면 사라집니다. 뒷부분이 호스트
+            Header의 "Pulse 홈으로"와 다른 이유는 목적지가 서비스 홈이 아니라 그 이벤트의
+            홈이기 때문입니다.
+          */
+          <Link href={`/e/${eventCode}`} aria-label="Pulse 이벤트 홈으로" className={FOCUS}>
+            <Logo />
+          </Link>
+        ) : (
+          /*
+            404 화면입니다. `not-found.tsx`는 `params`를 못 받아 이벤트 코드를 모릅니다.
+            예전에는 레이아웃이 코드를 갖고 있어서 로고가 방금 404를 낸 주소를 가리켰는데(#239),
+            갈 데가 없으면 링크를 안 거는 게 맞습니다.
+          */
+          <Logo />
+        )}
+      </div>
+    </header>
+  );
+};
+
+export { EventHeader };


### PR DESCRIPTION
## 변경 사항

참가자 화면의 헤더를 `EventHeader`로 빼고, 각 페이지가 자기 헤더를 고르게 했습니다.

| 화면 | 헤더 |
|---|---|
| 이벤트 홈 (`/e/[code]`) | 로고 |
| `not-found` | 로고 (링크 없음) |
| `/game` | `← 미니게임` |
| `/live` | `← 실시간 반응` |
| `/report` | `← 리포트` |

## 문제

`/live`와 `/report`에는 **소감 화면으로 돌아갈 길이 없었습니다.** 로고가 `/e/{code}`로 가긴 하지만 그렇게 보이지 않습니다.

`/game`은 `#301`에서 화살표를 넣었지만 **헤더 밖 본문에 떠 있었습니다.** 모바일에서 뒤로가기는 상단 바에 있는 게 표준입니다.

## 왜 이 구조인가

헤더가 `app/e/[code]/layout.tsx`에 있어서 **다섯 화면이 하나를 공유**하는 게 원인이었습니다.

세 화면에서만 뒤로가기를 띄우려면 레이아웃이 자기 밑에 어떤 화면이 왔는지 알아야 하는데, 지금은 서버 컴포넌트라 `usePathname`을 쓰려면 클라이언트로 내려야 합니다. 참가자 화면 전부가 영향을 받습니다.

각 페이지가 자기 헤더를 부르면 그럴 필요가 없습니다. 「레이아웃이 라우트마다 달라야 할 때」 Next.js가 권하는 방식입니다.

레이아웃에는 바깥 틀만 남았습니다.

```tsx
const EventLayout = ({ children }: LayoutProps<'/e/[code]'>) => {
  return <div className="flex flex-1 flex-col">{children}</div>;
};
```

## 헤더 이름은 `h1`이 아닙니다

세 화면 다 본문에 제목이 이미 있습니다.

| 화면 | 본문 `h1` |
|---|---|
| `/live` | 세션 제목 (위에 이벤트명) |
| `/report` | 이벤트 제목 (위에 날짜·소감 수) |
| `/game` | 없음 (상태별 `h2`) |

여기를 제목 요소로 만들면 **스크린리더에서 제목이 둘로 갈립니다.** `<p>`로 뒀습니다.

본문 제목과 겹치지도 않습니다 — 본문은 데이터(세션명·이벤트명)를 말하고 헤더는 화면 이름을 말합니다. `← 리포트` 아래 이벤트명이 오는 건 중복이 아니라 계층입니다.

`미니게임`으로 부르는 이유는 배너 문구가 「지금 게임이 열렸어요」라, 참가자가 이미 그 말로 들어오기 때문입니다.

## 404 화면은 로고에 링크를 안 겁니다

`not-found.tsx`는 **`params`를 못 받아** 이벤트 코드를 모릅니다. 전에는 레이아웃이 코드를 갖고 있어서 로고가 방금 404를 낸 주소를 가리켰는데(#239 주석에 남아 있음), 갈 데가 없으면 링크가 없는 게 맞습니다.

`EventHeader`가 `eventCode` 없이 불리면 이 모양이 됩니다.

## 주최자 화면은 안 건드렸습니다

두 쪽은 사실 다른 플랫폼입니다.

- **참가자** — QR로 들어와 한 가지 일만 하고 나가는 모바일 흐름. 상단 바 뒤로가기가 표준이고 로고는 할 일이 없습니다
- **주최자** — 로그인한 채 여러 화면을 오가는 데스크톱. 헤더가 앱 크롬 역할이라 로고·이메일·로그아웃이 늘 같은 자리에 있어야 하고, 화면 간 이동은 본문에 둡니다

`GameHostView`·`EventForm`의 본문 화살표는 그대로입니다. 프로젝터 게임 화면도 주최자 쪽이라 그대로입니다.

## 옮긴 결정들

`layout.tsx` 주석에 있던 근거를 `EventHeader`로 함께 옮겼습니다.

- `h-14`는 호스트 `Header`의 모바일 높이에서 가져온 값 (`components/layout/README.md` 스펙 표)
- 반응형 단계(`md:h-16`·`md:px-20`)는 일부러 안 따라감 — 참가자 화면은 모바일 전용
- 여백은 바깥(`header`), 테두리는 안쪽(`div`) — 선이 로고 왼쪽에서 시작해 본문 오른쪽에서 멈추게
- `aria-label`에 `Pulse`를 남기는 이유 — 로고의 텍스트를 덮어쓰기 때문

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

모바일 폭으로 다섯 화면 눈으로 확인:

- `/e/{code}` — 로고
- `/e/{code}/live?sessionId=…` — `← 실시간 반응`, 아래 세션 제목과 어떻게 보이는지
- `/e/{code}/report` — `← 리포트`, 리포트 없을 때 화면 포함
- `/e/{code}/game` — `← 미니게임`, 본문 화살표가 사라졌는지
- 없는 코드 — 로고에 링크가 안 걸리는지

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **참가자 화면 다섯 곳 전부**를 건드립니다. 주최자 화면은 안 건드렸습니다
- `#301`이 넣은 본문 화살표를 걷어냅니다. 같은 기능이 헤더로 옮겨간 것이라 동작은 유지됩니다
- 404 화면 로고의 링크가 없어집니다 (의도)

## 관련 이슈

- Closes #308
- `#301`의 후속입니다

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
