### PR TITLE
feat(event): 이벤트 폼 필드 재입력 시 유효성 에러를 즉시 지운다

### DIFF
--- a/components/events/EventForm.tsx
+++ b/components/events/EventForm.tsx
@@ -231,10 +231,12 @@ const EventForm = ({ eventCode, duplicateFrom }: EventFormProps) => {
   const handleInputChange = (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
     setEventFormInputs((prev) => ({ ...prev, [name]: value }));
+    setEventFormErrors((prev) => ({ ...prev, [name]: undefined }));
   };
 
   const handleEventDateChange = (value: string) => {
     setEventFormInputs((prev) => ({ ...prev, eventDate: value }));
+    setEventFormErrors((prev) => ({ ...prev, eventDate: undefined }));
   };
 
   const handleFormSubmit = (event: SubmitEvent<HTMLFormElement>) => {


### PR DESCRIPTION
## 변경 사항

이벤트 생성/수정 폼(`EventForm.tsx`)에서 유효성 검사 에러가 뜬 필드를 다시 입력하면, 그 필드의 에러가 즉시 사라지도록 고쳤습니다.

- **`handleInputChange`(`EventForm.tsx:231`)** 는 제목·설명 필드의 값을 갱신합니다.
  - AS-IS: 지금은 입력값만 `eventFormInputs`에 반영하고, 에러 상태(`eventFormErrors`)는 그대로 둡니다.
  - TO-BE: 값이 바뀌는 시점에 그 필드의 에러도 함께 `undefined`로 지웁니다.
- **`handleEventDateChange`(`EventForm.tsx:236`)** 는 행사 날짜 필드의 값을 갱신합니다.
  - AS-IS: 지금은 값만 갱신하고, `eventFormErrors.eventDate`는 그대로 둡니다.
  - TO-BE: 값이 바뀌는 시점에 `eventFormErrors.eventDate`도 함께 지웁니다.

이미 구현되어 있는 `SignupForm.tsx`의 `handleChange`(63-75행)를 그대로 따랐습니다.
같은 문제를 회원가입·로그인 폼에서 먼저 고친 이슈 #185 에서 정한 패턴이며, 이번에는 대상만 이벤트 폼으로 넓힌 것입니다.
재검증은 추가하지 않았습니다.
에러만 지우고, 다음 제출 시점에 `handleFormSubmit`(`EventForm.tsx:251`)이 다시 검증합니다.

## 관련 이슈

- Closes #315

## 검증 방법

- `npx tsc --noEmit` 실행 결과 에러가 없습니다.
- `npm run lint` 실행 결과 이번 변경과 무관한 기존 경고(`DashboardView.tsx:171`) 1건 외에는 없습니다.

아래 시나리오는 모두 이 PR을 반영한 뒤 기준으로 브라우저에서 직접 눌러 확인한 것입니다.

### 제목 필드는 값이 바뀌는 순간 에러가 사라집니다 (이 PR을 반영한 뒤 기준)

이벤트 등록 화면(`/events/new`)에서 제목 필드에 글자 1개만 입력한 채 등록 버튼을 누르면 "제목은 2자 이상이어야 합니다." 에러 문구와 빨간 테두리가 뜹니다.
이 상태에서 제목 필드에 글자를 하나 더 입력하면, 그 즉시 에러 문구와 빨간 테두리가 사라지는 것을 확인했습니다.

### 행사 날짜 필드는 캘린더 선택·직접 타이핑 둘 다로 에러가 사라집니다 (이 PR을 반영한 뒤 기준)

제목·행사 날짜를 모두 비운 채 등록 버튼을 누르면 행사 날짜 필드에 "행사 날짜를 선택해 주세요." 에러 문구가 뜹니다.
이 상태에서 달력을 열어 날짜를 클릭하면 에러 문구가 즉시 사라지는 것을 확인했습니다.
같은 상태를 다시 만든 뒤, 이번에는 달력 대신 숫자 8자리(예: 20260920)를 직접 타이핑해도 8자리를 다 채우는 순간 에러 문구가 즉시 사라지는 것을 확인했습니다.

### 재검증 없이 에러 표시만 지웁니다 (이 PR을 반영한 뒤 기준)

값을 다시 입력하는 시점에는 그 값이 실제로 유효한지 다시 검사하지 않고 에러 표시만 지웁니다.
그래서 여전히 유효하지 않은 값(예: 1자짜리 제목)이어도 에러 문구는 일단 사라지고, 다시 등록 버튼을 눌러야 그 시점에 `handleFormSubmit`이 재검증해서 에러를 다시 띄웁니다.
이슈 #185 에서 정한 것과 같은 방식입니다.

## 영향 범위

- 새 환경 변수: 없음
- 의존성 추가: 없음
- Breaking Change: 없음

## 트러블슈팅 및 참고 사항

없음

## 체크리스트

- [x] 이 PR은 하나의 논리적 변경만 담았습니다.
- [x] 커밋이 1개뿐이라 개발 과정 로그는 생략했습니다.
- [x] 검증 방법에 실행 명령과 실제 결과를 적었습니다.
- [x] 영향 범위에 환경 변수 / 의존성 / Breaking Change 여부를 적었습니다.
- [x] 커밋 전 diff를 확인했고 `.env`, 로그, 임시 파일, 시크릿 등 의도하지 않은 내용이 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014avJvytkEw1fnwawKnbBsz
