### PR TITLE
fix(auth): 로그아웃 시 쿼리 캐시 전체를 초기화한다

### DIFF
--- a/hooks/useAuth.ts
+++ b/hooks/useAuth.ts
@@ -65,6 +65,8 @@ export function useAuth(): UseAuthReturn {
       await queryClient.cancelQueries({ queryKey: ['auth', 'me'] });
     },
     onSuccess: () => {
+      // 다음 로그인 사용자에게 이전 사용자의 캐시된 데이터(예: myEvents)가 노출되지 않도록 전체 초기화합니다.
+      queryClient.clear();
       queryClient.setQueryData(['auth', 'me'], null);
     },
     onSettled: () => {


### PR DESCRIPTION
## 변경 사항

**로그아웃 성공 시 서버 상태 캐싱 라이브러리인 TanStack Query의 쿼리 캐시 전체를 초기화하도록 수정했습니다.**  
이렇게 결정한 이유는 로그인한 사용자를 구분하지 않는 캐시 키(`['myEvents']`)와, 로그아웃 시점에 그 캐시를 정리하지 않는 처리가 겹쳐 있었기 때문입니다.  
그 결과 이슈 #324 에서 확인된 것처럼, 로그아웃 후 다른 계정으로 재로그인하면 이전 계정의 이벤트 목록이 그대로 보이는 문제가 있었습니다.

- **`hooks/useAuth.ts`** (useAuth 훅, 로그인·회원가입·로그아웃 뮤테이션을 모아둔 파일)의 `logoutMutation`
  - AS-IS: 지금까지는 로그아웃 성공 시 `['auth', 'me']` 쿼리만 `null`로 갱신하고, `['myEvents']` 같은 다른 캐시는 그대로 남겨뒀습니다.
  - TO-BE: 로그아웃 성공 시 `queryClient.clear()`를 먼저 호출해 캐시 전체를 비운 뒤, `['auth', 'me']`를 다시 채우도록 바꿨습니다.  
    사용자별로 갈리는 쿼리가 지금은 `myEvents` 하나뿐이지만, 로그아웃이라는 시점 자체가 이전 사용자 데이터를 지우는 경계이므로 특정 키만 좁혀서 무효화하는 대신 전체를 비우기로 했습니다.

## 관련 이슈

- Closes #324

## 검증 방법

- `npx tsc --noEmit`을 실행했고 타입 에러가 없었습니다.
- `npm run lint`를 실행했습니다. `DashboardView.tsx`의 기존 `useEffect` 의존성 경고 1건만 남았고, 이번 변경과는 무관한 기존 코드입니다.

### 정상적으로 동작하는 경우 (이 PR을 반영한 뒤 기준)

- hancom@example.com 계정으로 로그인해서 이벤트 목록 화면(`/events`)에 접속하면 hancom 계정의 이벤트 목록이 보입니다.
- 로그아웃한 뒤 pulse@example.com 계정으로 로그인해서 이벤트 목록 화면에 접속하면, 새로고침 없이도 곧바로 pulse 계정의 이벤트 목록이 보입니다.

### 실패하던 경우 (이 PR을 반영하기 전 기준)

- 로그아웃 후 다른 계정으로 재로그인해서 이벤트 목록 화면에 접속하면, 새 계정이 아니라 이전 계정의 이벤트 목록 캐시가 그대로 렌더링됐습니다.  
  새로고침하면 정상적으로 갱신됐습니다.

## 영향 범위

- 새 환경 변수: 없습니다.
- 의존성 추가: 없습니다.
- Breaking Change: 없습니다.

## 트러블슈팅 및 참고 사항

### 로그아웃 시 캐시가 비워지는 순간에도 화면에 로딩 상태가 노출되지 않습니다

`components/layout/HostHeader.tsx`(주최자 화면 공통 헤더)의 `handleLogout`은 `await logout()`으로 로그아웃 뮤테이션이 끝나기를 기다린 뒤에야 `router.push('/login')`을 호출합니다.  
`useAuth.ts`의 `logout`은 `logoutMutation.mutateAsync()`를 `await`합니다.  
그래서 `queryClient.clear()`를 포함한 `onSuccess`·`onSettled` 콜백이 모두 끝난 뒤에 `router.push('/login')`이 실행됩니다.  
캐시가 비워지는 시점에는 이미 로그인 화면으로 이동한 뒤이므로, 이벤트 목록 등 다른 화면이 캐시가 사라진 채로 잠깐 보이는 현상은 없습니다.

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다. (여러 목적이면 PR을 나누세요)
- [x] 커밋이 2개 이상이면 개발 과정 로그에 커밋 단위로 기록했습니다. (커밋 1개라 개발 과정 로그 표는 생략했습니다)
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다. (체크박스가 아니라 위 내용 확인)
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014avJvytkEw1fnwawKnbBsz
