### PR TITLE
fix(build): prepare 스크립트가 Windows에서 실패한다

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "tagger:eval": "node scripts/tagger-eval.mjs",
-    "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
+    "prepare": "git config core.hooksPath .githooks || exit 0"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.7.1",


### PR DESCRIPTION
## 변경 사항

Windows에서 `npm install`이 항상 에러로 끝나는 문제를 고칩니다. `package.json` 한 줄입니다.

```diff
- "prepare": "git config core.hooksPath .githooks 2>/dev/null || true"
+ "prepare": "git config core.hooksPath .githooks || exit 0"
```

## 문제

```
> pulse-frontend@0.1.0 prepare
> git config core.hooksPath .githooks 2>/dev/null || true

지정된 경로를 찾을 수 없습니다.
'true'은(는) 내부 또는 외부 명령, 실행할 수 있는 프로그램, 또는
배치 파일이 아닙니다.
npm error code 1
```

`2>/dev/null`과 `true`는 **리눅스·맥 문법**입니다. npm이 Windows에서 `cmd.exe /d /s /c`로 스크립트를 돌리기 때문에 둘 다 실패하고, **에러를 무시하려고 넣은 `|| true` 자체가 에러를 냅니다.**

## 왜 지금 고치나

설치 자체는 성공합니다. `prepare`는 설치가 끝난 뒤 도는 훅이라 패키지는 이미 다 들어와 있습니다. 문제는 그다음입니다.

- **Windows 팀원은 `npm install`마다 빨간 에러**를 봅니다. 진짜 실패와 구분이 안 됩니다
- **CI에서 `npm ci`가 같은 이유로 멈춥니다**
- **`core.hooksPath`가 안 잡혀서 커밋 훅이 안 도는 사람이 생깁니다.** 커밋 메시지 검사(`.githooks/commit-msg`)와 `lint-staged`가 조용히 빠진 채로 작업하게 됩니다

세 번째가 제일 큽니다. 훅이 빠져도 아무 표시가 안 나서, 컨벤션에 안 맞는 커밋이 그대로 올라갑니다.

## `|| exit 0`인 이유

`||`와 `exit 0`은 **cmd · PowerShell · sh 모두에서** 동작합니다. `git config`가 실패해도(저장소가 아닌 곳에서 설치하는 경우 등) 0으로 끝나서 설치를 막지 않습니다. **원래 의도는 그대로입니다.**

## 검증 방법

```
npm install     에러 없이 종료 (Windows / PowerShell)
git config core.hooksPath
  → .githooks
```

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음
- **이미 훅이 잡혀 있는 사람은 동작 변화가 없습니다.** 새로 클론하는 사람에게 영향이 있습니다
- 리눅스·맥에서도 동일하게 동작합니다

## 관련 이슈

- Closes #322

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.
