### PR TITLE
chore(deps): npm audit fix로 취약점 3건을 없앤다

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2903,9 +2903,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3799,9 +3799,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6404,9 +6404,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -7310,9 +7310,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## 변경 사항

Dependabot이 PR마다 알려주던 경고를 확인하고, 안전하게 고칠 수 있는 것만 반영했습니다.

**`package-lock.json` 한 파일, 12줄**입니다. `package.json`은 안 바뀝니다.

```
9 high → 6 high
```

## 없앤 것 (3건)

| 패키지 | 내용 |
|---|---|
| `brace-expansion` | 무한 확장으로 인한 메모리 고갈 (DoS) |
| `js-yaml` | `!!omap` 처리에서 CPU 2차 소모 |
| `nanoid` | size가 0일 때 무한 루프 |

셋 다 직접 설치한 게 아니라 다른 패키지가 끌고 오는 것들이라, **잠금 파일에서만 버전이 올라갑니다.**

## `--force`를 쓰지 않은 이유

`postcss`를 고치려면 `npm`이 이렇게 알려줍니다.

```
Will install next@16.3.4, which is outside the stated dependency range
```

**발표 5일 전에 프레임워크 마이너 버전을 올리는 건 위험합니다.** Next 16.2.12를 그대로 둡니다.

## 남은 6건은 브라우저 번들에 안 들어갑니다

| 패키지 | 경로 | 왜 안 걸리나 |
|---|---|---|
| `adm-zip` | ← `onnxruntime-node` ← `@huggingface/transformers` | **브라우저는 `onnxruntime-web`을 씁니다.** `-node`는 서버용이라 참가자 번들에 안 들어갑니다 |
| `sharp` | ← `next` | 이미지 최적화용. 빌드·서버에서만 돕니다 |
| `postcss` | ← `next` | CSS 빌드 도구. 사용자 브라우저에서 안 돕니다 |

`@huggingface/transformers`가 `onnxruntime-node`와 `onnxruntime-web`을 **둘 다 의존성으로 가집니다.**

```json
"dependencies": {
  "onnxruntime-node": "1.24.3",
  "onnxruntime-web": "1.26.0-dev...",
  "sharp": "^0.34.5"
}
```

설치는 되지만 브라우저에서는 `-web`만 로드됩니다. 감정 태깅은 Web Worker에서 `-web` 경로로만 돌아갑니다.

## 검증 방법

```
npm audit        9 high → 6 high
npm run build    ✓ Compiled successfully (Next.js 16.2.12 유지)
npm run test     ✓ 14 files, 223 tests passed
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- `package.json` 변경 없음 — 잠금 파일만 갱신됩니다
- **Next 버전은 16.2.12 그대로**입니다
- 팀원은 `git pull` 후 `npm install` 한 번 돌리면 됩니다

## 참고

남은 6건은 발표 이후에 Next 업그레이드와 함께 보는 게 맞아 보입니다. `adm-zip`과 `sharp`는 지금 시점에 **수정본 자체가 없습니다**(`No fix available`).

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
