### PR TITLE
fix(report): 머지 중 사라진 리포트 화면 헤더를 되살린다

### DIFF
--- a/app/e/[code]/report/page.tsx
+++ b/app/e/[code]/report/page.tsx
@@ -5,6 +5,7 @@ import { EmptyState } from '@/components/ui/EmptyState';
 import { Stat } from '@/components/ui/Stat';
 import { fetchEventByCode, fetchPublicReport, fetchSessionsByEventCode } from '@/lib/api/endpoints';
 import { ApiError } from '@/lib/apiClient';
+import { EventHeader } from '@/components/layout/EventHeader';
 
 interface ReportPageProps {
   params: Promise<{ code: string }>;
@@ -57,12 +58,15 @@ const ReportPage = async ({ params }: ReportPageProps) => {
 
   if (report === null) {
     return (
-      <main className={PAGE}>
-        <EmptyState
-          title="공개된 리포트가 없어요"
-          description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
-        />
-      </main>
+      <>
+        <EventHeader eventCode={code} title="리포트" />
+        <main className={PAGE}>
+          <EmptyState
+            title="공개된 리포트가 없어요"
+            description="주최자가 공개하면 이 페이지에서 볼 수 있어요"
+          />
+        </main>
+      </>
     );
   }
 
@@ -87,67 +91,72 @@ const ReportPage = async ({ params }: ReportPageProps) => {
   const positiveRate = toRates(counts).positive;
 
   return (
-    <main className={PAGE}>
-      <header className="flex flex-col gap-1">
-        {/*
-          행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
-          일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
+    <>
+      <EventHeader eventCode={code} title="리포트" />
+      <main className={PAGE}>
+        <header className="flex flex-col gap-1">
+          {/*
+            행사 날짜(`eventDate`)입니다. `createdAt`은 주최자가 이벤트를 등록한 시각이라,
+            일주일 전에 만들어뒀으면 참가자에게 엉뚱한 날짜가 보입니다.
 
-          소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
-        */}
-        <p className="text-xs leading-4 text-text-tertiary">
-          <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
-          {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
-        </p>
-        <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
-      </header>
-      <div className="grid grid-cols-3 gap-3">
-        <Stat label="총 소감" value={`${submissionCount}`} />
-        <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
-        <Stat label="세션" value={`${sessions.length}`} />
-      </div>
+            소감 수는 날짜가 아니므로 `time` 바깥에 둡니다. 문구는 LiveResult의 같은 줄과 맞췄습니다.
+          */}
+          <p className="text-xs leading-4 text-text-tertiary">
+            <time dateTime={event.eventDate}>{formatDate(event.eventDate)}</time> · 소감{' '}
+            {submissionCount}개{unclassifiedCount > 0 && ` (미분류 ${unclassifiedCount}개)`}
+          </p>
 
-      <section className={CARD}>
-        <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
-        <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
-      </section>
+          <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
+        </header>
 
-      <section className={`${CARD} items-center`}>
-        {/*
-          분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
-          총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
-        */}
-        <h2 className="self-start text-xs leading-4 text-text-tertiary">
-          감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
-        </h2>
-        {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
-        <Donut {...counts} className="py-2" />
-      </section>
+        <div className="grid grid-cols-3 gap-3">
+          <Stat label="총 소감" value={`${submissionCount}`} />
+          <Stat label="긍정 비율" value={`${positiveRate}%`} tone="positive" />
+          <Stat label="세션" value={`${sessions.length}`} />
+        </div>
 
-      <section className="flex flex-col gap-3">
-        <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
-        {/*
-          생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
-          이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
-        */}
-        {topKeywords.length === 0 ? (
-          <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
-        ) : (
-          /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
-          <ul className="flex flex-wrap gap-2">
-            {topKeywords.map(({ keyword, count }) => (
-              <li
-                key={keyword}
-                className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
-              >
-                {keyword}
-                <span className="text-text-tertiary">{count}</span>
-              </li>
-            ))}
-          </ul>
-        )}
-      </section>
-    </main>
+        <section className={CARD}>
+          <h2 className="text-xs leading-4 text-text-tertiary">AI 요약</h2>
+          <p className="whitespace-pre-line text-sm leading-6 text-text-primary">{summaryText}</p>
+        </section>
+
+        <section className={`${CARD} items-center`}>
+          {/*
+            분모가 헤더의 총 소감보다 작다는 걸 밝힙니다. 이 단서가 없으면 도넛 범례의 합(100%)과
+            총 소감 수가 어긋나 보입니다. 미분류가 0이면 뺄 것이 없어 붙이지 않습니다.
+          */}
+          <h2 className="self-start text-xs leading-4 text-text-tertiary">
+            감정 분포{unclassifiedCount > 0 && ' · 미분류 제외'}
+          </h2>
+          {/* API는 POS/NEU/NEG, Donut은 positive/neutral/negative라 여기서 이름만 맞춰 넘깁니다. */}
+          <Donut {...counts} className="py-2" />
+        </section>
+
+        <section className="flex flex-col gap-3">
+          <h2 className="text-xs leading-4 text-text-tertiary">주요 키워드</h2>
+          {/*
+            생성이 끝난 리포트라도 소감이 적으면 뽑힐 키워드가 없을 수 있습니다(publicReportSchema).
+            이때 제목만 남지 않도록 라이브 화면과 같은 문구를 보여줍니다.
+          */}
+          {topKeywords.length === 0 ? (
+            <p className="text-sm leading-5 text-text-tertiary">아직 모인 키워드가 없어요</p>
+          ) : (
+            /* Chip은 button + aria-pressed라 읽기 전용 목록에는 쓰지 않습니다(토글로 읽힙니다). */
+            <ul className="flex flex-wrap gap-2">
+              {topKeywords.map(({ keyword, count }) => (
+                <li
+                  key={keyword}
+                  className="inline-flex h-8 items-center gap-1.5 rounded-full border border-border-default bg-background-default px-3.5 text-sm leading-5 text-text-secondary"
+                >
+                  {keyword}
+                  <span className="text-text-tertiary">{count}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+      </main>
+    </>
   );
 };
 


### PR DESCRIPTION
## 변경 사항

`/e/{code}/report`에 **헤더가 없었습니다.** `#309`에서 붙인 `EventHeader`가 `#311`이 머지되면서 지워졌습니다.

`app/e/[code]/report/page.tsx` 한 파일입니다.

## 확인

```
$ git show 45c6a31:app/e/[code]/report/page.tsx | grep -n EventHeader
8:import { EventHeader } from '@/components/layout/EventHeader';
62:  <EventHeader eventCode={code} title="리포트" />
95:  <EventHeader eventCode={code} title="리포트" />

$ git show 02050f8:app/e/[code]/report/page.tsx | grep -n EventHeader
(없음)
```

- `45c6a31` — `#309` 머지 직후
- `02050f8` — `#311` 머지 직후 (직전 `dev`)

## 원인

`#310` 브랜치는 `#309` **이전**의 `dev`에서 갈라져 나왔습니다. `#309`가 `return`을 조각(`<>`)으로 감싸면서 **JSX 전체 들여쓰기를 바꿨기** 때문에, 리베이스 때 같은 파일에서 충돌 덩어리가 여러 개 났습니다.

`h1` 줄만 보고 나머지를 브랜치 쪽(= `#309` 이전)으로 남기면서 `EventHeader` 임포트와 사용 두 곳이 같이 지워졌습니다.

**`h1` 크기 통일(`#310`)은 정상 반영돼 있었습니다.** 헤더만 없어졌습니다.

## 해결

되돌리지(`revert`) 않았습니다. `#310`의 변경은 살려야 하기 때문입니다.

`#309` 버전 파일을 통째로 가져온 뒤 `h1` 한 줄만 `#310` 내용으로 다시 고쳤습니다. 충돌을 다시 푸는 것보다 안전합니다.

```powershell
git checkout 45c6a31 -- "app/e/[code]/report/page.tsx"
```

```diff
- <h1 className="text-2xl font-semibold leading-8">{event.title}</h1>
+ <h1 className="text-xl font-semibold leading-7 text-text-primary">{event.title}</h1>
```

## 피해 범위

이 파일 하나였습니다. 나머지 네 화면은 정상입니다.

| 화면 | `EventHeader` |
|---|---|
| `/e/[code]` | ✅ |
| `/e/[code]/game` | ✅ |
| `/e/[code]/live` | ✅ |
| `not-found` | ✅ |
| **`/e/[code]/report`** | **복구** |

## 검증 방법

```
npm run lint    통과 (DashboardView 경고 1건은 이 PR과 무관)
npm run build   ✓ Compiled successfully / ✓ Finished TypeScript
npm run test    ✓ 15 files, 230 tests passed
```

`EventHeader`를 리포트가 있을 때와 없을 때 각각 부르고 있어서 **두 상태를 다 확인**했습니다.

| 화면 | 결과 |
|---|---|
| `/e/kd7m2p/report` (리포트 있음) | `← 리포트` 표시 |
| `/e/ab3f9x/report` (리포트 없음) | `← 리포트` 표시 |

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `#309`가 원래 의도한 상태로 되돌리는 것이라 새로운 동작은 없습니다
- `#310`의 제목 크기 변경은 그대로 유지됩니다

## 관련 이슈

- Closes #318

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
