### PR TITLE
fix(event): 행사 날짜 입력의 연도 오버플로우 버그 수정

### DIFF
--- a/components/events/EventDateField.tsx
+++ b/components/events/EventDateField.tsx
@@ -1,0 +1,250 @@
+'use client';
+
+import {
+  type ChangeEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
+import { DayPicker } from 'react-day-picker';
+import { ko } from 'react-day-picker/locale';
+
+interface EventDateFieldProps {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const ISO_DATE_PATTERN = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+// year·month·day가 실제로 존재하는 달력 날짜인지 확인한다. new Date(2026, 1, 30)처럼
+// 존재하지 않는 날짜를 넘기면 JS는 에러 없이 3월로 넘겨버리므로(2월 30일 -> 3월 2일),
+// 만든 Date에서 다시 연/월/일을 읽어 원래 입력과 같은지 대조해야 한다.
+const isRealCalendarDate = (year: number, month: number, day: number) => {
+  const date = new Date(year, month - 1, day);
+  return date.getFullYear() === year && date.getMonth() === month - 1 && date.getDate() === day;
+};
+
+// "YYYY-MM-DD"를 new Date(문자열)로 파싱하면 UTC 자정으로 읽혀서, 타임존에 따라
+// 하루가 밀린다(lib/formatEventDate.ts와 같은 이유). 지역 시간 그대로 연/월/일을
+// 읽어 Date를 만든다. 자릿수는 맞아도 51월처럼 실제로 없는 날짜면(타이핑 중일 수
+// 있음) undefined를 돌려줘서 캘린더가 엉뚱한 달로 튀지 않게 한다.
+const parseIsoDate = (value: string): Date | undefined => {
+  const match = value.match(ISO_DATE_PATTERN);
+  if (!match) return undefined;
+  const [, year, month, day] = match;
+  const y = Number(year);
+  const m = Number(month);
+  const d = Number(day);
+  return isRealCalendarDate(y, m, d) ? new Date(y, m - 1, d) : undefined;
+};
+
+// Date.toISOString()은 UTC로 변환하므로 같은 이유로 쓰지 않는다. 지역 시간의
+// 연/월/일을 그대로 문자열로 만든다.
+const toIsoDate = (date: Date): string =>
+  `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+
+// 타이핑 중인 숫자 0~8자리를 부모에 전달할 형태("2026-09" 처럼 다 못 채운 상태도
+// 그대로)로 만든다. 다 채우지 못한 채로 등록을 누르면, 이 값이 그대로 lib/schemas/api.ts의
+// calendarDate 스키마(정확히 YYYY-MM-DD만 통과) 검증에 걸려 저장이 막힌다(#312 후속).
+const digitsToDraftValue = (digits: string) =>
+  [digits.slice(0, 4), digits.slice(4, 6), digits.slice(6, 8)].filter(Boolean).join('-');
+
+// 타이핑 중인 숫자 8자리(YYYYMMDD)를 네이티브 date input과 같은 형식("2026. 09. 02.")으로
+// 끊어 보여준다. slice로 연도를 4자리에서 강제로 자르기 때문에, 네이티브 date input에서
+// 겪었던 "연도 자리가 4자리를 넘겨도 계속 받아들이는" 문제 자체가 여기서는 생길 수 없다.
+const formatDraft = (digits: string) => {
+  const segments = [digits.slice(0, 4), digits.slice(4, 6), digits.slice(6, 8)].filter(Boolean);
+  return segments.length ? `${segments.join('. ')}.` : '';
+};
+
+/**
+ * 네이티브 `<input type="date">`의 연도 자리가 4자리를 넘겨도 계속 숫자를 받아들이는
+ * Chromium 버그(https://issues.chromium.org/issues/41235379, #312)를 피하려고
+ * react-day-picker 팝오버로 대체한 행사 날짜 입력입니다. 자릿수를 우리 코드가 직접
+ * 세기 때문에, 숫자 8자리(예: 20260902)를 타이핑해서 바로 날짜를 입력할 수도 있습니다.
+ */
+const EventDateField = ({ label, value, onChange, error }: EventDateFieldProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [rawDigits, setRawDigits] = useState(() => value.replaceAll('-', ''));
+  // 8자리를 다 못 채운 채 필드를 벗어났을 때만 "8자리로 입력하라"는 안내를 보여준다.
+  // 타이핑하는 도중(초점이 있는 동안)에는 아직 다 안 썼을 뿐이라 안내를 띄우지 않는다.
+  const [showIncompleteHint, setShowIncompleteHint] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const id = useId();
+  const errorId = `${id}-error`;
+
+  // 캘린더 클릭으로 값이 바뀌면(또는 외부에서 값이 바뀌면) 타이핑 중이던 자리도 맞춘다.
+  // 렌더링 중 상태 조정입니다(EventForm.tsx의 loadedEventData와 같은 이유로 useEffect가
+  // 아니라 여기서 직접 처리합니다 — 렌더가 한 번 더 겹치고 react-hooks/set-state-in-effect에
+  // 걸립니다).
+  const [lastSyncedValue, setLastSyncedValue] = useState(value);
+  if (value !== lastSyncedValue) {
+    setLastSyncedValue(value);
+    setRawDigits(value.replaceAll('-', ''));
+  }
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!rootRef.current?.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setIsOpen(false);
+    };
+
+    document.addEventListener('mousedown', handlePointerDown);
+    document.addEventListener('keydown', handleKeyDown);
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [isOpen]);
+
+  // 타이핑되는 대로 항상 부모(EventForm)의 값을 그대로 갱신한다. 8자리를 다 채운
+  // 유효한 날짜일 때만 반영하던 예전 방식은, 다 못 채운 채로 등록을 누르면 부모가
+  // 여전히 이전 값을 들고 있어서 조용히 예전 날짜로 저장되는 문제가 있었다(#312 후속).
+  const handleRawInputChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const digits = event.target.value.replace(/\D/g, '').slice(0, 8);
+    setRawDigits(digits);
+    onChange(digitsToDraftValue(digits));
+  };
+
+  // 화면에 보이는 값은 우리가 만든 마스크("2026. 09. 02.")라, 커서 바로 앞 글자가
+  // 숫자가 아니라 마침표·공백일 때가 있다. 그 상태로 브라우저 기본 백스페이스에 맡기면
+  // 마침표만 지워지고 숫자 개수는 그대로라 화면이 안 바뀐 것처럼 보인다. 그래서
+  // Backspace·Delete는 항상 "마지막 숫자 하나 지우기"로 직접 처리한다.
+  const handleRawKeyDown = (event: ReactKeyboardEvent<HTMLInputElement>) => {
+    if (event.key !== 'Backspace' && event.key !== 'Delete') return;
+    event.preventDefault();
+
+    const { selectionStart, selectionEnd } = event.currentTarget;
+    const hasSelection =
+      selectionStart !== null && selectionEnd !== null && selectionStart !== selectionEnd;
+
+    const digits = hasSelection ? '' : rawDigits.slice(0, -1);
+    setRawDigits(digits);
+    onChange(digitsToDraftValue(digits));
+  };
+
+  const handleFocus = () => {
+    setIsOpen(true);
+    setShowIncompleteHint(false);
+  };
+
+  const handleBlur = () => {
+    if (rawDigits.length > 0 && rawDigits.length < 8) {
+      setShowIncompleteHint(true);
+    }
+  };
+
+  const draftIsIncomplete = showIncompleteHint && rawDigits.length > 0 && rawDigits.length < 8;
+  const draftIsInvalidDate =
+    rawDigits.length === 8 &&
+    !isRealCalendarDate(
+      Number(rawDigits.slice(0, 4)),
+      Number(rawDigits.slice(4, 6)),
+      Number(rawDigits.slice(6, 8)),
+    );
+
+  let localError: string | undefined;
+  if (draftIsInvalidDate) {
+    localError = '올바른 날짜가 아닙니다.';
+  } else if (draftIsIncomplete) {
+    localError = '행사 날짜는 8자리 숫자(YYYYMMDD)로 입력해야 합니다.';
+  }
+
+  const displayedError = localError ?? error;
+  const selectedDate = parseIsoDate(value);
+
+  return (
+    <div ref={rootRef} className="relative flex flex-col gap-1">
+      <label htmlFor={id} className="text-xs font-normal leading-4 text-text-secondary">
+        {label}
+      </label>
+      <input
+        id={id}
+        type="text"
+        inputMode="numeric"
+        placeholder="행사 날짜를 입력하세요. (예: 20260902)"
+        value={formatDraft(rawDigits)}
+        onChange={handleRawInputChange}
+        onKeyDown={handleRawKeyDown}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+        role="combobox"
+        aria-haspopup="dialog"
+        aria-expanded={isOpen}
+        aria-controls={`${id}-calendar`}
+        aria-describedby={errorId}
+        className={`h-12 w-full rounded-lg border px-3.5 text-base font-normal leading-6 text-text-primary placeholder:text-text-disabled transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-darker ${
+          displayedError
+            ? 'border-negative-default'
+            : 'border-border-default focus:border-primary-darker'
+        }`}
+      />
+
+      {isOpen ? (
+        <div
+          id={`${id}-calendar`}
+          role="dialog"
+          aria-label={label}
+          className="absolute top-full z-10 mt-1 rounded-lg border border-border-default bg-background-default p-2 shadow-dialog"
+        >
+          <DayPicker
+            mode="single"
+            locale={ko}
+            selected={selectedDate}
+            onSelect={(date) => {
+              if (!date) return;
+              // rawDigits는 위 "값이 바뀌면 맞춘다" 렌더링 중 조정 로직이 알아서
+              // 새 value에 맞춰 갱신하므로, 여기서 직접 건드리지 않는다.
+              onChange(toIsoDate(date));
+              setIsOpen(false);
+            }}
+            classNames={{
+              months: 'flex',
+              month: 'flex flex-col gap-2',
+              month_caption:
+                'flex items-center justify-center h-9 text-sm font-medium text-text-primary',
+              nav: 'flex items-center justify-between absolute inset-x-1 top-0 h-9',
+              button_previous:
+                'flex h-7 w-7 items-center justify-center rounded hover:bg-background-muted',
+              button_next:
+                'flex h-7 w-7 items-center justify-center rounded hover:bg-background-muted',
+              weekdays: 'flex',
+              weekday: 'w-9 text-center text-xs font-normal text-text-secondary',
+              week: 'flex',
+              day: 'p-0 text-center',
+              day_button:
+                'flex h-9 w-9 items-center justify-center rounded-full text-sm text-text-primary hover:bg-background-muted',
+              selected: 'bg-primary-darker text-text-inverse hover:bg-primary-pressed',
+              today: 'font-semibold',
+              outside: 'text-text-disabled',
+              disabled: 'text-text-disabled',
+            }}
+          />
+        </div>
+      ) : null}
+
+      <p
+        id={errorId}
+        className={
+          displayedError ? 'text-xs font-normal leading-4 text-negative-darker' : 'sr-only'
+        }
+        role="alert"
+        aria-atomic="true"
+      >
+        {displayedError}
+      </p>
+    </div>
+  );
+};
+
+export default EventDateField;

--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { type ChangeEvent, type SubmitEvent, useState } from 'react';
 
+import EventDateField from '@/components/events/EventDateField';
 import SessionList from '@/components/events/SessionList';
 import rollbackEventDuplication from '@/components/events/rollbackEventDuplication';
 import ReportPanel from '@/components/report/ReportPanel';
@@ -225,6 +226,10 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
     setEventFormInputs((prev) => ({ ...prev, [name]: value }));
   };
 
+  const handleEventDateChange = (value: string) => {
+    setEventFormInputs((prev) => ({ ...prev, eventDate: value }));
+  };
+
   const handleFormSubmit = (event: SubmitEvent<HTMLFormElement>) => {
     event.preventDefault();
 
@@ -285,12 +290,10 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
           onChange={handleInputChange}
           error={eventFormErrors.title}
         />
-        <Field
+        <EventDateField
           label="행사 날짜"
-          name="eventDate"
-          type="date"
           value={eventFormInputs.eventDate}
-          onChange={handleInputChange}
+          onChange={handleEventDateChange}
           error={eventFormErrors.eventDate}
         />
         {isEditMode && eventQuery.data ? (

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "pdfjs-dist": "^6.2.108",
         "qrcode.react": "^4.2.0",
         "react": "19.2.4",
+        "react-day-picker": "^10.0.1",
         "react-dom": "19.2.4",
         "react-hook-form": "^7.84.0",
         "recharts": "^3.10.1",
@@ -301,6 +302,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@date-fns/tz": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@date-fns/tz/-/tz-1.5.0.tgz",
+      "integrity": "sha512-lwYN/vDPeNRULcepoE/LO2Pgx+7/RV+S9ARfbc9lr2DtGkOD7pAiruHvbR1RX3Qyf6ja47EWJDMsNK5vK08DJg==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -1451,9 +1458,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1473,9 +1477,6 @@
       "integrity": "sha512-yYkPbJDJiWj6N0gASA3CAvRypZmVpJnxU0DQg3aBhneLDQde9TPLKADsQkobNoJUtTT/lj46aWpzT48PDb3Qcg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1497,9 +1498,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1520,9 +1518,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1542,9 +1537,6 @@
       "integrity": "sha512-hb20MxKXXb5IB7AAwN8UHz9WRsa2HmdZfjsDCzjElwJoeV1aotVEwFU4FrFQcYQVzsJQLeaCc/2Qdt/0Q72mMg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4363,6 +4355,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.4.0.tgz",
+      "integrity": "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -8017,6 +8019,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-day-picker": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/react-day-picker/-/react-day-picker-10.0.1.tgz",
+      "integrity": "sha512-eNh6BlwcYInWaJtRv18mXQ06Ys/H6rdTZAnTaSdOYJuTpwP1JMCHNd1FDRadA+gbeinq+psdULN5Xnowy9mV8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@date-fns/tz": "^1.4.1",
+        "date-fns": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/gpbl"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pdfjs-dist": "^6.2.108",
     "qrcode.react": "^4.2.0",
     "react": "19.2.4",
+    "react-day-picker": "^10.0.1",
     "react-dom": "19.2.4",
     "react-hook-form": "^7.84.0",
     "recharts": "^3.10.1",


### PR DESCRIPTION
## 변경 사항

행사 날짜 입력(`components/events/EventForm.tsx`)을 네이티브 `<input type="date">`에서 `react-day-picker` 기반 컴포넌트(`components/events/EventDateField.tsx`, 새 파일)로 교체했습니다.

새 의존성 도입이 이 저장소의 "당장 shadcn/ui 같은 외부 컴포넌트 라이브러리는 쓰지 않는다"는 방침과 충돌하지 않는지 검토가 필요합니다.  
아래 "새 의존성을 이렇게 판단하고 들여왔습니다." 섹션에 판단 근거를 적어뒀습니다.

### AS-IS: 네이티브 date input의 연도 자리가 4자리를 넘겨도 계속 숫자를 받았습니다.

Chromium 자체의 알려진 버그입니다.  
Chromium 이슈 트래커에 "input date 'year' must be up to 4-digit"라는 제목으로 등록되어 있습니다(https://issues.chromium.org/issues/41235379).

이 버그 때문에 연도 자리에 숫자를 계속 입력하면 `202609`처럼 화면에 깨진 연도가 표시됐습니다.  
실제로 서버에 잘못된 값이 저장되지는 않았습니다.  
`lib/schemas/api.ts`의 `calendarDate` 스키마가 정확히 4자리 연도만 통과시키는 정규식이라, 등록 자체는 이미 안전하게 막혀 있었습니다.  
그래도 화면에 깨진 값이 보이는 것 자체가 문제였습니다.

### TO-BE: 캘린더에서 클릭하거나 숫자 8자리를 타이핑해서 입력합니다.

`EventDateField`를 클릭하면 캘린더 팝오버가 뜨고, 날짜를 클릭해서 고를 수 있습니다.  
숫자 8자리(`YYYYMMDD`, 예: `20260902`)를 그대로 타이핑해도 됩니다.  
자릿수를 코드가 직접 세고 4자리에서 자르기 때문에, 원래 버그가 이 구조에서는 재발할 수 없습니다.

### 같은 화면에서 별도 문제 두 개를 추가로 발견해서 함께 고쳤습니다.

- **백스페이스가 반응하지 않았습니다.**  
  화면에 보이는 값은 `2026. 09. 02.`처럼 이 컴포넌트가 만든 마스크 문자열입니다.  
  커서 바로 앞 글자가 숫자가 아니라 마침표일 때가 있는데, 그 상태로 브라우저 기본 백스페이스에 맡기면 마침표만 지워지고 숫자 개수는 그대로라 화면이 안 바뀐 것처럼 보이는 문제가 있었습니다.  
  Backspace·Delete 키를 직접 가로채서, 커서 위치와 무관하게 항상 마지막 숫자 하나를 지우도록 고쳤습니다.
- **8자리를 못 채운 채 저장하면 조용히 예전 날짜로 저장됐습니다.**  
  예를 들어 5월 1일로 바꾸려고 `202651`(6자리)만 입력하고 저장을 누르면, 화면은 아무 설명 없이 예전 날짜로 되돌아가고 실제로는 그 예전 날짜가 그대로 저장되는 문제가 있었습니다.  
  타이핑되는 값을 항상 부모(`EventForm`)의 상태에 그대로 반영하도록 바꿔서, 8자리를 못 채운 채 저장을 시도해도 이미 있는 `calendarDate` 스키마 검증이 이 상태를 잡아 저장을 막습니다.  
  8자리를 못 채운 채 필드를 벗어나면 "행사 날짜는 8자리 숫자(YYYYMMDD)로 입력해야 합니다."라는 안내도 즉시 뜹니다.

## 관련 이슈

- Closes #312

## 검증 방법

`npm run test`(230개 전체 통과), `npm run lint`(이 PR과 무관한 기존 경고 1개만 남음), `npm run build`(정상 완료)를 모두 실행했습니다.

아래 시나리오는 전부 브라우저로 직접 재현해서 확인했습니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- **행사 날짜 필드를 클릭하면** 한글 요일·월 표기의 캘린더 팝오버가 뜹니다.
- **캘린더에서 날짜를 클릭하면** 필드에 `2026. 09. 15.`처럼 표시되고 팝오버가 닫힙니다.  
  필드를 다시 열면 방금 고른 날짜가 파란 배경으로 하이라이트됩니다.
- **숫자 8자리(`20260902`)를 타이핑하면** 같은 형식으로 표시되고 캘린더도 해당 날짜를 하이라이트합니다.
- **백스페이스를 누르면** 마지막 숫자 하나씩 정확히 지워지고, 전부 지우면 플레이스홀더가 다시 보입니다.
- **8자리를 정확히 채운 뒤 등록·저장을 누르면** 정상 등록·저장되고, 목록·수정 화면 양쪽에서 왕복해도 날짜가 그대로입니다(타임존에 따른 하루 밀림 없음).

### 실패(차단)하는 경우 (이 PR을 반영한 뒤 기준)

- **숫자를 8자리 못 채운 채(예: `202651`) 필드를 벗어나면** 값이 사라지지 않고 그대로 남은 채 "행사 날짜는 8자리 숫자(YYYYMMDD)로 입력해야 합니다." 에러가 뜹니다.
- **그 상태로 저장을 누르면** 페이지 이동 없이 그대로 남고, 새로고침해도 서버 값은 바뀌지 않습니다.  
  예전 날짜가 조용히 저장되던 문제가 재현되지 않습니다.
- **존재하지 않는 날짜(8자리이지만 13월·32일 등)를 입력하면** "올바른 날짜가 아닙니다." 에러가 뜹니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: `react-day-picker`(캘린더 팝오버). pull 받은 뒤 `npm install`을 실행해야 합니다.
- Breaking Change: 없음. `EventForm`의 외부 props는 바뀌지 않았습니다.

## 트러블슈팅 및 참고 사항

### 처음엔 라이브러리 없이 값만 보정하는 방식을 먼저 시도했다가 되돌렸습니다.

네이티브 date input의 `.value`를 JS로 강제로 되돌리는 방식을 먼저 시도했습니다.  
최초 1회 발생한 연도 오버플로우는 이 방식으로 막을 수 있었습니다.  
하지만 보정된 값 위에서 연도 자리를 다시 클릭해 이어서 타이핑하면, `0002`처럼 사용자가 입력하지 않은 전혀 다른 값으로 틀어지는 새 문제가 발생했습니다.  
네이티브 date input은 세그먼트(연·월·일 각 칸) 단위 내부 상태를 JS로 직접 제어할 수 있는 공개 API가 없어서, 이 방식으로는 문제를 안정적으로 고칠 수 없다고 판단해 캘린더 라이브러리로 방향을 바꿨습니다.

### 새 의존성을 이렇게 판단하고 들여왔습니다.

`react-day-picker`는 헤드리스 방식으로 동작해서, 자체 스타일을 강제하지 않고 `classNames` prop으로 이 프로젝트의 Tailwind 디자인 토큰을 그대로 입힐 수 있습니다.  
날짜 계산·키보드 접근성·달력 렌더링만 라이브러리에 맡기고 겉모습은 직접 구현했다는 점에서, 이미 들여와 있는 `recharts`(차트)·`qrcode.react`(QR 코드)와 같은 좁은 목적의 라이브러리로 판단했습니다.  
shadcn/ui처럼 버튼·입력창 등 컴포넌트 전체를 제공하는 디자인 시스템과는 성격이 다르다고 봤습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그 표는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
