### PR TITLE
fix(event): 행사 날짜 캘린더의 날짜가 실제 요일과 다른 칸에 표시되는 버그 수정

### DIFF
--- a/components/events/EventDateField.tsx
+++ b/components/events/EventDateField.tsx
@@ -221,10 +221,11 @@ const EventDateField = ({ label, value, onChange, error }: EventDateFieldProps) 
               weekdays: 'flex',
               weekday: 'w-9 text-center text-xs font-normal text-text-secondary',
               week: 'flex',
-              day: 'p-0 text-center',
+              day: 'w-9 p-0 text-center data-[outside=true]:bg-transparent',
               day_button:
                 'flex h-9 w-9 items-center justify-center rounded-full text-sm text-text-primary hover:bg-background-muted',
-              selected: 'bg-primary-darker text-text-inverse hover:bg-primary-pressed',
+              selected:
+                'bg-primary-darker text-text-inverse hover:bg-primary-pressed [&_button]:text-text-inverse',
               today: 'font-semibold',
               outside: 'text-text-disabled',
               disabled: 'text-text-disabled',


### PR DESCRIPTION
## 변경 사항

행사 등록/수정 화면의 행사 날짜 캘린더에서, 날짜가 실제 요일과 다른 칸에 표시되던 문제를 고쳤습니다.
같은 컴포넌트를 고치는 과정에서 서로 다른 원인 세 가지가 겹쳐 있는 게 드러나서, 원인별로 나눠 정리합니다.

### 이전/다음 달에 속한 빈 칸에 폭이 없어서, 실제 날짜 전체가 요일 칸과 어긋나 보였습니다

AS-IS: `EventDateField.tsx`는 한 주(`week`)와 요일 헤더(`weekdays`)를 flex 레이아웃으로 그리는데, 각 날짜 칸(`day`)에는 폭이 지정되어 있지 않았습니다.
설치된 `react-day-picker`(버전 10.0.1) 소스코드를 확인한 결과, 이전/다음 달에 속한 칸은 내용 없이 빈 `<td>`로만 렌더링됩니다.
내용도 없고 지정된 폭도 없는 그 빈 칸은 flex 레이아웃에서 폭을 거의 확보하지 못해, 실제 날짜들이 그 주의 맨 앞 칸부터 순서대로 채워지면서 요일 헤더와 어긋났습니다.

TO-BE: `day` 클래스에 요일 헤더와 같은 폭(`w-9`)을 지정해서, 빈 칸도 항상 제 몫의 폭을 차지하도록 고쳤습니다.
그 결과 실제 날짜는 항상 정확한 요일 칸에 표시됩니다.

### 선택한 날짜가 있는 달을 벗어나면, 그 날짜 자리의 빈 칸에 선택 배경색만 남아있었습니다

AS-IS: `react-day-picker`는 "선택됨" 여부를 그 칸이 화면에 보이는지와 무관하게 실제 날짜 값만으로 판단하고, 그 판단 결과의 배경·글자색 클래스를 빈 칸(`<td>`)에도 그대로 적용합니다.
그래서 예를 들어 8월 1일을 선택해두고 7월로 이동하면, 7월 마지막 주에서 8월 1일 자리에 해당하는 빈 칸에 숫자 없이 선택 배경색만 칠해져 있었습니다.

TO-BE: `react-day-picker`가 이전/다음 달 칸에 항상 붙여주는 `data-outside="true"` 속성을 이용해서, `data-[outside=true]:bg-transparent`로 그 칸의 배경색만 무력화했습니다.

### 선택된 날짜의 글자색이 배경과 잘 구별되지 않았습니다

AS-IS: 선택 시 흰색 글자색(`text-text-inverse`)은 날짜 칸(`<td>`)에만 적용되는데, 실제 숫자를 담은 버튼(`day_button`)에는 이미 어두운 기본 글자색(`text-text-primary`)이 고정으로 지정되어 있어서 부모의 흰색을 상속받지 못했습니다.
그래서 배경은 진한 색으로 바뀌어도 숫자는 계속 어두운 색으로 남아 대비가 약했습니다.

TO-BE: `[&_button]:text-text-inverse`로 선택된 칸 안의 버튼에도 흰색 글자색을 직접 지정해서, 배경과 글자색의 대비가 항상 확보되도록 고쳤습니다.

## 관련 이슈

- Closes #327

## 검증 방법

**`npx tsc --noEmit`·`npm run lint`·`npm run test`를 실행했고, 모두 통과했습니다.**
`npm run test`는 기존 테스트 14개 파일·223개 케이스 전부를 포함합니다.
`npm run lint`에는 이번 변경과 무관한 기존 경고(`components/dashboard/DashboardView.tsx`) 하나만 남아 있고 에러는 없습니다.

브라우저로 아래 절차를 직접 확인했습니다.

1. 2026년 8월 캘린더를 열어 1일이 토요일 칸에, 2026년 7월 캘린더를 열어 1일이 수요일 칸에 정확히 표시되는지 확인했습니다.
2. 8월 1일을 선택한 뒤 7월로 이동해서, 7월 마지막 주의 빈 칸(8월 1일 자리)에 배경색이 남지 않는지 확인했습니다.
3. 9월 1일을 선택했을 때, 배경(틸 블루)과 글자색(흰색)의 대비가 잘 보이는지 확인했습니다.

수정 전/후 화면 스크린샷을 아래에 첨부합니다.

**- 수정 전 (요일 정렬이 어긋난 상태):**
> <img width="283" height="265" alt="shot-mtqgv2uo" src="https://github.com/user-attachments/assets/b7059278-e74e-4662-a762-24e395ecc596" />

**- 수정 후 (요일 정렬·배경색·글자색이 모두 고쳐진 상태):**
> <img width="279" height="263" alt="shot-mtqial32" src="https://github.com/user-attachments/assets/0996cbbe-8486-4bb5-a4eb-8cefba3bbfbd" />

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

### `react-day-picker`의 모디파이어 스타일은 날짜 칸(`<td>`)에만 적용되고, 실제 버튼에는 전달되지 않습니다

`selected`·`today`·`outside` 같은 상태별 스타일은 전부 날짜 칸에만 적용되는 구조라, 버튼 자체에 스타일이 필요하면 이번 PR의 `[&_button]:` 처럼 자식 선택자로 직접 지정해야 합니다.
이 구조를 모르면 "왜 배경색은 바뀌는데 글자색은 안 바뀌지?"처럼 같은 종류의 리뷰 코멘트가 다시 나올 수 있어서 남겨둡니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 해당 없음)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

