### PR TITLE
fix(event): 이벤트 연속 삭제 시 목록 캐시가 갱신되지 않는 문제를 고친다

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -217,7 +217,14 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
 
   const { mutate: removeEvent, isPending: isDeleting } = useMutation({
     mutationFn: () => deleteEvent(eventCode as string),
-    onSuccess: () => router.push('/events'),
+    onSuccess: () => {
+      // invalidateQueries는 stale 표시만 남길 뿐, 목록 화면이 재마운트되는 시점에는
+      // 여전히 캐시된(삭제 전) 값을 한 번 그립니다(#284의 startEvent와 같은 문제, #313).
+      queryClient.setQueryData<PulseEvent[]>(['myEvents'], (previous) =>
+        previous?.filter((item) => item.code !== eventCode),
+      );
+      router.push('/events');
+    },
   });
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {


### PR DESCRIPTION
## 변경 사항

이벤트를 연속으로 삭제하면 두 번째 삭제부터 목록 화면(`/events`)에 반영되지 않는 문제를 고쳤습니다.

- **`components/events/EventForm.tsx`** 는 이벤트 등록·수정·삭제를 처리하는 공용 폼 컴포넌트입니다.
  삭제 mutation `removeEvent`의 `onSuccess`에 `queryClient.setQueryData(['myEvents'], ...)`를 추가했습니다.  
  그래서 삭제된 이벤트를 목록 쿼리 캐시(쿼리 키 `['myEvents']`)에서 직접 제거하도록 고쳤습니다.
  - AS-IS: 지금은 `onSuccess`가 `router.push('/events')`만 실행하고 있어, 목록 캐시를 갱신하는 코드가 없습니다.
  - TO-BE: 삭제 성공 시 목록 캐시에서 해당 이벤트를 직접 제거합니다.  
    그러면 재마운트 시점의 `staleTime`(캐시된 데이터를 신선하다고 판단하는 기준 시간, `QueryProvider.tsx`에서 10초로 설정되어 있음) 값과 무관하게 항상 화면에 반영됩니다.
- 같은 파일의 `startEvent` mutation(#284 에서 같은 종류의 캐시 미반영 문제를 해결한 패턴)과 동일한 방식입니다.

원인 분석은 이슈 #313 본문에 상세히 정리되어 있어 여기서 다시 쓰지 않습니다.

### 스크린샷
> <img width="1778" height="1778" alt="2026-09-02 PR#314 이벤트 연속 삭제 성공" src="https://github.com/user-attachments/assets/beb1176c-5be0-4369-8a81-b0fdb2a270f5" />


## 관련 이슈

- Fixes #313

## 검증 방법

### 자동 검증

- `npx tsc --noEmit` — 통과했습니다.
- `npm run lint` — 통과했습니다. 경고 1건은 `DashboardView.tsx`에 원래 있던 것으로 이번 변경과 무관합니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

이벤트가 2개 이상 있는 상태에서 곧바로 이어서 두 이벤트를 연속으로 삭제하면, 두 번의 삭제 모두 새로고침 없이 목록에 즉시 반영됩니다.

실제로 두 이벤트를 10초 이내 간격으로 연속 삭제하는 과정을 GIF로 녹화해서 확인했습니다.

- 카드가 5개인 상태에서 시작했습니다.
  - 시작 시점 카드 목록: "Pulse 최종 발표"·"Pulse 중간 발표"·"Pulse 멘토링"·"삭제용 이벤트"·"삭제용 이벤트 복제"
- "삭제용 이벤트 복제" 카드를 먼저 삭제하자, 목록 화면으로 돌아온 직후 카드가 4개로 줄었습니다.
- 곧바로(10초 이내) "삭제용 이벤트" 카드를 삭제하자, 목록 화면으로 돌아온 직후 카드가 3개로 줄었습니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
