### PR TITLE
fix(report): 참가자 화면 제목 크기를 통일한다

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -5,7 +5,6 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
-import { EventHeader } from '@/components/layout/EventHeader';
 
 interface ReportPageProps {
   params: Promise<{ code: string }>;
@@ -58,15 +57,12 @@ const ReportPage = async ({ params }: ReportPageProps) => {
 
   if (report === null) {
     return (
-      <>
-        <EventHeader eventCode={code} title="리포트" />
-        <main className={PAGE}>
-          <EmptyState
-            title="공개된 리포트가 없어요"
-            description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
-          />
-        </main>
-      </>
+      <main className={PAGE}>
+        <EmptyState
+          title="공개된 리포트가 없어요"
+          description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
+        />
+      </main>
     );
   }
 
@@ -91,72 +87,67 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   const positiveRate = toRates(counts).positive;
 
   return (
-    <>
-      <EventHeader eventCode={code} title="리포트" />
-      <main className={PAGE}>
-        <header className="flex flex-col gap-1">
-          {/*
-            행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
-            일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
+    <main className={PAGE}>
+      <header className="flex flex-col gap-1">
+        {/*
+          행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
+          일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
 
-            소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
-          */}
-          <p className="text-xs leading-4 text-text-tertiary">
-            <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
-            {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
-          </p>
+          소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
+        */}
+        <p className="text-xs leading-4 text-text-tertiary">
+          <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
+          {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
+        </p>
+        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
+      </header>
+      <div className="grid grid-cols-3 gap-3">
+        <Stat label="총 소감" value={`${submissionCount}`} />
+        <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
+        <Stat label="세션" value={`${sessions.length}`} />
+      </div>
 
-          <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
-        </header>
+      <section className={CARD}>
+        <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
+        <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
+      </section>
 
-        <div className="grid grid-cols-3 gap-3">
-          <Stat label="총 소감" value={`${submissionCount}`} />
-          <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
-          <Stat label="세션" value={`${sessions.length}`} />
-        </div>
+      <section className={`${CARD} items-center`}>
+        {/*
+          분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
+          총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
+        */}
+        <h2 className="self-start text-xs leading-4 text-text-tertiary">
+          감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
+        </h2>
+        {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
+        <Donut {...counts} className="py-2" />
+      </section>
 
-        <section className={CARD}>
-          <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
-          <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
-        </section>
-
-        <section className={`${CARD} items-center`}>
-          {/*
-            분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
-            총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
-          */}
-          <h2 className="self-start text-xs leading-4 text-text-tertiary">
-            감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
-          </h2>
-          {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
-          <Donut {...counts} className="py-2" />
-        </section>
-
-        <section className="flex flex-col gap-3">
-          <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
-          {/*
-            생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
-            이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
-          */}
-          {topKeywords.length === 0 ? (
-            <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
-          ) : (
-            /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
-            <ul className="flex flex-wrap gap-2">
-              {topKeywords.map(({ keyword, count }) => (
-                <li
-                  key={keyword}
-                  className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
-                >
-                  {keyword}
-                  <span className="text-text-tertiary">{count}</span>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-      </main>
-    </>
+      <section className="flex flex-col gap-3">
+        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+        {/*
+          생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
+          이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
+        */}
+        {topKeywords.length === 0 ? (
+          <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
+        ) : (
+          /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
+          <ul className="flex flex-wrap gap-2">
+            {topKeywords.map(({ keyword, count }) => (
+              <li
+                key={keyword}
+                className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
+              >
+                {keyword}
+                <span className="text-text-tertiary">{count}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </main>
   );
 };
 


### PR DESCRIPTION
## 변경 사항

참가자 화면의 `h1` 크기가 `/report`만 달랐습니다.

```diff
- <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
+ <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
```

`app/e/[code]/report/page.tsx` 한 줄입니다.

## 문제

| 화면 | `h1` | 내용 |
|---|---|---|
| 소감 화면 (`EventEntryView`) | `text-xl leading-7` | 이벤트 제목 |
| `/live` (`LiveResult`) | `text-xl leading-7` | 세션 제목 |
| `/report` | **`text-2xl leading-8`** | 이벤트 제목 |

소감 화면과 `/report`는 **같은 값**(`event.title`)을 제목으로 쓰는데 크기가 달랐습니다. 화면을 옮기면 같은 제목이 커졌다 작아졌다 합니다.

`#308`에서 헤더에 화면 이름을 넣으면서 세 화면이 나란히 비교되게 됐고, 그때 눈에 띄었습니다.

## `text-xl` 쪽으로 맞춘 이유

셋 중 둘이 이미 `text-xl`이고, 그 둘이 참가자가 가장 자주 보는 화면입니다. 소수를 다수에 맞췄습니다.

`text-text-primary`도 함께 붙였습니다. 색을 안 주고 상속받고 있었는데, 나머지 두 화면은 명시하고 있습니다.

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

모바일 폭으로 소감 화면 → `/report`를 오가며 제목 크기가 안 튀는지 확인했습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `/report` 화면 하나, 한 줄입니다
- `/report` 안의 `h2`들(`text-xs`)은 안 건드렸습니다. 카드 라벨이라 역할이 다릅니다
- `#308`과 같은 파일이지만 헤더는 위쪽, 이건 109번 줄이라 충돌하지 않습니다

## 관련 이슈

- Closes #310

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
